### PR TITLE
fix: move generateClassName into StylesProvider

### DIFF
--- a/src/table/Root.jsx
+++ b/src/table/Root.jsx
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles';
+import { StylesProvider } from '@mui/styles';
 import TableWrapper from './components/TableWrapper';
 
 export function render(rootElement, props) {
@@ -8,10 +9,12 @@ export function render(rootElement, props) {
 
   ReactDOM.render(
     <React.StrictMode>
-      <StyledEngineProvider injectFirst generateClassName={muiParameters.generateClassName}>
-        <ThemeProvider theme={muiParameters.theme}>
-          <TableWrapper {...props} />
-        </ThemeProvider>
+      <StyledEngineProvider injectFirst>
+        <StylesProvider generateClassName={muiParameters.generateClassName}>
+          <ThemeProvider theme={muiParameters.theme}>
+            <TableWrapper {...props} />
+          </ThemeProvider>
+        </StylesProvider>
       </StyledEngineProvider>
     </React.StrictMode>,
     rootElement


### PR DESCRIPTION
`generateClassName` does not work with `StyledEngineProvider`
so revert back the `StylesProvider` and move generateClassName to work with StylesProvider