### PR TITLE
fix: make sure page for getHyperCubeData is never more than 10k cells

### DIFF
--- a/src/__test__/generate-test-data.js
+++ b/src/__test__/generate-test-data.js
@@ -14,7 +14,7 @@ export function generateDataPages(height, width) {
   return [{ qMatrix }];
 }
 
-export function generateLayout(nDims, nMeas, qColumnOrder = []) {
+export function generateLayout(nDims, nMeas, nRows, qColumnOrder = []) {
   const createField = (idx) => ({
     qFallbackTitle: `title-${idx}`,
     qAttrExprInfo: [],
@@ -37,7 +37,7 @@ export function generateLayout(nDims, nMeas, qColumnOrder = []) {
       qMeasureInfo,
       qColumnOrder,
       qEffectiveInterColumnSortOrder: qColumnOrder, // little hack, assuming the column order is the same as the sort order
-      qSize: { qcx: nDims + nMeas },
+      qSize: { qcx: nDims + nMeas, qcy: nRows },
     },
   };
 }

--- a/src/__test__/handle-data.spec.js
+++ b/src/__test__/handle-data.spec.js
@@ -129,5 +129,14 @@ describe('handle-data', () => {
       expect(tableData).to.be.null;
       expect(setPageInfo).to.have.been.calledOnceWith({ ...pageInfo, rowsPerPage: 4 });
     });
+
+    it('should return null and call setPageInfo with rowsPerPage 4 when width > 10000', async () => {
+      pageInfo = { ...pageInfo, page: 0 };
+      layout = generateLayout(6000, 6000, 100);
+      const tableData = await manageData(model, layout, pageInfo, setPageInfo);
+
+      expect(tableData).to.be.null;
+      expect(setPageInfo).to.have.been.calledOnceWith({ ...pageInfo, rowsPerPage: 0 });
+    });
   });
 });

--- a/src/__test__/handle-data.spec.js
+++ b/src/__test__/handle-data.spec.js
@@ -7,7 +7,7 @@ describe('handle-data', () => {
   let colIdx;
 
   beforeEach(() => {
-    layout = generateLayout(2, 2, [1, 2, 0, 3]);
+    layout = generateLayout(2, 2, 200, [1, 2, 0, 3]);
   });
 
   describe('getColumnInfo', () => {
@@ -24,7 +24,7 @@ describe('handle-data', () => {
     });
 
     it('should return column info for dimension', () => {
-      const columnInfo = getColumnInfo(layout, colIdx);
+      const columnInfo = getColumnInfo(layout.qHyperCube, colIdx);
       expect(columnInfo).to.eql(getExpectedInfo(colIdx, true));
     });
 
@@ -39,35 +39,35 @@ describe('handle-data', () => {
       const expected = getExpectedInfo(colIdx, true);
       expected.stylingInfo = ['someId'];
 
-      const columnInfo = getColumnInfo(layout, colIdx);
+      const columnInfo = getColumnInfo(layout.qHyperCube, colIdx);
       expect(columnInfo).to.eql(expected);
     });
 
     it('should return false for hidden column', () => {
       layout.qHyperCube.qDimensionInfo[colIdx].qError = { qErrorCode: 7005 };
 
-      const columnInfo = getColumnInfo(layout, colIdx);
+      const columnInfo = getColumnInfo(layout.qHyperCube, colIdx);
       expect(columnInfo).to.be.false;
     });
 
     it('should return column info for measure', () => {
       colIdx = 3;
 
-      const columnInfo = getColumnInfo(layout, colIdx);
+      const columnInfo = getColumnInfo(layout.qHyperCube, colIdx);
       expect(columnInfo).to.eql(getExpectedInfo(colIdx, false));
     });
   });
 
   describe('getColumnOrder', () => {
     it('should return qColumnOrder when length of qColumnOrder equals the number of columns', () => {
-      const columnLayout = getColumnOrder(layout);
+      const columnLayout = getColumnOrder(layout.qHyperCube);
       expect(columnLayout).to.equal(layout.qHyperCube.qColumnOrder);
     });
 
     it('should return [0, 1, ... , number of columns] when length of qColumnOrder does not equal number of columns', () => {
       layout.qHyperCube.qColumnOrder = [];
 
-      const columnLayout = getColumnOrder(layout);
+      const columnLayout = getColumnOrder(layout.qHyperCube);
       expect(columnLayout).to.eql([0, 1, 2, 3]);
     });
   });
@@ -78,8 +78,8 @@ describe('handle-data', () => {
     let setPageInfo;
 
     beforeEach(() => {
-      model = { getHyperCubeData: async () => generateDataPages(2, 4) };
       pageInfo = { page: 1, rowsPerPage: 100 };
+      model = { getHyperCubeData: async () => generateDataPages(100, 4) };
       setPageInfo = sinon.spy();
     });
 
@@ -87,7 +87,7 @@ describe('handle-data', () => {
       const { size, rows, columns } = await manageData(model, layout, pageInfo, setPageInfo);
 
       expect(size).to.equal(layout.qHyperCube.qSize);
-      expect(rows.length).to.equal(2);
+      expect(rows.length).to.equal(100);
       expect(rows[0]['col-0'].qText).to.equal('2');
       expect(rows[0]['col-0'].rowIdx).to.equal(100);
       expect(rows[0]['col-0'].colIdx).to.equal(0);
@@ -110,6 +110,24 @@ describe('handle-data', () => {
 
       expect(tableData).to.be.null;
       expect(setPageInfo).to.have.been.calledOnceWith({ page: 0, rowsPerPage: 100 });
+    });
+
+    it('should return null and call setPageInfo with rowsPerPage 25 when height * width > 10000 and width is 120', async () => {
+      pageInfo = { page: 0, rowsPerPage: 100 };
+      layout = generateLayout(60, 60, 1100);
+      const tableData = await manageData(model, layout, pageInfo, setPageInfo);
+
+      expect(tableData).to.be.null;
+      expect(setPageInfo).to.have.been.calledOnceWith({ page: 0, rowsPerPage: 25 });
+    });
+
+    it('should return null and call setPageInfo with rowsPerPage 4 when height * width > 10000 and width is 2200', async () => {
+      pageInfo = { page: 0, rowsPerPage: 100 };
+      layout = generateLayout(1100, 1100, 100);
+      const tableData = await manageData(model, layout, pageInfo, setPageInfo);
+
+      expect(tableData).to.be.null;
+      expect(setPageInfo).to.have.been.calledOnceWith({ page: 0, rowsPerPage: 4 });
     });
   });
 });

--- a/src/__test__/handle-data.spec.js
+++ b/src/__test__/handle-data.spec.js
@@ -109,7 +109,7 @@ describe('handle-data', () => {
       const tableData = await manageData(model, layout, pageInfo, setPageInfo);
 
       expect(tableData).to.be.null;
-      expect(setPageInfo).to.have.been.calledOnceWith({ page: 0, rowsPerPage: 100 });
+      expect(setPageInfo).to.have.been.calledOnceWith({ ...pageInfo, page: 0 });
     });
 
     it('should return null and call setPageInfo with rowsPerPage 25 when height * width > 10000 and width is 120', async () => {
@@ -118,7 +118,7 @@ describe('handle-data', () => {
       const tableData = await manageData(model, layout, pageInfo, setPageInfo);
 
       expect(tableData).to.be.null;
-      expect(setPageInfo).to.have.been.calledOnceWith({ page: 0, rowsPerPage: 25 });
+      expect(setPageInfo).to.have.been.calledOnceWith({ ...pageInfo, rowsPerPage: 25 });
     });
 
     it('should return null and call setPageInfo with rowsPerPage 4 when height * width > 10000 and width is 2200', async () => {
@@ -127,7 +127,7 @@ describe('handle-data', () => {
       const tableData = await manageData(model, layout, pageInfo, setPageInfo);
 
       expect(tableData).to.be.null;
-      expect(setPageInfo).to.have.been.calledOnceWith({ page: 0, rowsPerPage: 4 });
+      expect(setPageInfo).to.have.been.calledOnceWith({ ...pageInfo, rowsPerPage: 4 });
     });
   });
 });

--- a/src/__test__/handle-data.spec.js
+++ b/src/__test__/handle-data.spec.js
@@ -78,7 +78,7 @@ describe('handle-data', () => {
     let setPageInfo;
 
     beforeEach(() => {
-      pageInfo = { page: 1, rowsPerPage: 100 };
+      pageInfo = { page: 1, rowsPerPage: 100, rowsPerPageOptions: [10, 25, 100] };
       model = { getHyperCubeData: async () => generateDataPages(100, 4) };
       setPageInfo = sinon.spy();
     });
@@ -113,7 +113,7 @@ describe('handle-data', () => {
     });
 
     it('should return null and call setPageInfo with rowsPerPage 25 when height * width > 10000 and width is 120', async () => {
-      pageInfo = { page: 0, rowsPerPage: 100 };
+      pageInfo = { ...pageInfo, page: 0 };
       layout = generateLayout(60, 60, 1100);
       const tableData = await manageData(model, layout, pageInfo, setPageInfo);
 
@@ -122,7 +122,7 @@ describe('handle-data', () => {
     });
 
     it('should return null and call setPageInfo with rowsPerPage 4 when height * width > 10000 and width is 2200', async () => {
-      pageInfo = { page: 0, rowsPerPage: 100 };
+      pageInfo = { ...pageInfo, page: 0 };
       layout = generateLayout(1100, 1100, 100);
       const tableData = await manageData(model, layout, pageInfo, setPageInfo);
 

--- a/src/__test__/sorting-factory.spec.js
+++ b/src/__test__/sorting-factory.spec.js
@@ -9,7 +9,7 @@ describe('sorting-factory', () => {
   let expectedPatches;
 
   beforeEach(() => {
-    layout = generateLayout(2, 2, [0, 1, 2, 3]);
+    layout = generateLayout(2, 2, 2, [0, 1, 2, 3]);
     model = {
       applyPatches: sinon.spy(),
     };

--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -44,12 +44,12 @@ export default async function manageData(model, layout, pageInfo, setPageInfo) {
   // When the number of rows is reduced (e.g. confirming selections),
   // you can end up still being on a page that doesn't exist anymore, then go back to the first page and return null
   if (page > 0 && top >= totalHeight) {
-    setPageInfo({ rowsPerPage, page: 0 });
+    setPageInfo({ ...pageInfo, page: 0 });
     return null;
   }
   // If the number of cells exceeds 10k then we need to lower the rows per page to the maximum possible value
   if (height * width > MAX_CELLS) {
-    setPageInfo({ rowsPerPage: getHighestPossibleRpp(width, rowsPerPageOptions), page: 0 });
+    setPageInfo({ ...pageInfo, rowsPerPage: getHighestPossibleRpp(width, rowsPerPageOptions), page: 0 });
     return null;
   }
 

--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -3,14 +3,22 @@ const directionMap = {
   D: 'desc',
 };
 
-export function getColumnOrder(layout) {
-  const { qColumnOrder, qDimensionInfo, qMeasureInfo } = layout.qHyperCube;
+const MAX_CELLS = 10000;
+
+export const ROWS_PER_PAGE_OPTIONS = [10, 25, 100];
+
+export function getHighestPossibleRpp(width) {
+  const highestPossibleOption = [...ROWS_PER_PAGE_OPTIONS].reverse().find((opt) => opt * width <= MAX_CELLS);
+  return highestPossibleOption || Math.floor(MAX_CELLS / width); // covering corner case of lowest option being too high
+}
+
+export function getColumnOrder({ qColumnOrder, qDimensionInfo, qMeasureInfo }) {
   if (qColumnOrder?.length === qDimensionInfo.length + qMeasureInfo.length) return qColumnOrder;
   return [...Array(qDimensionInfo.length + qMeasureInfo.length).keys()];
 }
 
-export function getColumnInfo(layout, colIndex) {
-  const { qDimensionInfo, qMeasureInfo } = layout.qHyperCube;
+export function getColumnInfo(qHyperCube, colIndex) {
+  const { qDimensionInfo, qMeasureInfo } = qHyperCube;
   const numDims = qDimensionInfo.length;
   const isDim = colIndex < numDims;
   const info = isDim ? qDimensionInfo[colIndex] : qMeasureInfo[colIndex - numDims];
@@ -30,23 +38,29 @@ export function getColumnInfo(layout, colIndex) {
 
 export default async function manageData(model, layout, pageInfo, setPageInfo) {
   const { page, rowsPerPage } = pageInfo;
-  const top = page * rowsPerPage;
   const size = layout.qHyperCube.qSize;
-  const allRowsLength = size.qcy;
+  const top = page * rowsPerPage;
+  const width = size.qcx;
+  const totalHeight = size.qcy;
+  const height = Math.min(rowsPerPage, totalHeight - top);
   // When the number of rows is reduced (e.g. confirming selections),
   // you can end up still being on a page that doesn't exist anymore, then go back to the first page and return null
-  if (page > 0 && top >= allRowsLength) {
+  if (page > 0 && top >= totalHeight) {
     setPageInfo({ rowsPerPage, page: 0 });
     return null;
   }
+  // If the number of cells exceeds 10k then we need to lower the rows per page to the maximum possible value
+  if (height * width > MAX_CELLS) {
+    setPageInfo({ rowsPerPage: getHighestPossibleRpp(width), page: 0 });
+    return null;
+  }
 
-  const columnOrder = getColumnOrder(layout);
-  const dataPages = await model.getHyperCubeData('/qHyperCubeDef', [
-    { qTop: top, qLeft: 0, qHeight: rowsPerPage, qWidth: columnOrder.length },
-  ]);
-
+  const columnOrder = getColumnOrder(layout.qHyperCube);
   // using filter to remove hidden columns (represented with false)
-  const columns = columnOrder.map((colIndex) => getColumnInfo(layout, colIndex)).filter(Boolean);
+  const columns = columnOrder.map((colIndex) => getColumnInfo(layout.qHyperCube, colIndex)).filter(Boolean);
+  const dataPages = await model.getHyperCubeData('/qHyperCubeDef', [
+    { qTop: top, qLeft: 0, qHeight: height, qWidth: width },
+  ]);
   const rows = dataPages[0].qMatrix.map((r, rowIdx) => {
     const row = { key: `row-${rowIdx}` };
     columns.forEach((c, colIdx) => {

--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -5,10 +5,8 @@ const directionMap = {
 
 const MAX_CELLS = 10000;
 
-export const ROWS_PER_PAGE_OPTIONS = [10, 25, 100];
-
-export function getHighestPossibleRpp(width) {
-  const highestPossibleOption = [...ROWS_PER_PAGE_OPTIONS].reverse().find((opt) => opt * width <= MAX_CELLS);
+export function getHighestPossibleRpp(width, rowsPerPageOptions) {
+  const highestPossibleOption = [...rowsPerPageOptions].reverse().find((opt) => opt * width <= MAX_CELLS);
   return highestPossibleOption || Math.floor(MAX_CELLS / width); // covering corner case of lowest option being too high
 }
 
@@ -37,7 +35,7 @@ export function getColumnInfo(qHyperCube, colIndex) {
 }
 
 export default async function manageData(model, layout, pageInfo, setPageInfo) {
-  const { page, rowsPerPage } = pageInfo;
+  const { page, rowsPerPage, rowsPerPageOptions } = pageInfo;
   const size = layout.qHyperCube.qSize;
   const top = page * rowsPerPage;
   const width = size.qcx;
@@ -51,7 +49,7 @@ export default async function manageData(model, layout, pageInfo, setPageInfo) {
   }
   // If the number of cells exceeds 10k then we need to lower the rows per page to the maximum possible value
   if (height * width > MAX_CELLS) {
-    setPageInfo({ rowsPerPage: getHighestPossibleRpp(width), page: 0 });
+    setPageInfo({ rowsPerPage: getHighestPossibleRpp(width, rowsPerPageOptions), page: 0 });
     return null;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export default function supernova(env) {
       const theme = useTheme();
       const keyboard = useKeyboard();
       const rect = useRect();
-      const [pageInfo, setPageInfo] = useState(() => ({ page: 0, rowsPerPage: 25 }));
+      const [pageInfo, setPageInfo] = useState(() => ({ page: 0, rowsPerPage: 100 }));
       const [tableData] = usePromise(() => manageData(model, layout, pageInfo, setPageInfo), [layout, pageInfo]);
 
       useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,11 @@ export default function supernova(env) {
       const theme = useTheme();
       const keyboard = useKeyboard();
       const rect = useRect();
-      const [pageInfo, setPageInfo] = useState(() => ({ page: 0, rowsPerPage: 100 }));
+      const [pageInfo, setPageInfo] = useState(() => ({
+        page: 0,
+        rowsPerPage: 100,
+        rowsPerPageOptions: [10, 25, 100],
+      }));
       const [tableData] = usePromise(() => manageData(model, layout, pageInfo, setPageInfo), [layout, pageInfo]);
 
       useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export default function supernova(env) {
       const theme = useTheme();
       const keyboard = useKeyboard();
       const rect = useRect();
-      const [pageInfo, setPageInfo] = useState(() => ({ page: 0, rowsPerPage: 100 }));
+      const [pageInfo, setPageInfo] = useState(() => ({ page: 0, rowsPerPage: 25 }));
       const [tableData] = usePromise(() => manageData(model, layout, pageInfo, setPageInfo), [layout, pageInfo]);
 
       useEffect(() => {

--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -14,6 +14,7 @@ import { handleTableWrapperKeyDown } from '../utils/handle-key-press';
 import { updateFocus, handleResetFocus, handleFocusoutEvent } from '../utils/handle-accessibility';
 import { handleScroll, handleNavigateTop } from '../utils/handle-scroll';
 import announcementFactory from '../utils/announcement-factory';
+import { ROWS_PER_PAGE_OPTIONS } from '../../handle-data';
 
 const useStyles = makeStyles({
   paper: {
@@ -60,7 +61,7 @@ export default function TableWrapper(props) {
   const classes = useStyles();
   const containerMode = constraints.active ? 'containerOverflowHidden' : 'containerOverflowAuto';
   const paginationHidden = constraints.active && 'paginationHidden';
-  const paginationFixedRpp = selectionsAPI.isModal() || rect.width < 550;
+  const paginationFixedRpp = selectionsAPI.isModal() || rect.width < 550 || size.qcx >= 100;
   /* eslint-disable react-hooks/rules-of-hooks */
   const announce = announcer || useMemo(() => announcementFactory(rootElement, translator), [translator.language]);
   const totalPages = Math.ceil(size.qcy / rowsPerPage);
@@ -165,7 +166,7 @@ export default function TableWrapper(props) {
       <Paper className={classes.tablePaginationSection}>
         <TablePagination
           className={classes[paginationHidden]}
-          rowsPerPageOptions={paginationFixedRpp ? [rowsPerPage] : [10, 25, 100]}
+          rowsPerPageOptions={paginationFixedRpp ? [rowsPerPage] : ROWS_PER_PAGE_OPTIONS}
           component="div"
           count={size.qcy}
           rowsPerPage={rowsPerPage}

--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -75,7 +75,7 @@ export default function TableWrapper(props) {
     announce({ keys: [['SNTable.Pagination.PageStatusReport', [pageIdx + 1, totalPages]]], politeness: 'assertive' });
   };
   const handleChangeRowsPerPage = (evt) => {
-    setPageInfo({ page: 0, rowsPerPage: +evt.target.value });
+    setPageInfo({ ...pageInfo, page: 0, rowsPerPage: +evt.target.value });
     announce({ keys: [['SNTable.Pagination.RowsPerPageChange', evt.target.value]], politeness: 'assertive' });
   };
 

--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -14,7 +14,6 @@ import { handleTableWrapperKeyDown } from '../utils/handle-key-press';
 import { updateFocus, handleResetFocus, handleFocusoutEvent } from '../utils/handle-accessibility';
 import { handleScroll, handleNavigateTop } from '../utils/handle-scroll';
 import announcementFactory from '../utils/announcement-factory';
-// import { ROWS_PER_PAGE_OPTIONS } from '../../handle-data';
 
 const useStyles = makeStyles({
   paper: {

--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -61,7 +61,7 @@ export default function TableWrapper(props) {
   const classes = useStyles();
   const containerMode = constraints.active ? 'containerOverflowHidden' : 'containerOverflowAuto';
   const paginationHidden = constraints.active && 'paginationHidden';
-  const fixedRowsPerPage = selectionsAPI.isModal() || rect.width < 550 || size.qcx >= 100;
+  const fixedRowsPerPage = selectionsAPI.isModal() || rect.width < 550 || size.qcx > 100;
   /* eslint-disable react-hooks/rules-of-hooks */
   const announce = announcer || useMemo(() => announcementFactory(rootElement, translator), [translator.language]);
   const totalPages = Math.ceil(size.qcy / rowsPerPage);

--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -14,7 +14,7 @@ import { handleTableWrapperKeyDown } from '../utils/handle-key-press';
 import { updateFocus, handleResetFocus, handleFocusoutEvent } from '../utils/handle-accessibility';
 import { handleScroll, handleNavigateTop } from '../utils/handle-scroll';
 import announcementFactory from '../utils/announcement-factory';
-import { ROWS_PER_PAGE_OPTIONS } from '../../handle-data';
+// import { ROWS_PER_PAGE_OPTIONS } from '../../handle-data';
 
 const useStyles = makeStyles({
   paper: {
@@ -53,7 +53,7 @@ export default function TableWrapper(props) {
     announcer, // this is only for testing purposes
   } = props;
   const { size, rows, columns } = tableData;
-  const { page, rowsPerPage } = pageInfo;
+  const { page, rowsPerPage, rowsPerPageOptions } = pageInfo;
   const [focusedCellCoord, setFocusedCellCoord] = useState([0, 0]);
   const shouldRefocus = useRef(false);
   const tableSectionRef = useRef();
@@ -61,7 +61,7 @@ export default function TableWrapper(props) {
   const classes = useStyles();
   const containerMode = constraints.active ? 'containerOverflowHidden' : 'containerOverflowAuto';
   const paginationHidden = constraints.active && 'paginationHidden';
-  const paginationFixedRpp = selectionsAPI.isModal() || rect.width < 550 || size.qcx >= 100;
+  const fixedRowsPerPage = selectionsAPI.isModal() || rect.width < 550 || size.qcx >= 100;
   /* eslint-disable react-hooks/rules-of-hooks */
   const announce = announcer || useMemo(() => announcementFactory(rootElement, translator), [translator.language]);
   const totalPages = Math.ceil(size.qcy / rowsPerPage);
@@ -166,7 +166,7 @@ export default function TableWrapper(props) {
       <Paper className={classes.tablePaginationSection}>
         <TablePagination
           className={classes[paginationHidden]}
-          rowsPerPageOptions={paginationFixedRpp ? [rowsPerPage] : ROWS_PER_PAGE_OPTIONS}
+          rowsPerPageOptions={fixedRowsPerPage ? [rowsPerPage] : rowsPerPageOptions}
           component="div"
           count={size.qcy}
           rowsPerPage={rowsPerPage}

--- a/src/table/components/__tests__/TableBodyWrapper.spec.jsx
+++ b/src/table/components/__tests__/TableBodyWrapper.spec.jsx
@@ -14,7 +14,7 @@ import * as handleKeyPress from '../../utils/handle-key-press';
 import * as handleAccessibility from '../../utils/handle-accessibility';
 
 describe('<TableBodyWrapper />', async () => {
-  const model = { getHyperCubeData: async () => generateDataPages(2, 2) };
+  const model = { getHyperCubeData: async () => generateDataPages(2, 2, 2) };
 
   let tableData;
   let constraints;
@@ -26,7 +26,7 @@ describe('<TableBodyWrapper />', async () => {
   beforeEach(async () => {
     sinon.stub(selectionsUtils, 'addSelectionListeners').returns(sinon.spy());
 
-    tableData = await manageData(model, generateLayout(1, 1), { top: 0, height: 100 });
+    tableData = await manageData(model, generateLayout(1, 1, 2), { top: 0, height: 100 });
     constraints = {};
     selectionsAPI = {
       isModal: () => true,


### PR DESCRIPTION
- When there is more than 100 columns you can't change the rows per page manually
- Set height to the smallest possible value. On the last page we always fetched with `qHeight: rowsPerPage` even though there was usually fewer rows
- When there are > 10k cells, set rows per page to a lower options, e.g. 150 cols, 100 rows -> 150 cols, 25 rows. If the lowest option is too high (10 currently, meaning > 1000 columns...) It is set to 10k / columns.

I have tested with > 100 columns, but not > 1000.