### PR TITLE
feat: announcing number of rows and columns when entering table

### DIFF
--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -84,7 +84,7 @@ export default function TableWrapper(props) {
       onKeyDown={(evt) => updatePage(evt, size.qcy, page, rowsPerPage, handleChangePage, setShouldRefocus)}
     >
       <TableContainer className={classes[containerMode]}>
-        <Table sticgkyHeader aria-label={`showing ${rows.length + 1} rows and ${columns.length} columns`}>
+        <Table stickyHeader aria-label={`showing ${rows.length + 1} rows and ${columns.length} columns`}>
           <TableHeadWrapper {...props} focusedCellCoord={focusedCellCoord} />
           <TableBodyWrapper
             {...props}

--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles({
 
 export default function TableWrapper(props) {
   const { rootElement, tableData, layout, setPageInfo, constraints, selectionsAPI } = props;
-  const { size, rows } = tableData;
+  const { size, rows, columns } = tableData;
   const [tableWidth, setTableWidth] = useState();
   const [bodyHeight, setBodyHeight] = useState();
   const [page, setPage] = useState(0);
@@ -84,7 +84,7 @@ export default function TableWrapper(props) {
       onKeyDown={(evt) => updatePage(evt, size.qcy, page, rowsPerPage, handleChangePage, setShouldRefocus)}
     >
       <TableContainer className={classes[containerMode]}>
-        <Table stickyHeader aria-label="sticky table">
+        <Table sticgkyHeader aria-label={`showing ${rows.length + 1} rows and ${columns.length} columns`}>
           <TableHeadWrapper {...props} focusedCellCoord={focusedCellCoord} />
           <TableBodyWrapper
             {...props}

--- a/src/table/__tests__/TableWrapper.spec.jsx
+++ b/src/table/__tests__/TableWrapper.spec.jsx
@@ -26,6 +26,7 @@ describe('<TableWrapper />', () => {
     tableData = {
       size: { qcy: 200 },
       rows: [{ qText: '1' }],
+      columns: [{}],
     };
     setPageInfo = sinon.spy();
     constraints = {};
@@ -58,7 +59,7 @@ describe('<TableWrapper />', () => {
       />
     );
 
-    expect(queryByLabelText('sticky table')).to.be.visible;
+    expect(queryByLabelText('showing 2 rows and 1 columns')).to.be.visible;
     expect(queryByText(`1-${rowsPerPage} of ${tableData.size.qcy}`)).to.be.visible;
     expect(queryByText(rowsPerPage)).to.be.visible;
   });
@@ -74,7 +75,7 @@ describe('<TableWrapper />', () => {
       />
     );
 
-    fireEvent.keyDown(queryByLabelText('sticky table'), { key: 'Control', code: 'ControlLeft' });
+    fireEvent.keyDown(queryByLabelText('showing 2 rows and 1 columns'), { key: 'Control', code: 'ControlLeft' });
     expect(handleKeyPress.updatePage).to.have.been.calledOnce;
   });
 


### PR DESCRIPTION
fixes #165

It only reads this when focusing into the table, so not for every cell.