### PR TITLE
fix: avoid numbers at start of class

### DIFF
--- a/src/mui-setup.js
+++ b/src/mui-setup.js
@@ -20,9 +20,9 @@ export default function muiSetup(sproutBase) {
 
   const theme = createMuiTheme(sproutBase);
   const generateClassName = createGenerateClassName({
-    productionPrefix: 'sn-t',
+    productionPrefix: `${process.env.PACKAGE_VERSION}`,
     disableGlobal: true,
-    seed: Date.now(),
+    seed: `sn-t-${Date.now()}`,
   });
 
   return { theme, generateClassName };


### PR DESCRIPTION
Numbers at the start of css classnames are not allowed. This works in general, but breaks in some browsers, better keep it safe.