### PR TITLE
fix for double esc key press to cancel

### DIFF
--- a/src/table/TableWrapper.jsx
+++ b/src/table/TableWrapper.jsx
@@ -132,6 +132,7 @@ export default function TableWrapper(props) {
         ref={tableSectionRef}
         className={classes[containerMode]}
         tabIndex="-1"
+        role="application"
         data-testid="table-wrapper"
       >
         <Table

--- a/src/table/__tests__/TableWrapper.spec.jsx
+++ b/src/table/__tests__/TableWrapper.spec.jsx
@@ -73,6 +73,7 @@ describe('<TableWrapper />', () => {
     expect(queryByLabelText('SNTable.Accessibility.RowsAndColumns')).to.be.visible;
     expect(queryByLabelText('SNTable.Pagination.RowsPerPage')).to.be.visible;
     expect(queryByTestId('table-wrapper')).to.has.attr('tabindex', '-1');
+    expect(queryByTestId('table-wrapper')).to.has.attr('role', 'application');
     expect(queryByText('SNTable.Pagination.DisplayedRowsLabel')).to.be.visible;
     expect(queryByText(rowsPerPage)).to.be.visible;
   });


### PR DESCRIPTION
fixes #321 
NVDA turns to focus mode and the problem of pressing Esc key two times to cancel selection and more worse than than the problem of navigation on table cell rises. 

it turns out that NVDA has two basic modes at general: 
1. focus mode
2. browse mode
and in our cases it turns focus mode on by a typewriting machine sound ( like a glitch ). 

in order to prevent foucs mode on NVDA at all, we need to use `role="application"`. this will prevent this issue. 

also i added a simple test case to ensure that we always put `role="application"` on our `<TableContainer />`. 

**SPOILER ALERT:** this could be the possible solution for the same `role="button"` issue that we had previously while the sorting of the table. and that was exactly the same and turns focus mode on in the NVDA. but i'll check that in  another PR and will see if that was the case there as well.