### PR TITLE
fix: variable name confusion

### DIFF
--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -18,17 +18,18 @@ export const updatePage = (evt, totalRowSize, page, rowsPerPage, handleChangePag
 
 export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, selState) => {
   let [nextRow, nextCol] = cellCoord;
-  const isSelectedTable = selState && selState.rows.length > 0;
+  // check if you have unconfirmed selections, so one or more cells are selected but not confirmed yet.
+  const hasUnconfirmedSelection = selState && selState.rows.length > 0;
 
   switch (evt.key) {
     case 'ArrowDown':
       nextRow + 1 < rowAndColumnCount.rowCount && nextRow++;
       break;
     case 'ArrowUp':
-      nextRow > 0 && (!isSelectedTable || nextRow !== 1) && nextRow--;
+      nextRow > 0 && (!hasUnconfirmedSelection || nextRow !== 1) && nextRow--;
       break;
     case 'ArrowRight':
-      if (isSelectedTable) break;
+      if (hasUnconfirmedSelection) break;
       if (nextCol < rowAndColumnCount.columnCount - 1) {
         nextCol++;
       } else if (nextRow < rowAndColumnCount.rowCount - 1) {
@@ -37,7 +38,7 @@ export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, selState)
       }
       break;
     case 'ArrowLeft':
-      if (isSelectedTable) break;
+      if (hasUnconfirmedSelection) break;
       if (nextCol > 0) {
         nextCol--;
       } else if (nextRow > 0) {


### PR DESCRIPTION
<img width="511" alt="Screenshot 2021-08-24 at 15 10 13" src="https://user-images.githubusercontent.com/4471489/133252571-a73eed5a-0215-466e-95f8-e4514ce750bc.png">

`selState && selState.rows.length > 0;` to check if you have unconfirmed selections, so one or more cells are selected but not confirmed yet.

I feel it have the same meaning with selectionsAPI.isModal(), but selectionsAPI is a react hook and can't be used in regular JavaScript functions..