### PR TITLE
table body performance

### DIFF
--- a/src/table/TableBodyWrapper.jsx
+++ b/src/table/TableBodyWrapper.jsx
@@ -25,10 +25,10 @@ const useStyles = makeStyles({
   }),
 });
 
-export default function TableBodyWrapper({ tableData, constraints, selectionsAPI, layout, theme }) {
+const TableBodyWrapper = ({ tableData, constraints, selectionsAPI, layout, theme }) => {
   const { rows, columns } = tableData;
   const hoverEffect = layout.components?.[0]?.content?.hoverEffect;
-  const styling = useMemo(() => getBodyStyle(layout, theme, hoverEffect));
+  const styling = useMemo(() => getBodyStyle(layout, theme), [layout, theme]);
   const classes = useStyles(styling);
   const getColumnRenderers = (selectionsEnabled) => tableData.columns.map((c) => getCellRenderer(c, selectionsEnabled));
   const [columnRenderers, setColumnRenderers] = useState(getColumnRenderers(false));
@@ -84,7 +84,7 @@ export default function TableBodyWrapper({ tableData, constraints, selectionsAPI
       ))}
     </TableBody>
   );
-}
+};
 
 TableBodyWrapper.propTypes = {
   tableData: PropTypes.object.isRequired,
@@ -93,3 +93,5 @@ TableBodyWrapper.propTypes = {
   layout: PropTypes.object.isRequired,
   theme: PropTypes.object.isRequired,
 };
+
+export default React.memo(TableBodyWrapper);

--- a/src/table/__tests__/TableWrapper.spec.jsx
+++ b/src/table/__tests__/TableWrapper.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import TableWrapper from '../TableWrapper';
-import * as TableBodyWrapper from '../TableBodyWrapper';
+import TableBodyWrapper from '../TableBodyWrapper';
 import * as TableHeadWrapper from '../TableHeadWrapper';
 
 describe('<TableWrapper />', () => {
@@ -19,7 +19,7 @@ describe('<TableWrapper />', () => {
   let modal;
 
   beforeEach(() => {
-    sandbox.replace(TableBodyWrapper, 'default', () => <tbody />);
+    sandbox.replace(TableBodyWrapper, 'type', () => <tbody />);
     sandbox.replace(TableHeadWrapper, 'default', () => <thead />);
 
     tableData = {


### PR DESCRIPTION
react skip render TableBodyWrapper when no  prop changes and add dependencies to use Memo otherwise a new value will be computed on every render