### PR TITLE
fix cell focus style

### DIFF
--- a/src/table/TableBodyWrapper.jsx
+++ b/src/table/TableBodyWrapper.jsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
       padding: ({ padding }) => padding,
       height: STYLING_DEFAULTS.HEIGHT,
       lineHeight: STYLING_DEFAULTS.HEAD_LINE_HEIGHT,
-      '&&:focus': {
+      '&:focus': {
         boxShadow: STYLING_DEFAULTS.FOCUS_OUTLINE,
       },
     },


### PR DESCRIPTION
a quick fix. will look into https://material-ui.com/styles/basics/#material-ui-styles and https://material-ui.com/customization/theming/ to use the theme. 

Not sure if rollup-plugin-postcss is in use.