### PR TITLE
fix: pagination select color in dark mode

### DIFF
--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -171,6 +171,9 @@ export default function TableWrapper(props) {
             inputProps: {
               'aria-label': translator.get('SNTable.Pagination.RowsPerPage'),
               'data-testid': 'select',
+              style: {
+                color: '#404040',
+              },
               tabindex: keyboard.active ? '0' : '-1',
             },
             native: true,


### PR DESCRIPTION
head:


![Screenshot 2021-10-28 at 11 06 49](https://user-images.githubusercontent.com/4471489/139225209-d7781f7f-6f38-43e5-af22-89b1ea49755e.png)

fixed:

![Screenshot 2021-10-28 at 11 06 19](https://user-images.githubusercontent.com/4471489/139225195-50450fca-e3c1-4df7-a954-9365d862ebeb.png)