### PR TITLE
chore: run `yarn spec` on npm version

### DIFF
--- a/.github/CONTRIBUTION.md
+++ b/.github/CONTRIBUTION.md
@@ -23,7 +23,8 @@ Run lint with:
 
 Currently only admins are able to publish.
 
-1. Check out master and make sure it is up to date
-2. Run `npm version minor/patch`
-3. Verify changes in `package.json`, commit and run `git push && git push --tags`
-4. Make sure all checks pass, then Circle automatically publishes to NPM.
+1. Check out master and run `git pull`.
+1. Run `git clean -dfx && yarn` to make sure depenencies are up-to-date.
+1. Run `npm version [major | minor | patch] -m "chore(release): v%s"`. Use semver string based on conventional commits since last release. Ex: `npm version patch -m "chore(release): v%s"`.
+1. Run `git push && git push --tags` to push commit and tag.
+1. Make sure all checks pass, then Circle CI automatically publishes to NPM.

--- a/.github/CONTRIBUTION.md
+++ b/.github/CONTRIBUTION.md
@@ -19,12 +19,25 @@ Run lint with:
 
 `yarn lint`
 
-## Publishing
+## Releasing
 
-Currently only admins are able to publish.
+Currently only admins are able to create a release. A release consists of the following:
+
+- Bumping the package version based on your commits
+- Updating the API specification
+- Creating a new commit with the changed files
+- Creating a tag with the new version
+- Pushing the release commit and tag to master
+
+### Step-By-Step
 
 1. Check out master and run `git pull`.
 1. Run `git clean -dfx && yarn` to make sure depenencies are up-to-date.
 1. Run `npm version [major | minor | patch] -m "chore(release): v%s"`. Use semver string based on conventional commits since last release. Ex: `npm version patch -m "chore(release): v%s"`.
 1. Run `git push && git push --tags` to push commit and tag.
 1. Make sure all checks pass, then Circle CI automatically publishes to NPM.
+
+### On version command failure
+
+1. Run `git tag` to make sure a tag not was created.
+1. If a tag was created, delete it with `git tag -d <tag>`.

--- a/.github/CONTRIBUTION.md
+++ b/.github/CONTRIBUTION.md
@@ -39,5 +39,7 @@ Currently only admins are able to create a release. A release consists of the fo
 
 ### On version command failure
 
-1. Run `git tag` to make sure a tag not was created.
+If you would run `npm version` and it for some reason fails, or you would like to revert the tag you just created:
+
+1. Run `git tag` to check if a new tag was created (or already existed).
 1. If a tag was created, delete it with `git tag -d <tag>`.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "test:rendering": "aw puppet --testExt '*.spec.js' --glob 'test/rendering/**/*.spec.js' --mocha.bail false --mocha.timeout 30000",
     "prepublishOnly": "NODE_ENV=production yarn run build && yarn spec",
     "prepack": "./tools/prepare-sn-pack.js",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "preversion": "yarn build",
+    "version": "yarn spec && git add api-specifications"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
Based on @cbt1's changes for mekko, `yarn spec` is added to run at the same time as version. Build  runs before to make sure the build step wont fail on Circle. Also extending the instructions a bit.