### PR TITLE
fix: revert header scroll fix

### DIFF
--- a/src/mui-setup.js
+++ b/src/mui-setup.js
@@ -11,16 +11,7 @@ export default function muiSetup(sproutBase) {
     sproutBase.overrides.MuiTableCell.root.height = 'auto';
     sproutBase.overrides.MuiTableCell.root.lineHeight = '130%';
     sproutBase.overrides.MuiTableCell.head.height = 'auto';
-    sproutBase.overrides.MuiTableCell.head = {
-      lineHeight: '150%',
-      position: '-webkit-sticky' /* Safari */,
-      // eslint-disable-next-line no-dupe-keys
-      position: 'sticky',
-      top: '0',
-      zIndex: '1',
-      boxShadow: 'inset 0 1px 0 #D9D9D9, inset 0 -1px 0 #D9D9D9',
-      ...sproutBase.overrides.MuiTableCell.head,
-    };
+    sproutBase.overrides.MuiTableCell.head.lineHeight = '150%';
     sproutBase.overrides.MuiTableCell.root['&:focus'] = {
       boxShadow: '0 0 0 2px #3f8ab3 inset',
       outline: 'none',

--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -85,7 +85,7 @@ export default function TableWrapper(props) {
       onKeyDown={(evt) => updatePage(evt, size.qcy, page, rowsPerPage, handleChangePage, setShouldRefocus)}
     >
       <TableContainer ref={tableSection} className={classes[containerMode]}>
-        <Table aria-label={`showing ${rows.length + 1} rows and ${columns.length} columns`}>
+        <Table stickyHeader aria-label={`showing ${rows.length + 1} rows and ${columns.length} columns`}>
           <TableHeadWrapper {...props} focusedCellCoord={focusedCellCoord} />
           <TableBodyWrapper {...props} focusedCellCoord={focusedCellCoord} setShouldRefocus={setShouldRefocus} />
         </Table>


### PR DESCRIPTION
There was a reason for that lint issue, can't use the package in the mashup when you have multiple keys on an object apperently. 