### PR TITLE
feat: focus on first cell from pressing enter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,6 @@ export default function supernova(env) {
       const selectionsAPI = useSelections();
       const theme = useTheme();
       const a11y = useAccessibility();
-      console.log(a11y);
 
       const [pageInfo, setPageInfo] = useState({ top: 0, height: 100 });
       const [muiParameters] = useState(muiSetup(__OPIONAL_THEME_DEPS__));

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
   useSelections,
   useTheme,
   usePromise,
+  useAccessibility,
 } from '@nebula.js/stardust';
 import properties from './object-properties';
 import data from './data';
@@ -35,6 +36,8 @@ export default function supernova(env) {
       const constraints = useConstraints();
       const selectionsAPI = useSelections();
       const theme = useTheme();
+      const a11y = useAccessibility();
+      console.log(a11y);
 
       const [pageInfo, setPageInfo] = useState({ top: 0, height: 100 });
       const [muiParameters] = useState(muiSetup(__OPIONAL_THEME_DEPS__));
@@ -54,9 +57,10 @@ export default function supernova(env) {
             muiParameters,
             theme,
             changeSortOrder,
+            a11y,
           });
         }
-      }, [tableData, constraints, selectionsAPI.isModal()]);
+      }, [tableData, constraints, selectionsAPI.isModal(), a11y]);
 
       useEffect(
         () => () => {

--- a/src/table/TableBodyWrapper.jsx
+++ b/src/table/TableBodyWrapper.jsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles({
   },
 });
 
-const TableBodyWrapper = ({ rootElement, tableData, constraints, selectionsAPI, layout, theme }) => {
+const TableBodyWrapper = ({ rootElement, tableData, constraints, selectionsAPI, layout, theme, setFocusedCell }) => {
   const { rows, columns } = tableData;
   const hoverEffect = layout.components?.[0]?.content?.hoverEffect;
   const styling = useMemo(() => getBodyStyle(layout, theme), [layout, theme]);
@@ -71,7 +71,7 @@ const TableBodyWrapper = ({ rootElement, tableData, constraints, selectionsAPI, 
                   selState={selState}
                   selDispatch={selDispatch}
                   tabIndex={-1}
-                  onKeyDown={(evt) => handleKeyPress(evt, rootElement, rowIndex + 1, columnIndex)}
+                  onKeyDown={(evt) => handleKeyPress(evt, rootElement, [rowIndex + 1, columnIndex], setFocusedCell)}
                 >
                   {value}
                 </CellRenderer>
@@ -91,6 +91,7 @@ TableBodyWrapper.propTypes = {
   selectionsAPI: PropTypes.object.isRequired,
   layout: PropTypes.object.isRequired,
   theme: PropTypes.object.isRequired,
+  setFocusedCell: PropTypes.func.isRequired,
 };
 
 export default React.memo(TableBodyWrapper);

--- a/src/table/TableHeadWrapper.jsx
+++ b/src/table/TableHeadWrapper.jsx
@@ -34,11 +34,13 @@ export default function TableHeadWrapper({ rootElement, tableData, theme, layout
             className={`${classes.head} sn-table-head-cell sn-table-cell`}
             style={{ minWidth: column.minWidth }}
             onKeyDown={(e) => handleKeyPress(e, rootElement, [0, columnIndex], setFocusedCell)}
+            tabindex={-1}
           >
             <TableSortLabel
               active={layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === columnIndex}
               direction={column.sortDirection}
               onClick={() => changeSortOrder(layout, column.isDim, columnIndex)}
+              tabindex={-1}
             >
               {column.label}
             </TableSortLabel>

--- a/src/table/TableHeadWrapper.jsx
+++ b/src/table/TableHeadWrapper.jsx
@@ -18,33 +18,29 @@ const useStyles = makeStyles({
   }),
 });
 
-export default function TableHeadWrapper({ rootElement, tableData, theme, layout, changeSortOrder }) {
+export default function TableHeadWrapper({ rootElement, tableData, theme, layout, changeSortOrder, setFocusedCell }) {
   const classes = useStyles(getHeadStyle(layout, theme));
 
   return (
     <TableHead>
       <TableRow className="sn-table-row">
-        {tableData.columns.map((column, columnIndex) => {
-          const tabIndex = columnIndex === 0 ? '0' : '-1';
-          return (
-            <TableCell
-              key={column.id}
-              align={column.align}
-              className={`${classes.head} sn-table-head-cell sn-table-cell`}
-              style={{ minWidth: column.minWidth }}
-              tabIndex={tabIndex}
-              onKeyDown={(e) => handleKeyPress(e, rootElement, 0, columnIndex)}
+        {tableData.columns.map((column, columnIndex) => (
+          <TableCell
+            key={column.id}
+            align={column.align}
+            className={`${classes.head} sn-table-head-cell sn-table-cell`}
+            style={{ minWidth: column.minWidth }}
+            onKeyDown={(e) => handleKeyPress(e, rootElement, [0, columnIndex], setFocusedCell)}
+          >
+            <TableSortLabel
+              active={layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === columnIndex}
+              direction={column.sortDirection}
+              onClick={() => changeSortOrder(layout, column.isDim, columnIndex)}
             >
-              <TableSortLabel
-                active={layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === columnIndex}
-                direction={column.sortDirection}
-                onClick={() => changeSortOrder(layout, column.isDim, columnIndex)}
-              >
-                {column.label}
-              </TableSortLabel>
-            </TableCell>
-          );
-        })}
+              {column.label}
+            </TableSortLabel>
+          </TableCell>
+        ))}
       </TableRow>
     </TableHead>
   );
@@ -56,4 +52,5 @@ TableHeadWrapper.propTypes = {
   theme: PropTypes.object.isRequired,
   layout: PropTypes.object.isRequired,
   changeSortOrder: PropTypes.func.isRequired,
+  setFocusedCell: PropTypes.func.isRequired,
 };

--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -90,9 +90,6 @@ export default function TableWrapper(props) {
         page={page}
         onChangePage={handleChangePage}
         onChangeRowsPerPage={handleChangeRowsPerPage}
-        SelectProps={{ inputProps: { tabIndex: paginationTabindex } }}
-        backIconButtonProps={{ tabIndex: paginationTabindex }}
-        nextIconButtonProps={{ tabIndex: paginationTabindex }}
       />
     </Paper>
   );

--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -35,7 +35,6 @@ export default function TableWrapper(props) {
   const containerMode = constraints.active ? 'containerOverflowHidden' : 'containerOverflowAuto';
   const paginationHidden = constraints.active && 'paginationHidden';
   const paginationFixedRpp = selectionsAPI.isModal() || tableWidth < 400;
-  const paginationTabindex = a11y.focus ? 0 : -1;
 
   const handleChangePage = (event, newPage) => {
     setPageInfo({ top: newPage * rowsPerPage, height: rowsPerPage });
@@ -65,13 +64,6 @@ export default function TableWrapper(props) {
       focusCell(rootElement.getElementsByClassName('sn-table-row'), focusedCell.length ? focusedCell : [0, 0]);
     }
   }, [a11y]);
-
-  // refocus after
-  useEffect(() => {
-    if (a11y.focus && focusedCell.length) {
-      focusCell(rootElement.getElementsByClassName('sn-table-row'), focusedCell);
-    }
-  }, [tableData]);
 
   return (
     <Paper className={classes.paper}>

--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -35,6 +35,7 @@ export default function TableWrapper(props) {
   const containerMode = constraints.active ? 'containerOverflowHidden' : 'containerOverflowAuto';
   const paginationHidden = constraints.active && 'paginationHidden';
   const paginationFixedRpp = selectionsAPI.isModal() || tableWidth < 400;
+  const paginationTabindex = a11y.focus ? 0 : -1;
 
   const handleChangePage = (event, newPage) => {
     setPageInfo({ top: newPage * rowsPerPage, height: rowsPerPage });
@@ -60,23 +61,17 @@ export default function TableWrapper(props) {
   }, []);
 
   useEffect(() => {
-    console.log('a11y updated');
     if (a11y.focus) {
-      if (focusedCell.length) {
-        focusCell(rootElement.getElementsByClassName('sn-table-row'), focusedCell);
-      } else {
-        focusCell(rootElement.getElementsByClassName('sn-table-row'), [0, 0]);
-      }
-    } else {
-      setFocusedCell([]);
+      focusCell(rootElement.getElementsByClassName('sn-table-row'), focusedCell.length ? focusedCell : [0, 0]);
     }
   }, [a11y]);
 
+  // refocus after
   useEffect(() => {
     if (a11y.focus && focusedCell.length) {
       focusCell(rootElement.getElementsByClassName('sn-table-row'), focusedCell);
     }
-  });
+  }, [tableData]);
 
   return (
     <Paper className={classes.paper}>
@@ -95,6 +90,9 @@ export default function TableWrapper(props) {
         page={page}
         onChangePage={handleChangePage}
         onChangeRowsPerPage={handleChangeRowsPerPage}
+        SelectProps={{ inputProps: { tabIndex: paginationTabindex } }}
+        backIconButtonProps={{ tabIndex: paginationTabindex }}
+        nextIconButtonProps={{ tabIndex: paginationTabindex }}
       />
     </Paper>
   );

--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -7,6 +7,7 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableHeadWrapper from './TableHeadWrapper';
 import TableBodyWrapper from './TableBodyWrapper';
+import { focusCell } from './cells/handle-key-press';
 
 const useStyles = makeStyles({
   paper: {
@@ -24,11 +25,12 @@ const useStyles = makeStyles({
 });
 
 export default function TableWrapper(props) {
-  const { rootElement, tableData, setPageInfo, constraints, selectionsAPI } = props;
+  const { rootElement, tableData, setPageInfo, constraints, selectionsAPI, a11y } = props;
   const { size, rows } = tableData;
   const [tableWidth, setTableWidth] = useState();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(100);
+  const [focusedCell, setFocusedCell] = useState([]);
   const classes = useStyles();
   const containerMode = constraints.active ? 'containerOverflowHidden' : 'containerOverflowAuto';
   const paginationHidden = constraints.active && 'paginationHidden';
@@ -57,12 +59,25 @@ export default function TableWrapper(props) {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
+  useEffect(() => {
+    if (a11y.focus) {
+      if (focusedCell.length) {
+        focusCell(rootElement.getElementsByClassName('sn-table-row'), focusedCell);
+      } else {
+        focusCell(rootElement.getElementsByClassName('sn-table-row'), [0, 0]);
+        setFocusedCell([0, 0]);
+      }
+    } else {
+      setFocusedCell([]);
+    }
+  }, [a11y]);
+
   return (
     <Paper className={classes.paper}>
       <TableContainer className={classes[containerMode]}>
         <Table stickyHeader aria-label="sticky table">
-          <TableHeadWrapper {...props} />
-          <TableBodyWrapper {...props} />
+          <TableHeadWrapper {...props} setFocusedCell={setFocusedCell} />
+          <TableBodyWrapper {...props} setFocusedCell={setFocusedCell} />
         </Table>
       </TableContainer>
       <TablePagination
@@ -85,4 +100,5 @@ TableWrapper.propTypes = {
   setPageInfo: PropTypes.func.isRequired,
   constraints: PropTypes.object.isRequired,
   selectionsAPI: PropTypes.object.isRequired,
+  a11y: PropTypes.object.isRequired,
 };

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -73,6 +73,7 @@ const handleKeyPress = (evt, rootElement, cellCoord, setFocusedCell, cell, selSt
     case 'Enter': {
       preventDefaultBehavior(evt);
       selState.api.confirm();
+      // TODO: make sure focus is kept, or set on nebula cell
       break;
     }
     // Esc: Cancels selections if any, otherwise blur
@@ -80,14 +81,20 @@ const handleKeyPress = (evt, rootElement, cellCoord, setFocusedCell, cell, selSt
       preventDefaultBehavior(evt);
       if (selState?.rows.length) {
         selState.api.cancel();
+        // TODO: make sure focus is kept
       } else {
         removeCurrentFocus(evt);
+        // dropFocus()
       }
       break;
     }
-    // Tab: blur cell
+    // Tab: blur cell, or if shift, focus nebula cell
     case 'Tab': {
+      // dropFocus()
       removeCurrentFocus(evt);
+      if (evt.shiftKey) {
+        // go to nebula... might not be done here
+      }
       break;
     }
     default:

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -1,33 +1,29 @@
-export const moveToNextFocus = (rowElements, nextRow, nextCol) => {
-  const nextCell = rowElements[nextRow].getElementsByClassName('sn-table-cell')[nextCol];
+export const focusCell = (rowElements, nextCellCoord) => {
+  const nextCell = rowElements[nextCellCoord[0]].getElementsByClassName('sn-table-cell')[nextCellCoord[1]];
   nextCell.focus();
   nextCell.setAttribute('tabIndex', '0');
 };
 
-export const arrowKeysNavigation = (evt, rowAndColumnCount, rowIndex, colIndex) => {
-  let nextRow = rowIndex;
-  let nextCol = colIndex;
+export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord) => {
+  let [nextRow, nextCol] = cellCoord;
 
   switch (evt.key) {
     case 'ArrowDown':
-      rowIndex + 1 < rowAndColumnCount.rowCount && nextRow++;
+      nextRow + 1 < rowAndColumnCount.rowCount && nextRow++;
       break;
     case 'ArrowUp':
-      rowIndex > 0 && --nextRow;
+      nextRow > 0 && --nextRow;
       break;
     case 'ArrowRight':
-      colIndex < rowAndColumnCount.columnCount - 1 && nextCol++;
+      nextCol < rowAndColumnCount.columnCount - 1 && nextCol++;
       break;
     case 'ArrowLeft':
-      colIndex > 0 && --nextCol;
+      nextCol > 0 && --nextCol;
       break;
     default:
   }
 
-  return {
-    nextRow,
-    nextCol,
-  };
+  return [nextRow, nextCol];
 };
 
 export const getRowAndColumnCount = (rootElement) => {
@@ -50,7 +46,7 @@ export const preventDefaultBehavior = (evt) => {
   evt.preventDefault();
 };
 
-const handleKeyPress = (evt, rootElement, rowIndex, colIndex) => {
+const handleKeyPress = (evt, rootElement, cellCoord, setFocusedCell) => {
   preventDefaultBehavior(evt);
   switch (evt.key) {
     // TODO page up/down etc
@@ -60,11 +56,16 @@ const handleKeyPress = (evt, rootElement, rowIndex, colIndex) => {
     case 'ArrowLeft': {
       removeCurrentFocus(evt);
       const rowAndColumnCount = getRowAndColumnCount(rootElement);
-      const { nextRow, nextCol } = arrowKeysNavigation(evt, rowAndColumnCount, rowIndex, colIndex);
-      moveToNextFocus(rowAndColumnCount.rowElements, nextRow, nextCol);
+      const nextCellCoord = arrowKeysNavigation(evt, rowAndColumnCount, cellCoord);
+      focusCell(rowAndColumnCount.rowElements, nextCellCoord);
+      setFocusedCell(nextCellCoord);
       break;
     }
     // TODO handle selections, search?, sorting...
+    case 'Escape':
+      evt.target.blur();
+      // setFocusedCell([]);
+      break;
     default:
       break;
   }

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -85,6 +85,11 @@ const handleKeyPress = (evt, rootElement, cellCoord, setFocusedCell, cell, selSt
       }
       break;
     }
+    // Tab: blur cell
+    case 'Tab': {
+      removeCurrentFocus(evt);
+      break;
+    }
     default:
       break;
   }


### PR DESCRIPTION
So this is the first part of handling focus in and out of the table. When pressing enter on the nebula cell, the first cell in the table gets focus. Which cell has focus is stored as a state, so when you navigate back to the table, you get the same position.

Right now we only get an update when you press enter on the nebula cell, `a11y.focus` becomes true. We also need something that tells nebula that the table looses focus (working name `dropFocus`), which we would call on esc and shift+tab. Alternatively, nebula catches those events by it self. Additionally, there will be an enabled flag on the the `useAccessiblity` hook that tells whether we want the things in the table focusable at all times or not

Listening to `a11y` changes in `TableWrapper` is another reason to put the navigation listener in that file as well, and having seperate listeners for selections and sorting, placed on cell level. I'll look into that refactoring... 