### PR TITLE
[FIX#261]: fixed double tab to focus in firefox

### DIFF
--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -107,7 +107,7 @@ export default function TableWrapper(props) {
         })
       }
     >
-      <TableContainer ref={tableSection} className={classes[containerMode]}>
+      <TableContainer ref={tableSection} className={classes[containerMode]} tabIndex="-1" data-testid="table-wrapper">
         <Table stickyHeader aria-label={`showing ${rows.length + 1} rows and ${columns.length} columns`}>
           <TableHeadWrapper {...props} setfocusedCellCoord={setfocusedCellCoord} />
           <TableBodyWrapper {...props} setfocusedCellCoord={setfocusedCellCoord} setShouldRefocus={setShouldRefocus} />

--- a/src/table/__tests__/TableWrapper.spec.jsx
+++ b/src/table/__tests__/TableWrapper.spec.jsx
@@ -48,7 +48,7 @@ describe('<TableWrapper />', () => {
   });
 
   it('should render table', () => {
-    const { queryByLabelText, queryByText } = render(
+    const { queryByLabelText, queryByText, queryByTestId } = render(
       <TableWrapper
         tableData={tableData}
         setPageInfo={setPageInfo}
@@ -58,6 +58,7 @@ describe('<TableWrapper />', () => {
       />
     );
 
+    expect(queryByTestId('table-wrapper')).to.has.attr('tabindex', '-1');
     expect(queryByLabelText('showing 2 rows and 1 columns')).to.be.visible;
     expect(queryByText(`1-${rowsPerPage} of ${tableData.size.qcy}`)).to.be.visible;
     expect(queryByText(rowsPerPage)).to.be.visible;


### PR DESCRIPTION
fixes #261 
it looks like we miss the `tabIndex` on our `<TableWrapper />` component. it will does the job.