### PR TITLE
Revert "fix(translations): bugfixes - RDL-5173 - Bug Fix (#335)"

### DIFF
--- a/locale/locales/de.json
+++ b/locale/locales/de.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} von {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Letzte Seite",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/es.json
+++ b/locale/locales/es.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} de {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Última página",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/fr.json
+++ b/locale/locales/fr.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} sur {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Dernière page",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/it.json
+++ b/locale/locales/it.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} di {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Ultima pagina",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/ja.json
+++ b/locale/locales/ja.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} / {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "最後のページ",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/ko.json
+++ b/locale/locales/ko.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{1}의 {0}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "마지막 페이지",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/nl.json
+++ b/locale/locales/nl.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} van {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Laatste pagina",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/pl.json
+++ b/locale/locales/pl.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} z {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Ostatnia strona",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/pt.json
+++ b/locale/locales/pt.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} de {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Última página",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/ru.json
+++ b/locale/locales/ru.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} из {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Последняя страница",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/sv.json
+++ b/locale/locales/sv.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} av {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Sista sidan",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/tr.json
+++ b/locale/locales/tr.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} / {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "Son sayfa",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/zh-CN.json
+++ b/locale/locales/zh-CN.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} / {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "最后一页",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",

--- a/locale/locales/zh-TW.json
+++ b/locale/locales/zh-TW.json
@@ -14,10 +14,6 @@
     "comment": "tooltip and aria-label for the first page button. (tew 210929)",
     "version": "vp2MW/tPZq4FsBw+3qknqA=="
   },
-  "SNTable.Pagination.DisplayedRowsLabel": {
-    "value": "{0} / {1}",
-    "comment": "label for the displayed rows, e.g. '1-100 of 234' (tew 211004)"
-  },
   "SNTable.Pagination.LastPage": {
     "value": "最後一頁",
     "comment": "tooltip and aria-label for the last page button. (tew 210929)",


### PR DESCRIPTION
This reverts commit d1d5e1e8501869e3b363735d12ab2cf4e303c285.

There was two PRs, adding translations with the same name. Reverting the one that is missing the `version` property.