### PR TITLE
reset focus on change page

### DIFF
--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -107,7 +107,7 @@ export default function TableWrapper(props) {
       shouldRefocus,
       setFocusedCellCoord,
       hasSelections: selectionsAPI.isModal(),
-      shouldAddTabstop: keyboard.active,
+      shouldAddTabstop: !keyboard.enabled || keyboard.active,
     });
   }, [rows.length, size.qcy, size.qcx, page]);
 


### PR DESCRIPTION
when we have some selections, and trying to change the page, focus should stay on the very first cell of the same column. 

this PR fixes that 


fixes #301 