### PR TITLE
[fix/#161]: fixed table navigation move to the next/previous line

### DIFF
--- a/src/table/cells/__tests__/handle-key-press.spec.js
+++ b/src/table/cells/__tests__/handle-key-press.spec.js
@@ -89,6 +89,50 @@ describe('handle-key-press', () => {
       expect(nextRow).to.eql(0);
       expect(nextCol).to.eql(0);
     });
+
+    it('should move to the next row when we reach to the end of the current row', () => {
+      evt.key = 'ArrowRight';
+      rowAndColumnCount.rowCount = 3;
+      rowAndColumnCount.columnCount = 3;
+      rowIndex = 1;
+      colIndex = 3;
+      const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
+      expect(nextRow).to.eql(2);
+      expect(nextCol).to.eql(0);
+    });
+
+    it('should move to the prev row when we reach to the beganing of the current row', () => {
+      evt.key = 'ArrowLeft';
+      rowAndColumnCount.rowCount = 3;
+      rowAndColumnCount.columnCount = 3;
+      rowIndex = 2;
+      colIndex = 0;
+      const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
+      expect(nextRow).to.eql(1);
+      expect(nextCol).to.eql(2);
+    });
+
+    it('should stay at the first row and first col of table when we reached to the beganing of the table', () => {
+      evt.key = 'ArrowLeft';
+      rowAndColumnCount.rowCount = 2;
+      rowAndColumnCount.columnCount = 2;
+      rowIndex = 0;
+      colIndex = 0;
+      const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
+      expect(nextRow).to.eql(0);
+      expect(nextCol).to.eql(0);
+    });
+
+    it('should stay at the end row and end col of table when we reached to the end of the table', () => {
+      evt.key = 'ArrowRight';
+      rowAndColumnCount.rowCount = 2;
+      rowAndColumnCount.columnCount = 2;
+      rowIndex = 2;
+      colIndex = 2;
+      const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
+      expect(nextRow).to.eql(2);
+      expect(nextCol).to.eql(2);
+    });
   });
 
   describe('getRowAndColumnCount', () => {

--- a/src/table/cells/__tests__/handle-key-press.spec.js
+++ b/src/table/cells/__tests__/handle-key-press.spec.js
@@ -109,7 +109,7 @@ describe('handle-key-press', () => {
       expect(nextCol).to.eql(0);
     });
 
-    it.only('should stay at the end row and end col of table when we reached to the end of the table', () => {
+    it('should stay at the end row and end col of table when we reached to the end of the table', () => {
       evt.key = 'ArrowRight';
       rowAndColumnCount.rowCount = 2;
       rowAndColumnCount.columnCount = 2;

--- a/src/table/cells/__tests__/handle-key-press.spec.js
+++ b/src/table/cells/__tests__/handle-key-press.spec.js
@@ -109,15 +109,15 @@ describe('handle-key-press', () => {
       expect(nextCol).to.eql(0);
     });
 
-    it('should stay at the end row and end col of table when we reached to the end of the table', () => {
+    it.only('should stay at the end row and end col of table when we reached to the end of the table', () => {
       evt.key = 'ArrowRight';
       rowAndColumnCount.rowCount = 2;
       rowAndColumnCount.columnCount = 2;
-      rowIndex = 2;
-      colIndex = 2;
+      rowIndex = 1;
+      colIndex = 1;
       const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
-      expect(nextRow).to.eql(2);
-      expect(nextCol).to.eql(2);
+      expect(nextRow).to.eql(1);
+      expect(nextCol).to.eql(1);
     });
   });
 

--- a/src/table/cells/__tests__/handle-key-press.spec.js
+++ b/src/table/cells/__tests__/handle-key-press.spec.js
@@ -37,16 +37,24 @@ describe('handle-key-press', () => {
 
     it('should stay the current cell when move left', () => {
       evt.key = 'ArrowLeft';
+      rowAndColumnCount.rowCount = 1;
+      rowAndColumnCount.columnCount = 3;
+      rowIndex = 1;
+      colIndex = 3;
       const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
-      expect(nextRow).to.eql(0);
-      expect(nextCol).to.eql(0);
+      expect(nextRow).to.eql(1);
+      expect(nextCol).to.eql(2);
     });
 
     it('should stay the current cell when move right', () => {
       evt.key = 'ArrowRight';
+      rowAndColumnCount.rowCount = 1;
+      rowAndColumnCount.columnCount = 3;
+      rowIndex = 1;
+      colIndex = 1;
       const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
-      expect(nextRow).to.eql(0);
-      expect(nextCol).to.eql(0);
+      expect(nextRow).to.eql(1);
+      expect(nextCol).to.eql(2);
     });
 
     it('should go to one row down cell', () => {

--- a/src/table/cells/__tests__/handle-key-press.spec.js
+++ b/src/table/cells/__tests__/handle-key-press.spec.js
@@ -35,28 +35,6 @@ describe('handle-key-press', () => {
       expect(nextCol).to.eql(0);
     });
 
-    it('should stay the current cell when move left', () => {
-      evt.key = 'ArrowLeft';
-      rowAndColumnCount.rowCount = 1;
-      rowAndColumnCount.columnCount = 3;
-      rowIndex = 1;
-      colIndex = 3;
-      const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
-      expect(nextRow).to.eql(1);
-      expect(nextCol).to.eql(2);
-    });
-
-    it('should stay the current cell when move right', () => {
-      evt.key = 'ArrowRight';
-      rowAndColumnCount.rowCount = 1;
-      rowAndColumnCount.columnCount = 3;
-      rowIndex = 1;
-      colIndex = 1;
-      const [nextRow, nextCol] = arrowKeysNavigation(evt, rowAndColumnCount, [rowIndex, colIndex]);
-      expect(nextRow).to.eql(1);
-      expect(nextCol).to.eql(2);
-    });
-
     it('should go to one row down cell', () => {
       evt.key = 'ArrowDown';
       rowAndColumnCount.rowCount = 2;

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -27,32 +27,22 @@ export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, selState)
     case 'ArrowUp':
       nextRow > 0 && (!isSelectedTable || nextRow !== 1) && nextRow--;
       break;
-    case 'ArrowRight': {
-      if (nextCol < rowAndColumnCount.columnCount - 1) !isSelectedTable && nextCol++;
-      else if (!isSelectedTable) {
-        // move to the next row
-        // if we are at the end of the table do nothing
-        if (nextRow + 1 > rowAndColumnCount.rowCount - 1) break;
-        else {
-          nextRow++;
-          nextCol = 0;
-        }
+    case 'ArrowRight':
+      if (nextCol < rowAndColumnCount.columnCount - 1 && !isSelectedTable) {
+        nextCol++;
+      } else if (!isSelectedTable && nextRow < rowAndColumnCount.rowCount - 1) {
+        nextRow++;
+        nextCol = 0;
       }
       break;
-    }
-    case 'ArrowLeft': {
-      if (nextCol > 0) !isSelectedTable && nextCol--;
-      else if (!isSelectedTable) {
-        // move to the prev row
-        // if we are at the beganing of the table do nothing
-        if (nextRow - 1 < 0) break;
-        else {
-          nextRow--;
-          nextCol = rowAndColumnCount.columnCount - 1;
-        }
+    case 'ArrowLeft':
+      if (nextCol > 0 && !isSelectedTable) {
+        nextCol--;
+      } else if (!isSelectedTable && nextRow > 0) {
+        nextRow--;
+        nextCol = rowAndColumnCount.columnCount - 1;
       }
       break;
-    }
     default:
   }
 

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -28,26 +28,25 @@ export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, selState)
       nextRow > 0 && (!isSelectedTable || nextRow !== 1) && nextRow--;
       break;
     case 'ArrowRight':
-      if (!isSelectedTable) {
-        if (nextCol < rowAndColumnCount.columnCount - 1) {
-          nextCol++;
-        } else if (nextRow < rowAndColumnCount.rowCount - 1) {
-          nextRow++;
-          nextCol = 0;
-        }
+      if (isSelectedTable) break;
+      if (nextCol < rowAndColumnCount.columnCount - 1) {
+        nextCol++;
+      } else if (nextRow < rowAndColumnCount.rowCount - 1) {
+        nextRow++;
+        nextCol = 0;
       }
       break;
     case 'ArrowLeft':
-      if (!isSelectedTable) {
-        if (nextCol > 0) {
-          nextCol--;
-        } else if (nextRow > 0) {
-          nextRow--;
-          nextCol = rowAndColumnCount.columnCount - 1;
-        }
+      if (isSelectedTable) break;
+      if (nextCol > 0) {
+        nextCol--;
+      } else if (nextRow > 0) {
+        nextRow--;
+        nextCol = rowAndColumnCount.columnCount - 1;
       }
       break;
     default:
+      break;
   }
 
   return [nextRow, nextCol];

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -27,12 +27,32 @@ export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, selState)
     case 'ArrowUp':
       nextRow > 0 && (!isSelectedTable || nextRow !== 1) && nextRow--;
       break;
-    case 'ArrowRight':
-      nextCol < rowAndColumnCount.columnCount - 1 && !isSelectedTable && nextCol++;
+    case 'ArrowRight': {
+      if (nextCol < rowAndColumnCount.columnCount - 1) !isSelectedTable && nextCol++;
+      else if (!isSelectedTable) {
+        // move to the next row
+        // if we are at the end of the table do nothing
+        if (nextRow + 1 > rowAndColumnCount.rowCount - 1) break;
+        else {
+          nextRow++;
+          nextCol = 0;
+        }
+      }
       break;
-    case 'ArrowLeft':
-      nextCol > 0 && !isSelectedTable && nextCol--;
+    }
+    case 'ArrowLeft': {
+      if (nextCol > 0) !isSelectedTable && nextCol--;
+      else if (!isSelectedTable) {
+        // move to the prev row
+        // if we are at the beganing of the table do nothing
+        if (nextRow - 1 < 0) break;
+        else {
+          nextRow--;
+          nextCol = rowAndColumnCount.columnCount - 1;
+        }
+      }
       break;
+    }
     default:
   }
 

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -28,19 +28,23 @@ export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, selState)
       nextRow > 0 && (!isSelectedTable || nextRow !== 1) && nextRow--;
       break;
     case 'ArrowRight':
-      if (nextCol < rowAndColumnCount.columnCount - 1 && !isSelectedTable) {
-        nextCol++;
-      } else if (!isSelectedTable && nextRow < rowAndColumnCount.rowCount - 1) {
-        nextRow++;
-        nextCol = 0;
+      if (!isSelectedTable) {
+        if (nextCol < rowAndColumnCount.columnCount - 1) {
+          nextCol++;
+        } else if (nextRow < rowAndColumnCount.rowCount - 1) {
+          nextRow++;
+          nextCol = 0;
+        }
       }
       break;
     case 'ArrowLeft':
-      if (nextCol > 0 && !isSelectedTable) {
-        nextCol--;
-      } else if (!isSelectedTable && nextRow > 0) {
-        nextRow--;
-        nextCol = rowAndColumnCount.columnCount - 1;
+      if (!isSelectedTable) {
+        if (nextCol > 0) {
+          nextCol--;
+        } else if (nextRow > 0) {
+          nextRow--;
+          nextCol = rowAndColumnCount.columnCount - 1;
+        }
       }
       break;
     default:


### PR DESCRIPTION
in this PR, I have tweaked the functionality for `arrowKeysNavigation` a bit in order to support the row navigation when reaching to the end or beginning of each row in table. 

also since the only purpose of this PR is to navigate between rows in table there are two constrains for it: 
1. **when we reach to the beginning of the table (`[0, 0]` coordinates)**
2. **when we reach to the end of the table (`[rowLenght - 1, colLength - 1]` coordinates)**

in those cases we are still making user to remain in those cells until they actually want to move to the next element by using `shift + tab` in order to move to the previous focused element or by just using `tab` in order to move to the next element on the screen.