### PR TITLE
[chore]: fully moved to use `sinon.stub` instead of `sandbox.replace`

### DIFF
--- a/src/table/TableBodyWrapper.jsx
+++ b/src/table/TableBodyWrapper.jsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles({
   },
 });
 
-const TableBodyWrapper = ({
+function TableBodyWrapper({
   rootElement,
   tableData,
   constraints,
@@ -44,7 +44,7 @@ const TableBodyWrapper = ({
   theme,
   focusedCellCoord,
   setShouldRefocus,
-}) => {
+}) {
   const { rows, columns } = tableData;
   const hoverEffect = layout.components?.[0]?.content?.hoverEffect;
   const bodyStyle = useMemo(() => getBodyStyle(layout, theme), [layout, theme.name()]);
@@ -117,7 +117,7 @@ const TableBodyWrapper = ({
       ))}
     </TableBody>
   );
-};
+}
 
 TableBodyWrapper.propTypes = {
   rootElement: PropTypes.object.isRequired,
@@ -130,4 +130,4 @@ TableBodyWrapper.propTypes = {
   setShouldRefocus: PropTypes.func.isRequired,
 };
 
-export default React.memo(TableBodyWrapper);
+export default TableBodyWrapper;

--- a/src/table/TableHeadWrapper.jsx
+++ b/src/table/TableHeadWrapper.jsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles({
   },
 });
 
-export default function TableHeadWrapper({
+function TableHeadWrapper({
   rootElement,
   tableData,
   theme,
@@ -100,3 +100,5 @@ TableHeadWrapper.propTypes = {
   focusedCellCoord: PropTypes.object.isRequired,
   selectionsAPI: PropTypes.object.isRequired,
 };
+
+export default TableHeadWrapper;

--- a/src/table/__tests__/TableBodyWrapper.spec.jsx
+++ b/src/table/__tests__/TableBodyWrapper.spec.jsx
@@ -14,7 +14,6 @@ import * as handleKeyPress from '../cells/handle-key-press';
 import * as handleCellFocus from '../cells/handle-cell-focus';
 
 describe('<TableBodyWrapper />', async () => {
-  const sandbox = sinon.createSandbox();
   const model = { getHyperCubeData: async () => generateDataPages(2, 2) };
 
   let tableData;
@@ -22,9 +21,10 @@ describe('<TableBodyWrapper />', async () => {
   let selectionsAPI;
   let layout;
   let theme;
+  let cellRendererSpy;
 
   beforeEach(async () => {
-    sandbox.replace(selectionsUtils, 'addSelectionListeners', () => {});
+    sinon.stub(selectionsUtils, 'addSelectionListeners').returns(sinon.spy());
 
     tableData = await manageData(model, generateLayout(1, 1), { top: 0, height: 100 });
     constraints = {};
@@ -34,17 +34,17 @@ describe('<TableBodyWrapper />', async () => {
       name: () => {},
     };
     layout = {};
+    cellRendererSpy = sinon.spy();
   });
 
   afterEach(() => {
-    sandbox.verifyAndRestore();
-    sandbox.resetHistory();
+    sinon.verifyAndRestore();
+    sinon.resetHistory();
   });
 
   it('should render 2x2 table body and call CellRenderer', () => {
-    const cellRendererSpy = sinon.spy();
     // eslint-disable-next-line react/prop-types
-    sandbox.replace(getCellRenderer, 'default', () => ({ value }) => {
+    sinon.stub(getCellRenderer, 'default').returns(({ value }) => {
       cellRendererSpy();
       return <td>{value}</td>;
     });
@@ -67,7 +67,7 @@ describe('<TableBodyWrapper />', async () => {
   });
 
   it('should call bodyHandleKeyPress on keyDown', () => {
-    sandbox.replace(handleKeyPress, 'bodyHandleKeyPress', sinon.spy());
+    sinon.stub(handleKeyPress, 'bodyHandleKeyPress').returns(sinon.spy());
 
     const { queryByText } = render(
       <TableBodyWrapper
@@ -84,7 +84,7 @@ describe('<TableBodyWrapper />', async () => {
   });
 
   it('should call handleClickToFocusBody on mouseDown', () => {
-    sandbox.replace(handleCellFocus, 'handleClickToFocusBody', sinon.spy());
+    sinon.stub(handleCellFocus, 'handleClickToFocusBody').returns(sinon.spy());
 
     const { queryByText } = render(
       <TableBodyWrapper

--- a/src/table/__tests__/TableHeadWrapper.spec.jsx
+++ b/src/table/__tests__/TableHeadWrapper.spec.jsx
@@ -8,7 +8,6 @@ import * as handleKeyPress from '../cells/handle-key-press';
 import * as handleCellFocus from '../cells/handle-cell-focus';
 
 describe('<TableHeadWrapper />', () => {
-  const sandbox = sinon.createSandbox();
   let tableData;
   let theme;
   let layout;
@@ -42,8 +41,8 @@ describe('<TableHeadWrapper />', () => {
   });
 
   afterEach(() => {
-    sandbox.verifyAndRestore();
-    sandbox.resetHistory();
+    sinon.verifyAndRestore();
+    sinon.resetHistory();
   });
 
   it('should render table head', () => {
@@ -110,7 +109,7 @@ describe('<TableHeadWrapper />', () => {
   });
 
   it('should call headHandleKeyPress when keyDown on a header cell', () => {
-    sandbox.replace(handleKeyPress, 'headHandleKeyPress', sinon.spy());
+    sinon.stub(handleKeyPress, 'headHandleKeyPress').returns(sinon.spy());
 
     const { queryByText } = render(
       <TableHeadWrapper
@@ -128,7 +127,7 @@ describe('<TableHeadWrapper />', () => {
   });
 
   it('should call handleClickToFocusHead when clicking a header cell', () => {
-    sandbox.replace(handleCellFocus, 'handleClickToFocusHead', sinon.spy());
+    sinon.stub(handleCellFocus, 'handleClickToFocusHead').returns(sinon.spy());
 
     const { queryByText } = render(
       <TableHeadWrapper

--- a/src/table/__tests__/TableWrapper.spec.jsx
+++ b/src/table/__tests__/TableWrapper.spec.jsx
@@ -5,12 +5,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import TableWrapper from '../TableWrapper';
-import TableBodyWrapper from '../TableBodyWrapper';
+import * as TableBodyWrapper from '../TableBodyWrapper';
 import * as TableHeadWrapper from '../TableHeadWrapper';
 import * as handleKeyPress from '../cells/handle-key-press';
 
 describe('<TableWrapper />', () => {
-  const sandbox = sinon.createSandbox();
   let tableData;
   let setPageInfo;
   let constraints;
@@ -20,8 +19,8 @@ describe('<TableWrapper />', () => {
   let rootElement;
 
   beforeEach(() => {
-    sandbox.replace(TableBodyWrapper, 'type', () => <tbody />);
-    sandbox.replace(TableHeadWrapper, 'default', () => <thead />);
+    sinon.stub(TableBodyWrapper, 'default').returns(() => <tbody />);
+    sinon.stub(TableHeadWrapper, 'default').returns(() => <thead />);
 
     tableData = {
       size: { qcy: 200 },
@@ -40,12 +39,12 @@ describe('<TableWrapper />', () => {
       clientHeight: {},
       getElementsByTagName: () => [{ clientHeight: {} }],
     };
-    sandbox.replace(handleKeyPress, 'updatePage', sinon.spy());
+    sinon.stub(handleKeyPress, 'updatePage').returns(sinon.spy());
   });
 
   afterEach(() => {
-    sandbox.verifyAndRestore();
-    sandbox.resetHistory();
+    sinon.verifyAndRestore();
+    sinon.resetHistory();
   });
 
   it('should render table', () => {

--- a/src/table/cells/__tests__/handle-key-press.spec.js
+++ b/src/table/cells/__tests__/handle-key-press.spec.js
@@ -427,7 +427,6 @@ describe('handle-key-press', () => {
   });
 
   describe('updatePage', () => {
-    const sandbox = sinon.createSandbox();
     let evt = {};
     let totalRowSize;
     let page;
@@ -442,12 +441,12 @@ describe('handle-key-press', () => {
         metaKey: true,
         key: 'ArrowRight',
       };
-      handleChangePage = sandbox.spy();
-      setShouldRefocus = sandbox.spy();
+      handleChangePage = sinon.spy();
+      setShouldRefocus = sinon.spy();
     });
 
     afterEach(() => {
-      sandbox.verifyAndRestore();
+      sinon.verifyAndRestore();
     });
 
     it('when shift key is not pressed, handleChangePage should not run', () => {

--- a/src/table/cells/__tests__/renderer.spec.js
+++ b/src/table/cells/__tests__/renderer.spec.js
@@ -5,20 +5,19 @@ import * as withStyling from '../withStyling';
 
 describe('render', () => {
   describe('getCellRenderer', () => {
-    const sandbox = sinon.createSandbox();
     let selectionsEnabled;
     let hasColumnStyling;
 
     beforeEach(() => {
       selectionsEnabled = false;
       hasColumnStyling = false;
-      sandbox.replace(withSelections, 'default', sandbox.spy());
-      sandbox.replace(withColumnStyling, 'default', sandbox.spy());
-      sandbox.replace(withStyling, 'default', sandbox.spy());
+      sinon.stub(withSelections, 'default').returns(sinon.spy());
+      sinon.stub(withColumnStyling, 'default').returns(sinon.spy());
+      sinon.stub(withStyling, 'default').returns(sinon.spy());
     });
 
     afterEach(() => {
-      sandbox.verifyAndRestore();
+      sinon.verifyAndRestore();
     });
 
     it('should call withStyling when selectionsEnabled and hasColumnStyling is false', () => {

--- a/src/table/cells/__tests__/withColumnStyling.spec.jsx
+++ b/src/table/cells/__tests__/withColumnStyling.spec.jsx
@@ -8,7 +8,6 @@ import * as withColumnStyling from '../withColumnStyling';
 import * as stylingUtils from '../../styling-utils';
 
 describe('withColumnStyling', () => {
-  const sandbox = sinon.createSandbox();
   let HOC;
   let cell;
   let column;
@@ -18,7 +17,7 @@ describe('withColumnStyling', () => {
     // This is a bit of dummy mock. value will be on props, but this is not how the value is set. That is done in tableBodyWrapper
     // But this enables testing that withStyling uses the CellComponent correctly
     HOC = withColumnStyling.default((props) => <div {...props}>{props.value}</div>);
-    sandbox.replace(stylingUtils, 'getColumnStyle', sinon.spy());
+    sinon.stub(stylingUtils, 'getColumnStyle').returns(sinon.spy());
 
     styling = {};
     cell = {
@@ -30,8 +29,8 @@ describe('withColumnStyling', () => {
   });
 
   afterEach(() => {
-    sandbox.verifyAndRestore();
-    sandbox.resetHistory();
+    sinon.verifyAndRestore();
+    sinon.resetHistory();
   });
 
   it('should render table head', () => {

--- a/src/table/cells/__tests__/withSelections.spec.jsx
+++ b/src/table/cells/__tests__/withSelections.spec.jsx
@@ -8,7 +8,6 @@ import * as withSelections from '../withSelections';
 import * as selectionsUtils from '../../selections-utils';
 
 describe('withSelections', async () => {
-  const sandbox = sinon.createSandbox();
   let HOC;
   let cell;
   let selState;
@@ -18,7 +17,7 @@ describe('withSelections', async () => {
 
   beforeEach(() => {
     HOC = withSelections.default((props) => <div {...props}>{props.cell.value}</div>);
-    sandbox.replace(selectionsUtils, 'selectCell', sinon.spy());
+    sinon.stub(selectionsUtils, 'selectCell').returns(sinon.spy());
 
     cell = {
       isDim: true,
@@ -34,8 +33,8 @@ describe('withSelections', async () => {
   });
 
   afterEach(() => {
-    sandbox.verifyAndRestore();
-    sandbox.resetHistory();
+    sinon.verifyAndRestore();
+    sinon.resetHistory();
   });
 
   it('should render a mocked component with the passed value', () => {

--- a/src/table/cells/__tests__/withStyling.spec.jsx
+++ b/src/table/cells/__tests__/withStyling.spec.jsx
@@ -2,12 +2,10 @@ import '../../__tests__/rtl-setup';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import * as withStyling from '../withStyling';
 
 describe('withStyling', () => {
-  const sandbox = sinon.createSandbox();
   let HOC;
   let styling;
 
@@ -17,11 +15,6 @@ describe('withStyling', () => {
     HOC = withStyling.default((props) => <div {...props}>{props.value}</div>);
 
     styling = {};
-  });
-
-  afterEach(() => {
-    sandbox.verifyAndRestore();
-    sandbox.resetHistory();
   });
 
   it('should render table head', () => {


### PR DESCRIPTION
this is a quick PR for updating the way we use sinon in our test files
it's more refinement to our test cases rather than developing some feature or fixing a bug!