### PR TITLE
feat: add react hook ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     }
   },
   "extends": ["airbnb", "prettier", "eslint:recommended"],
-  "plugins": ["prettier", "react"],
+  "plugins": ["prettier", "react", "react-hooks"],
   "rules": {
     "max-len": 0,
     "no-plusplus": 0,
@@ -23,6 +23,8 @@
     "no-nested-ternary": 0,
     "react/forbid-prop-types": 0,
     "react/jsx-props-no-spreading": 0,
+    "react-hooks/rules-of-hooks": 2,
+    "react-hooks/exhaustive-deps": 1,
     "import/no-extraneous-dependencies": [2, { "devDependencies": true }],
     "prefer-destructuring": ["error", { "object": true, "array": false }],
     "no-param-reassign": [2, { "props": false }]

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
   useElement,
   useStaleLayout,


### PR DESCRIPTION
just found that eslint-plugin-react-hooks was already installed, but the eslint rule is not added.