### PR TITLE
fix: remove hidden column from columnOrder

### DIFF
--- a/src/__test__/generate-test-data.js
+++ b/src/__test__/generate-test-data.js
@@ -36,7 +36,6 @@ export function generateLayout(nDims, nMeas, nRows, qColumnOrder = []) {
       qDimensionInfo,
       qMeasureInfo,
       qColumnOrder,
-      qEffectiveInterColumnSortOrder: qColumnOrder, // little hack, assuming the column order is the same as the sort order
       qSize: { qcx: nDims + nMeas, qcy: nRows },
     },
   };

--- a/src/__test__/handle-data.spec.js
+++ b/src/__test__/handle-data.spec.js
@@ -21,6 +21,7 @@ describe('handle-data', () => {
       align: isDim ? 'left' : 'right',
       stylingInfo: [],
       sortDirection: 'asc',
+      dataColIdx: colIx,
     });
 
     it('should return column info for dimension', () => {

--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -30,22 +30,9 @@ export function getColumnInfo(qHyperCube, colIndex) {
       align: !info.textAlign || info.textAlign.auto ? (isDim ? 'left' : 'right') : info.textAlign.align,
       stylingInfo: info.qAttrExprInfo.map((expr) => expr.id),
       sortDirection: directionMap[info.qSortIndicator],
+      dataColIdx: colIndex,
     }
   );
-}
-
-export function getColumns(qHyperCube) {
-  const columns = [];
-  const columnOrder = [];
-  const columnOrderUnfiltered = getColumnOrder(qHyperCube);
-  columnOrderUnfiltered.forEach((colIndex) => {
-    const column = getColumnInfo(qHyperCube, colIndex);
-    if (column) {
-      columns.push(column);
-      columnOrder.push(colIndex);
-    }
-  });
-  return { columnOrder, columns };
 }
 
 export default async function manageData(model, layout, pageInfo, setPageInfo) {
@@ -68,8 +55,9 @@ export default async function manageData(model, layout, pageInfo, setPageInfo) {
     return null;
   }
 
-  const { columns, columnOrder } = getColumns(qHyperCube);
-
+  const columnOrder = getColumnOrder(qHyperCube);
+  // using filter to remove hidden columns (represented with false)
+  const columns = columnOrder.map((colIndex) => getColumnInfo(qHyperCube, colIndex)).filter(Boolean);
   const dataPages = await model.getHyperCubeData('/qHyperCubeDef', [
     { qTop: top, qLeft: 0, qHeight: height, qWidth: width },
   ]);
@@ -88,5 +76,5 @@ export default async function manageData(model, layout, pageInfo, setPageInfo) {
     return row;
   });
 
-  return { size, rows, columns, columnOrder };
+  return { size, rows, columns };
 }

--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -11,8 +11,8 @@ export function getHighestPossibleRpp(width, rowsPerPageOptions) {
 }
 
 export function getColumnOrder({ qColumnOrder, qDimensionInfo, qMeasureInfo }) {
-  if (qColumnOrder?.length === qDimensionInfo.length + qMeasureInfo.length) return qColumnOrder;
-  return [...Array(qDimensionInfo.length + qMeasureInfo.length).keys()];
+  const columnsLength = qDimensionInfo.length + qMeasureInfo.length;
+  return qColumnOrder?.length === columnsLength ? qColumnOrder : [...Array(columnsLength).keys()];
 }
 
 export function getColumnInfo(qHyperCube, colIndex) {
@@ -36,12 +36,13 @@ export function getColumnInfo(qHyperCube, colIndex) {
 
 export function getColumns(qHyperCube) {
   const columns = [];
-  const columnOrder = getColumnOrder(qHyperCube);
-  columnOrder.forEach((colIndex, idx, self) => {
+  const columnOrder = [];
+  const columnOrderUnfiltered = getColumnOrder(qHyperCube);
+  columnOrderUnfiltered.forEach((colIndex) => {
     const column = getColumnInfo(qHyperCube, colIndex);
     if (column) {
       columns.push(column);
-      self.splice(idx, 1);
+      columnOrder.push(colIndex);
     }
   });
   return { columnOrder, columns };

--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -34,9 +34,23 @@ export function getColumnInfo(qHyperCube, colIndex) {
   );
 }
 
+export function getColumns(qHyperCube) {
+  const columns = [];
+  const columnOrder = getColumnOrder(qHyperCube);
+  columnOrder.forEach((colIndex, idx, self) => {
+    const column = getColumnInfo(qHyperCube, colIndex);
+    if (column) {
+      columns.push(column);
+      self.splice(idx, 1);
+    }
+  });
+  return { columnOrder, columns };
+}
+
 export default async function manageData(model, layout, pageInfo, setPageInfo) {
   const { page, rowsPerPage, rowsPerPageOptions } = pageInfo;
-  const size = layout.qHyperCube.qSize;
+  const { qHyperCube } = layout;
+  const size = qHyperCube.qSize;
   const top = page * rowsPerPage;
   const width = size.qcx;
   const totalHeight = size.qcy;
@@ -53,9 +67,8 @@ export default async function manageData(model, layout, pageInfo, setPageInfo) {
     return null;
   }
 
-  const columnOrder = getColumnOrder(layout.qHyperCube);
-  // using filter to remove hidden columns (represented with false)
-  const columns = columnOrder.map((colIndex) => getColumnInfo(layout.qHyperCube, colIndex)).filter(Boolean);
+  const { columns, columnOrder } = getColumns(qHyperCube);
+
   const dataPages = await model.getHyperCubeData('/qHyperCubeDef', [
     { qTop: top, qLeft: 0, qHeight: height, qWidth: width },
   ]);

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export default function supernova(env) {
       useEffect(() => {
         if (layout && tableData) {
           registerLocale(translator);
-          const changeSortOrder = sortingFactory(model, tableData.columnOrder);
+          const changeSortOrder = sortingFactory(model);
           render(rootElement, {
             rootElement,
             layout,

--- a/src/sorting-factory.js
+++ b/src/sorting-factory.js
@@ -1,7 +1,7 @@
 export default function sortingFactory(model, columnOrder) {
   return (layout, isDim, columnIndex) => {
     const sortIdx = columnOrder[columnIndex];
-    const sortOrder = [].concat(layout.qHyperCube.qEffectiveInterColumnSortOrder);
+    const sortOrder = [...layout.qHyperCube.qEffectiveInterColumnSortOrder];
     const topSortIdx = sortOrder[0];
 
     if (sortIdx !== topSortIdx) {

--- a/src/sorting-factory.js
+++ b/src/sorting-factory.js
@@ -1,12 +1,14 @@
-export default function sortingFactory(model, columnOrder) {
-  return (layout, isDim, columnIndex) => {
-    const sortIdx = columnOrder[columnIndex];
-    const sortOrder = [...layout.qHyperCube.qEffectiveInterColumnSortOrder];
+export default function sortingFactory(model) {
+  return async (layout, column) => {
+    const { isDim, dataColIdx } = column;
+    // The sort order from the properties is needed since it contains hidden columns
+    const properties = await model.getEffectiveProperties();
+    const sortOrder = properties.qHyperCubeDef.qInterColumnSortOrder;
     const topSortIdx = sortOrder[0];
 
-    if (sortIdx !== topSortIdx) {
-      sortOrder.splice(sortOrder.indexOf(sortIdx), 1);
-      sortOrder.unshift(sortIdx);
+    if (dataColIdx !== topSortIdx) {
+      sortOrder.splice(sortOrder.indexOf(dataColIdx), 1);
+      sortOrder.unshift(dataColIdx);
     }
 
     const patches = [
@@ -18,9 +20,9 @@ export default function sortingFactory(model, columnOrder) {
     ];
 
     // reverse
-    if (sortIdx === topSortIdx) {
+    if (dataColIdx === topSortIdx) {
       const { qDimensionInfo, qMeasureInfo } = layout.qHyperCube;
-      const idx = isDim ? sortIdx : sortIdx - qDimensionInfo.length;
+      const idx = isDim ? dataColIdx : dataColIdx - qDimensionInfo.length;
       const { qReverseSort } = isDim ? qDimensionInfo[idx] : qMeasureInfo[idx];
       const qPath = `/qHyperCubeDef/${isDim ? 'qDimensions' : 'qMeasures'}/${idx}/qDef/qReverseSort`;
 
@@ -31,6 +33,7 @@ export default function sortingFactory(model, columnOrder) {
       });
     }
 
+    console.log(patches);
     model.applyPatches(patches, true);
   };
 }

--- a/src/sorting-factory.js
+++ b/src/sorting-factory.js
@@ -33,7 +33,6 @@ export default function sortingFactory(model) {
       });
     }
 
-    console.log(patches);
     model.applyPatches(patches, true);
   };
 }

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -54,8 +54,7 @@ function TableHeadWrapper({
       <TableRow className="sn-table-row">
         {tableData.columns.map((column, columnIndex) => {
           const tabIndex = columnIndex === 0 && !keyboard.enabled ? 0 : -1;
-          const isCurrentColumnActive =
-            layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === tableData.columnOrder[columnIndex];
+          const isCurrentColumnActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.dataColIdx;
           const isFocusInHead = focusedCellCoord[0] === 0;
 
           return (
@@ -71,17 +70,15 @@ function TableHeadWrapper({
                   e,
                   rootElement,
                   [0, columnIndex],
+                  column,
                   changeSortOrder,
                   layout,
-                  column.isDim,
                   !constraints.active,
                   setFocusedCellCoord
                 )
               }
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
-              onClick={() =>
-                !selectionsAPI.isModal() && !constraints.active && changeSortOrder(layout, column.isDim, columnIndex)
-              }
+              onClick={() => !selectionsAPI.isModal() && !constraints.active && changeSortOrder(layout, column)}
             >
               <TableSortLabel
                 className={classes.sortLabel}

--- a/src/table/components/__tests__/TableHeadWrapper.spec.jsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.jsx
@@ -21,10 +21,9 @@ describe('<TableHeadWrapper />', () => {
   beforeEach(() => {
     tableData = {
       columns: [
-        { id: 1, align: 'left', label: 'someDim', sortDirection: 'asc', isDim: true },
-        { id: 2, align: 'right', label: 'someMsr', sortDirection: 'desc', isDim: false },
+        { id: 1, align: 'left', label: 'someDim', sortDirection: 'asc', isDim: true, dataColIdx: 0 },
+        { id: 2, align: 'right', label: 'someMsr', sortDirection: 'desc', isDim: false, dataColIdx: 1 },
       ],
-      columnOrder: [0, 1],
     };
     theme = {
       getColorPickerColor: () => {},
@@ -87,7 +86,7 @@ describe('<TableHeadWrapper />', () => {
     );
     fireEvent.click(queryByText(tableData.columns[0].label));
 
-    expect(changeSortOrder).to.have.been.calledWith(layout, true, 0);
+    expect(changeSortOrder).to.have.been.calledWith(layout, tableData.columns[0]);
   });
 
   it('should not call changeSortOrder when clicking a header cell in edit mode', () => {

--- a/src/table/utils/__tests__/handle-key-press.spec.js
+++ b/src/table/utils/__tests__/handle-key-press.spec.js
@@ -556,17 +556,18 @@ describe('handle-key-press', () => {
   describe('headHandleKeyPress', () => {
     let rowIndex;
     let colIndex;
+    let column;
     let evt = {};
     let rootElement = {};
     let changeSortOrder;
     let layout;
-    let isDim;
     let isAnalysisMode;
     let setFocusedCellCoord;
 
     beforeEach(() => {
       rowIndex = 0;
       colIndex = 0;
+      column = {};
       evt = {
         key: 'ArrowDown',
         stopPropagation: sinon.spy(),
@@ -585,7 +586,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press arrow down key on head cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell', () => {
-      headHandleKeyPress(evt, rootElement, [rowIndex, colIndex], null, null, null, false, setFocusedCellCoord);
+      headHandleKeyPress(evt, rootElement, [rowIndex, colIndex], column, null, null, null, setFocusedCellCoord);
       expect(evt.preventDefault).to.have.been.calledOnce;
       expect(evt.stopPropagation).to.have.been.calledOnce;
       expect(evt.target.setAttribute).to.have.been.calledOnce;
@@ -598,9 +599,9 @@ describe('handle-key-press', () => {
         evt,
         rootElement,
         [rowIndex, colIndex],
+        column,
         changeSortOrder,
         layout,
-        isDim,
         isAnalysisMode,
         setFocusedCellCoord
       );
@@ -617,9 +618,9 @@ describe('handle-key-press', () => {
         evt,
         rootElement,
         [rowIndex, colIndex],
+        column,
         changeSortOrder,
         layout,
-        isDim,
         isAnalysisMode,
         setFocusedCellCoord
       );
@@ -635,9 +636,9 @@ describe('handle-key-press', () => {
         evt,
         rootElement,
         [rowIndex, colIndex],
+        column,
         changeSortOrder,
         layout,
-        isDim,
         isAnalysisMode,
         setFocusedCellCoord
       );
@@ -654,9 +655,9 @@ describe('handle-key-press', () => {
         evt,
         rootElement,
         [rowIndex, colIndex],
+        column,
         changeSortOrder,
         layout,
-        isDim,
         isAnalysisMode,
         setFocusedCellCoord
       );
@@ -674,9 +675,9 @@ describe('handle-key-press', () => {
         evt,
         rootElement,
         [rowIndex, colIndex],
+        column,
         changeSortOrder,
         layout,
-        isDim,
         isAnalysisMode,
         setFocusedCellCoord
       );

--- a/src/table/utils/handle-key-press.js
+++ b/src/table/utils/handle-key-press.js
@@ -104,9 +104,9 @@ export const headHandleKeyPress = (
   evt,
   rootElement,
   cellCoord,
+  column,
   changeSortOrder,
   layout,
-  isDim,
   isAnalysisMode,
   setFocusedCellCoord
 ) => {
@@ -121,7 +121,7 @@ export const headHandleKeyPress = (
     case ' ':
     case 'Enter': {
       preventDefaultBehavior(evt);
-      isAnalysisMode && changeSortOrder(layout, isDim, cellCoord[1]);
+      isAnalysisMode && changeSortOrder(layout, column);
       break;
     }
     default:


### PR DESCRIPTION
- Remove the dependency of the `columnOrder` array outside `manageData`. Keep the "data" index of the column in the column info instead
- Use the column sort order from the properties instead of layout. `layout.qEffectiveInterColumnSortOrder` doesn't contain hidden column, thus it's ending the wrong thing in the patches. Fetching the properties makes the sorting function asynchronous, but that shouldn't matter 