### PR TITLE
fix: table loses focus in an embedded sheet after pressing ctrl+shift+left or right arrow to change page

### DIFF
--- a/src/table/cells/__tests__/handle-key-press.spec.js
+++ b/src/table/cells/__tests__/handle-key-press.spec.js
@@ -501,6 +501,8 @@ describe('handle-key-press', () => {
         ctrlKey: true,
         metaKey: true,
         key: 'ArrowRight',
+        stopPropagation: () => {},
+        preventDefault: () => {},
       };
       handleChangePage = sinon.spy();
       setShouldRefocus = sinon.spy();

--- a/src/table/cells/handle-key-press.js
+++ b/src/table/cells/handle-key-press.js
@@ -19,8 +19,8 @@ export const handleTableWrapperKeyDown = ({
   isSelectionActive,
 }) => {
   if (isCtrlShift(evt)) {
+    preventDefaultBehavior(evt);
     const lastPage = Math.ceil(totalRowSize / rowsPerPage) - 1;
-
     if (evt.key === 'ArrowRight' && page < lastPage) {
       setShouldRefocus();
       handleChangePage(null, page + 1);


### PR DESCRIPTION
fix #325 