### PR TITLE
fix: content property issue in mui-config

### DIFF
--- a/src/mui-config.json
+++ b/src/mui-config.json
@@ -192,7 +192,7 @@
           "color": "rgba(0, 0, 0, 0.55)",
           "WebkitFontSmoothing": "antialiased",
           "&::after": {
-            "content": ""
+            "content": "''"
           }
         },
         "& ~i": {


### PR DESCRIPTION
fix a style issue in nebula dev:


<img width="1776" alt="Screenshot 2021-10-21 at 16 48 11" src="https://user-images.githubusercontent.com/4471489/138428949-843774b0-c1a9-4c0b-8d13-0bc969ab1b9d.png">


