### PR TITLE
Fix similar code checking in codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,8 +4,8 @@ plugins:
     enabled: true
     config:
       languages:
-        javascript:
-          count_threshold: 3
+        filters:
+          - "(object (Identifier PropTypes))"
 checks:
   method-lines:
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,11 @@
 version: "2"
+plugins:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        javascript:
+          count_threshold: 3
 checks:
   method-lines:
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,11 +1,11 @@
 version: "2"
 plugins:
   duplication:
-    enabled: true
     config:
       languages:
-        filters:
-          - "(object (Identifier PropTypes))"
+        javascript:
+          filters:
+            - "(property (Identifier propTypes))"
 checks:
   method-lines:
     config:


### PR DESCRIPTION
similar-code threshold describes the mass code block to be analyzed for duplication.
Refer https://github.com/codeclimate/codeclimate-duplication
for this settings.