### PR TITLE
fix: should use tabIndex

### DIFF
--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -167,7 +167,7 @@ export default function TableWrapper(props) {
               style: {
                 color: '#404040',
               },
-              tabindex: keyboard.active ? 0 : -1,
+              tabIndex: keyboard.active ? 0 : -1,
             },
             native: true,
           }}


### PR DESCRIPTION
need to use tabindex in `<select>` component in mui v4.
in mui v5, it was fixed. 