### PR TITLE
fix: proper focus styling + refactor

### DIFF
--- a/src/mui-setup.js
+++ b/src/mui-setup.js
@@ -12,17 +12,16 @@ export default function muiSetup(sproutBase) {
       },
     };
 
-    sproutBase.overrides.MuiTableSortLabel.root.color = 'inherit';
-    sproutBase.overrides.MuiTableSortLabel.root['&$active'].color = 'inherit';
-    sproutBase.overrides.MuiTableSortLabel.root['&:hover'].color = 'inherit';
-
-    sproutBase.overrides.MuiTableRow.hover['&&:hover'].backgroundColor = 'rgba(0, 0, 0, 0)';
     sproutBase.overrides.MuiTableRow.root = {
       display: 'table',
       width: '100%',
       tableLayout: 'fixed',
     };
 
+    sproutBase.overrides.MuiTableSortLabel.root.color = 'inherit';
+    sproutBase.overrides.MuiTableSortLabel.root['&$active'].color = 'inherit';
+    sproutBase.overrides.MuiTableSortLabel.root['&:hover'].color = 'inherit';
+    sproutBase.overrides.MuiTableRow.hover['&&:hover'].backgroundColor = 'rgba(0, 0, 0, 0)';
     sproutBase.overrides.MuiTableCell.root.height = 'auto';
     sproutBase.overrides.MuiTableCell.root.lineHeight = '130%';
     sproutBase.overrides.MuiTableCell.head.height = 'auto';

--- a/src/mui-setup.js
+++ b/src/mui-setup.js
@@ -8,6 +8,7 @@ export default function muiSetup(sproutBase) {
     sproutBase.overrides.MuiTableSortLabel.root.color = 'inherit';
     sproutBase.overrides.MuiTableSortLabel.root['&$active'].color = 'inherit';
     sproutBase.overrides.MuiTableSortLabel.root['&:hover'].color = 'inherit';
+    sproutBase.overrides.MuiTableRow.hover['&&:hover'].backgroundColor = 'rgba(0, 0, 0, 0)';
     sproutBase.overrides.MuiTableCell.root.height = 'auto';
     sproutBase.overrides.MuiTableCell.root.lineHeight = '130%';
     sproutBase.overrides.MuiTableCell.head.height = 'auto';

--- a/src/mui-setup.js
+++ b/src/mui-setup.js
@@ -8,6 +8,14 @@ export default function muiSetup(sproutBase) {
     sproutBase.overrides.MuiTableSortLabel.root.color = 'inherit';
     sproutBase.overrides.MuiTableSortLabel.root['&$active'].color = 'inherit';
     sproutBase.overrides.MuiTableSortLabel.root['&:hover'].color = 'inherit';
+    sproutBase.overrides.MuiTableCell.root.height = 'auto';
+    sproutBase.overrides.MuiTableCell.root.lineHeight = '130%';
+    sproutBase.overrides.MuiTableCell.head.height = 'auto';
+    sproutBase.overrides.MuiTableCell.head.lineHeight = '150%';
+    sproutBase.overrides.MuiTableCell.root['&:focus'] = {
+      boxShadow: '0 0 0 2px #3f8ab3 inset',
+      outline: 'none',
+    };
   }
 
   const theme = createMuiTheme(sproutBase);

--- a/src/mui-setup.js
+++ b/src/mui-setup.js
@@ -12,21 +12,17 @@ export default function muiSetup(sproutBase) {
       },
     };
 
-    sproutBase.overrides.MuiTableBody.root = {
-      display: 'block',
-      overflow: 'auto',
-    };
+    sproutBase.overrides.MuiTableSortLabel.root.color = 'inherit';
+    sproutBase.overrides.MuiTableSortLabel.root['&$active'].color = 'inherit';
+    sproutBase.overrides.MuiTableSortLabel.root['&:hover'].color = 'inherit';
 
+    sproutBase.overrides.MuiTableRow.hover['&&:hover'].backgroundColor = 'rgba(0, 0, 0, 0)';
     sproutBase.overrides.MuiTableRow.root = {
       display: 'table',
       width: '100%',
       tableLayout: 'fixed',
     };
 
-    sproutBase.overrides.MuiTableSortLabel.root.color = 'inherit';
-    sproutBase.overrides.MuiTableSortLabel.root['&$active'].color = 'inherit';
-    sproutBase.overrides.MuiTableSortLabel.root['&:hover'].color = 'inherit';
-    sproutBase.overrides.MuiTableRow.hover['&&:hover'].backgroundColor = 'rgba(0, 0, 0, 0)';
     sproutBase.overrides.MuiTableCell.root.height = 'auto';
     sproutBase.overrides.MuiTableCell.root.lineHeight = '130%';
     sproutBase.overrides.MuiTableCell.head.height = 'auto';

--- a/src/table/TableBodyWrapper.jsx
+++ b/src/table/TableBodyWrapper.jsx
@@ -5,7 +5,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import { addSelectionListeners, reducer } from './selections-utils';
 import getCellRenderer from './cells/renderer';
-import { getBodyStyle, STYLING_DEFAULTS } from './styling-utils';
+import { getBodyStyle } from './styling-utils';
 import { bodyHandleKeyPress } from './cells/handle-key-press';
 import { handleClickToFocusBody } from './cells/handle-cell-focus';
 
@@ -15,11 +15,6 @@ const useStyles = makeStyles({
       color: ({ color }) => color,
       fontSize: ({ fontSize }) => fontSize,
       padding: ({ padding }) => padding,
-      height: STYLING_DEFAULTS.HEIGHT,
-      lineHeight: STYLING_DEFAULTS.HEAD_LINE_HEIGHT,
-      '&:focus': {
-        boxShadow: STYLING_DEFAULTS.FOCUS_OUTLINE,
-      },
     },
   },
   hoverTableRow: {

--- a/src/table/TableBodyWrapper.jsx
+++ b/src/table/TableBodyWrapper.jsx
@@ -19,10 +19,9 @@ const useStyles = makeStyles({
   },
   hoverTableRow: {
     '&&:hover': {
-      backgroundColor: 'rgba(0, 0, 0, 0)',
       '& td:not(.selected)': {
-        backgroundColor: ({ hoverBackgroundColor }) => `${hoverBackgroundColor} !important`,
-        color: ({ hoverFontColor }) => `${hoverFontColor} !important`,
+        backgroundColor: ({ hoverBackgroundColor }) => hoverBackgroundColor,
+        color: ({ hoverFontColor }) => hoverFontColor,
       },
     },
   },

--- a/src/table/TableHeadWrapper.jsx
+++ b/src/table/TableHeadWrapper.jsx
@@ -5,7 +5,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
-import { STYLING_DEFAULTS, getHeadStyle } from './styling-utils';
+import { getHeadStyle } from './styling-utils';
 import { headHandleKeyPress } from './cells/handle-key-press';
 import { handleClickToFocusHead } from './cells/handle-cell-focus';
 
@@ -14,11 +14,6 @@ const useStyles = makeStyles({
     color: ({ color }) => color,
     fontSize: ({ fontSize }) => fontSize,
     padding: ({ padding }) => padding,
-    height: STYLING_DEFAULTS.HEIGHT,
-    lineHeight: STYLING_DEFAULTS.HEAD_LINE_HEIGHT,
-    '&:focus': {
-      boxShadow: STYLING_DEFAULTS.FOCUS_OUTLINE,
-    },
   },
 });
 

--- a/src/table/__tests__/styling-utils.spec.js
+++ b/src/table/__tests__/styling-utils.spec.js
@@ -173,8 +173,8 @@ describe('styling-utils', () => {
         fontSize: 22,
         color: resolvedColor,
         padding: '11px 22px',
-        hoverBackgroundColor: '#f4f4f4',
-        hoverFontColor: '',
+        hoverBackgroundColor: ['#f4f4f4', '!important'],
+        hoverFontColor: ['', '!important'],
         selectedCellClass: '',
       });
     });
@@ -183,30 +183,30 @@ describe('styling-utils', () => {
       layout.components[0].content.hoverFontColor.index = 1;
 
       const resultStyling = getBodyStyle(layout, theme);
-      expect(resultStyling.hoverBackgroundColor).to.equal('');
-      expect(resultStyling.hoverFontColor).to.equal(resolvedColor);
+      expect(resultStyling.hoverBackgroundColor).to.eql(['', '!important']);
+      expect(resultStyling.hoverFontColor).to.eql([resolvedColor, '!important']);
     });
     it('should return styling with dark hoverBackgroundColor and white hoverFontColor', () => {
       layout.components[0].content.hoverColor.index = 1;
 
       const resultStyling = getBodyStyle(layout, theme);
-      expect(resultStyling.hoverBackgroundColor).to.equal(resolvedColor);
-      expect(resultStyling.hoverFontColor).to.equal(STYLING_DEFAULTS.WHITE);
+      expect(resultStyling.hoverBackgroundColor).to.eql([resolvedColor, '!important']);
+      expect(resultStyling.hoverFontColor).to.eql([STYLING_DEFAULTS.WHITE, '!important']);
     });
     it('should return styling with light hoverBackgroundColor and no hoverFontColor', () => {
       layout.components[0].content.hoverColor.index = 2;
 
       const resultStyling = getBodyStyle(layout, theme);
-      expect(resultStyling.hoverBackgroundColor).to.equal(altResolvedColor);
-      expect(resultStyling.hoverFontColor).to.equal(STYLING_DEFAULTS.FONT_COLOR);
+      expect(resultStyling.hoverBackgroundColor).to.eql([altResolvedColor, '!important']);
+      expect(resultStyling.hoverFontColor).to.eql([STYLING_DEFAULTS.FONT_COLOR, '!important']);
     });
     it('should return styling with set hoverBackgroundColor and hoverFontColor', () => {
       layout.components[0].content.hoverColor.index = 1;
       layout.components[0].content.hoverFontColor.index = 2;
 
       const resultStyling = getBodyStyle(layout, theme);
-      expect(resultStyling.hoverBackgroundColor).to.equal(resolvedColor);
-      expect(resultStyling.hoverFontColor).to.equal(altResolvedColor);
+      expect(resultStyling.hoverBackgroundColor).to.eql([resolvedColor, '!important']);
+      expect(resultStyling.hoverFontColor).to.eql([altResolvedColor, '!important']);
     });
   });
 

--- a/src/table/styling-utils.js
+++ b/src/table/styling-utils.js
@@ -72,7 +72,12 @@ export function getBodyStyle(layout, theme) {
     ? ''
     : getColor(content.hoverFontColor, getAutoFontColor(hoverBackgroundColor), theme);
 
-  return { ...getBaseStyling(content, theme), hoverBackgroundColor, hoverFontColor, selectedCellClass: '' };
+  return {
+    ...getBaseStyling(content, theme),
+    hoverBackgroundColor: [hoverBackgroundColor, '!important'],
+    hoverFontColor: [hoverFontColor, '!important'],
+    selectedCellClass: '',
+  };
 }
 
 export function getColumnStyle(styling, qAttrExps, stylingInfo) {

--- a/src/table/styling-utils.js
+++ b/src/table/styling-utils.js
@@ -10,10 +10,6 @@ export const STYLING_DEFAULTS = {
     'repeating-linear-gradient(-45deg, rgba(200,200,200,0.08), rgba(200,200,200,0.08) 2px, rgba(200,200,200,0.3) 2.5px, rgba(200,200,200,0.08) 3px, rgba(200,200,200,0.08) 5px)',
   WHITE: '#fff',
   PADDING: '7px 14px',
-  HEIGHT: 'auto',
-  HEAD_LINE_HEIGHT: '150%',
-  BODY_LINE_HEIGHT: '130%',
-  FOCUS_OUTLINE: '0 0 0 2px #3f8ab3 inset',
 };
 
 export const SELECTION_STYLING = {

--- a/src/table/styling-utils.js
+++ b/src/table/styling-utils.js
@@ -20,7 +20,7 @@ export const SELECTION_STYLING = {
     selectedCellClass: STYLING_DEFAULTS.SELECTED_CLASS,
   },
   POSSIBLE: {
-    fontColor: STYLING_DEFAULTS.FONT_COLOR,
+    color: STYLING_DEFAULTS.FONT_COLOR,
     background: STYLING_DEFAULTS.WHITE,
   },
 };


### PR DESCRIPTION
Moving a bunch of static css to the theme.
Also found two bugs and fixed them:
- The hover wasn't updating when changing colors. JSS prefers a different syntax.
- There was a double hover border. It should be the inset one only.