### PR TITLE
ix: mui focused style for input label

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 coverage
 node_modules
 src/mui-config.json
+*.css

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import manageData from './handle-data';
 import sortingFactory from './sorting-factory';
 import { render, teardown } from './table/Root';
 import muiSetup from './mui-setup';
+import './table/components/TablePaginationActions.css';
 
 export default function supernova(env) {
   return {

--- a/src/table/components/TablePaginationActions.css
+++ b/src/table/components/TablePaginationActions.css
@@ -1,0 +1,3 @@
+.MuiInputLabel-root.Mui-focused {
+  color: #404040;
+}


### PR DESCRIPTION
<img width="251" alt="Screenshot 2021-10-28 at 13 34 12" src="https://user-images.githubusercontent.com/4471489/139259500-813da0e8-881a-462b-a474-7600150135e6.png">
based on the name, i think it is from mui.
Learning from https://mui.com/api/input-label/

![Screenshot 2021-10-28 at 14 56 59](https://user-images.githubusercontent.com/4471489/139259667-8043196a-8a1c-4700-80c5-1edc4884aefc.png) 

and https://mui.com/guides/interoperability/#global-css, 
I came up with the solution
