### PR TITLE
chore: move sprout deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,13 +75,11 @@
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-visualizer": "^4.2.0",
-    "scriptappy-from-jsdoc": "0.7.0"
+    "scriptappy-from-jsdoc": "0.7.0",
+    "@qlik/sprout-icons": "^0.9.2",
+    "@qlik/sprout-theme": "^1.16.0"
   },
   "peerDependencies": {
     "@nebula.js/stardust": "^1.0"
-  },
-  "optionalDependencies": {
-    "@qlik/sprout-icons": "^0.9.2",
-    "@qlik/sprout-theme": "^1.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8880,7 +8880,7 @@ promise.series@^0.2.0:
   resolved "https://registry.yarnpkg.com/promise.series/-/promise.series-0.2.0.tgz#2cc7ebe959fc3a6619c04ab4dbdc9e452d864bbd"
   integrity sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=
 
-prop-types@*, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9074,13 +9074,6 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
-
-react-proptypes@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-proptypes/-/react-proptypes-1.0.0.tgz#88e9cf5cc61b18844a5f57a06c839ae39fe9a57f"
-  integrity sha1-iOnPXMYbGIRKX1egbIOa45/ppX8=
-  dependencies:
-    prop-types "*"
 
 react-transition-group@^4.4.0:
   version "4.4.1"


### PR DESCRIPTION
As optional deps are treated as actual deps after build, I need to move them into devDeps. This way they won't show up in installed sn-tables in other projects (as they are bundled). Still a bit unsure how externals should handle this, so I'll keep the rollup logic.