### PR TITLE
fix: warning that react does not recognize prop on a DOM event

### DIFF
--- a/src/table/components/TableBodyWrapper.jsx
+++ b/src/table/components/TableBodyWrapper.jsx
@@ -9,7 +9,7 @@ import { getBodyStyle } from '../utils/styling-utils';
 import { bodyHandleKeyPress } from '../utils/handle-key-press';
 import { handleClickToFocusBody } from '../utils/handle-accessibility';
 
-const CustomTableBody = styled(TableBody)(({ bodyStyle }) => ({
+const CustomTableBody = styled(TableBody)(({ bodystyle: bodyStyle }) => ({
   '& td, th': {
     color: bodyStyle.color,
     fontSize: bodyStyle.fontSize,
@@ -17,7 +17,7 @@ const CustomTableBody = styled(TableBody)(({ bodyStyle }) => ({
   },
 }));
 
-const CustomTableRow = styled(TableRow)(({ hover, bodyStyle }) => ({
+const CustomTableRow = styled(TableRow)(({ hover, bodystyle: bodyStyle }) => ({
   '&&:hover': {
     '& td:not(.selected), th:not(.selected)': {
       backgroundColor: hover && bodyStyle.hoverBackgroundColor,
@@ -42,9 +42,9 @@ function TableBodyWrapper({
   const hoverEffect = layout.components?.[0]?.content?.hoverEffect;
   const bodyStyle = useMemo(() => getBodyStyle(layout, theme), [layout, theme.name()]);
   const selectionsEnabled = !!selectionsAPI && !constraints.active;
-  const getColumnRenderers = tableData.columns.map((c) => getCellRenderer(!!c.stylingInfo.length, selectionsEnabled));
+  const getColumnRenderers = columns.map((column) => getCellRenderer(!!column.stylingInfo.length, selectionsEnabled));
   const [columnRenderers, setColumnRenderers] = useState(() => getColumnRenderers);
-  const [selectionState, selDispatch] = useReducer(reducer, {
+  const [selectionState, selectionDispatch] = useReducer(reducer, {
     api: selectionsAPI,
     rows: [],
     colIdx: -1,
@@ -52,18 +52,18 @@ function TableBodyWrapper({
   });
 
   useEffect(() => {
-    selDispatch({ type: 'set-enabled', payload: { isEnabled: selectionsEnabled } });
+    selectionDispatch({ type: 'set-enabled', payload: { isEnabled: selectionsEnabled } });
     setColumnRenderers(getColumnRenderers);
   }, [selectionsEnabled, columns.length]);
 
   useEffect(() => {
-    addSelectionListeners({ api: selectionsAPI, selDispatch, setShouldRefocus, keyboard, tableWrapperRef });
+    addSelectionListeners({ api: selectionsAPI, selectionDispatch, setShouldRefocus, keyboard, tableWrapperRef });
   }, []);
 
   return (
-    <CustomTableBody bodyStyle={bodyStyle}>
+    <CustomTableBody bodystyle={bodyStyle}>
       {rows.map((row, rowIndex) => (
-        <CustomTableRow hover={hoverEffect} bodyStyle={bodyStyle} tabIndex={-1} key={row.key} className="sn-table-row">
+        <CustomTableRow hover={hoverEffect} bodystyle={bodyStyle} tabIndex={-1} key={row.key} className="sn-table-row">
           {columns.map((column, columnIndex) => {
             const cell = row[column.id];
             const value = cell.qText;
@@ -79,8 +79,8 @@ function TableBodyWrapper({
                   key={column.id}
                   align={column.align}
                   styling={{}}
-                  selectionState={selectionState}
-                  selDispatch={selDispatch}
+                  selectionstate={selectionState}
+                  selectiondispatch={selectionDispatch}
                   tabIndex={-1}
                   announce={announce}
                   onKeyDown={(evt) =>
@@ -90,7 +90,7 @@ function TableBodyWrapper({
                       cellCoord: [rowIndex + 1, columnIndex],
                       selectionState,
                       cell,
-                      selDispatch,
+                      selectionDispatch,
                       isAnalysisMode: selectionsEnabled,
                       setFocusedCellCoord,
                       announce,

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -9,7 +9,7 @@ import { getHeadStyle } from '../utils/styling-utils';
 import { headHandleKeyPress } from '../utils/handle-key-press';
 import { handleClickToFocusHead } from '../utils/handle-accessibility';
 
-const CustomTableCell = styled(TableCell)(({ headCellStyle }) => ({
+const CustomTableCell = styled(TableCell)(({ headcellstyle: headCellStyle }) => ({
   color: headCellStyle.color,
   fontSize: headCellStyle.fontSize,
   padding: headCellStyle.padding,
@@ -58,7 +58,7 @@ function TableHeadWrapper({
 
           return (
             <CustomTableCell
-              headCellStyle={headCellStyle}
+              headcellstyle={headCellStyle}
               key={column.id}
               align={column.align}
               className="sn-table-head-cell sn-table-cell"

--- a/src/table/components/TablePaginationActions.jsx
+++ b/src/table/components/TablePaginationActions.jsx
@@ -22,7 +22,7 @@ const icons = {
   LastPageRTL: FirstPageIcon,
 };
 
-const PaginationActionIconButton = styled(IconButton)(({ disabledCondition }) => ({
+const PaginationActionIconButton = styled(IconButton)(({ disabledcondition: disabledCondition }) => ({
   color: disabledCondition ? 'rgba(0, 0, 0, 0.3)' : 'rgba(0, 0, 0, 0.54)',
   cursor: disabledCondition && 'default',
 }));
@@ -83,7 +83,7 @@ export default function TablePaginationActions({
         aria-label={translator.get(`SNTable.Pagination.${type}`)}
         title={translator.get(`SNTable.Pagination.${type}`)}
         tabIndex={tabIndex}
-        disabledCondition={disabledCondition}
+        disabledcondition={+disabledCondition}
         onKeyDown={onKeyDown}
       >
         <IconComponent />
@@ -130,8 +130,12 @@ export default function TablePaginationActions({
   );
 }
 
+TablePaginationActions.defaultProps = {
+  direction: null,
+};
+
 TablePaginationActions.propTypes = {
-  direction: PropTypes.string.isRequired,
+  direction: PropTypes.string,
   onPageChange: PropTypes.func.isRequired,
   page: PropTypes.number.isRequired,
   lastPageIdx: PropTypes.number.isRequired,

--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -26,12 +26,12 @@ const TablePaginationSection = styled(Paper)({
   justifyContent: 'flex-end',
 });
 
-const TableContainerSection = styled(TableContainer)(({ containerMode }) => ({
+const TableContainerSection = styled(TableContainer)(({ containermode: containerMode }) => ({
   height: containerMode ? '100%' : 'calc(100% - 52px)',
   overflow: containerMode ? 'hidden' : 'auto',
 }));
 
-const CustomTablePagination = styled(TablePagination)(({ paginationHidden }) => ({
+const CustomTablePagination = styled(TablePagination)(({ paginationhidden: paginationHidden }) => ({
   display: paginationHidden && 'none',
 }));
 
@@ -152,7 +152,7 @@ export default function TableWrapper(props) {
       <AnnounceElements />
       <TableContainerSection
         ref={tableContainerRef}
-        containerMode={constraints.active}
+        containermode={constraints.active}
         tabIndex={-1}
         role="application"
         data-testid="table-wrapper"
@@ -171,7 +171,7 @@ export default function TableWrapper(props) {
       </TableContainerSection>
       <TablePaginationSection>
         <CustomTablePagination
-          paginationHidden={constraints.active}
+          paginationhidden={constraints.active}
           rowsPerPageOptions={fixedRowsPerPage ? [rowsPerPage] : rowsPerPageOptions}
           component="div"
           count={size.qcy}
@@ -194,6 +194,7 @@ export default function TableWrapper(props) {
           }
           onRowsPerPageChange={handleChangeRowsPerPage}
           ActionsComponent={() => <div>{null}</div>}
+          onPageChange={() => {}}
         />
         <TablePaginationActions
           direction={direction}
@@ -211,12 +212,13 @@ export default function TableWrapper(props) {
 }
 
 TableWrapper.defaultProps = {
+  direction: null,
   announcer: null,
 };
 
 TableWrapper.propTypes = {
   rootElement: PropTypes.object.isRequired,
-  direction: PropTypes.string.isRequired,
+  direction: PropTypes.string,
   tableData: PropTypes.object.isRequired,
   pageInfo: PropTypes.object.isRequired,
   setPageInfo: PropTypes.func.isRequired,

--- a/src/table/components/__tests__/withSelections.spec.jsx
+++ b/src/table/components/__tests__/withSelections.spec.jsx
@@ -11,7 +11,7 @@ describe('withSelections', () => {
   let HOC;
   let cell;
   let selectionState;
-  let selDispatch;
+  let selectionDispatch;
   let evt;
   let styling;
   let announce;
@@ -29,7 +29,7 @@ describe('withSelections', () => {
       colIdx: -1,
       api: { isModal: () => true },
     };
-    selDispatch = () => {};
+    selectionDispatch = () => {};
     evt = { button: 0 };
     styling = {};
     announce = sinon.spy();
@@ -42,7 +42,7 @@ describe('withSelections', () => {
 
   it('should render a mocked component with the passed value', () => {
     const { queryByText } = render(
-      <HOC selectionState={selectionState} cell={cell} selDispatch={selDispatch} styling={styling} />
+      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
     );
 
     expect(queryByText(cell.value)).to.be.visible;
@@ -50,9 +50,9 @@ describe('withSelections', () => {
   it('should call selectCell on mouseUp', () => {
     const { queryByText } = render(
       <HOC
-        selectionState={selectionState}
+        selectionstate={selectionState}
         cell={cell}
-        selDispatch={selDispatch}
+        selectiondispatch={selectionDispatch}
         styling={styling}
         announce={announce}
       />
@@ -65,7 +65,7 @@ describe('withSelections', () => {
     cell.isDim = false;
 
     const { queryByText } = render(
-      <HOC selectionState={selectionState} cell={cell} selDispatch={selDispatch} styling={styling} />
+      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
     );
     fireEvent.mouseUp(queryByText(cell.value));
 
@@ -75,7 +75,7 @@ describe('withSelections', () => {
     cell.isDim = false;
 
     const { queryByText } = render(
-      <HOC selectionState={selectionState} cell={cell} selDispatch={selDispatch} styling={styling} />
+      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
     );
     fireEvent.mouseUp(queryByText(cell.value), evt);
 
@@ -85,7 +85,7 @@ describe('withSelections', () => {
     evt.button = 2;
 
     const { queryByText } = render(
-      <HOC selectionState={selectionState} cell={cell} selDispatch={selDispatch} styling={styling} />
+      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
     );
     fireEvent.mouseUp(queryByText(cell.value), evt);
 

--- a/src/table/components/withSelections.jsx
+++ b/src/table/components/withSelections.jsx
@@ -5,9 +5,9 @@ import { getSelectionStyle } from '../utils/styling-utils';
 
 export default function withSelections(CellComponent) {
   const HOC = (props) => {
-    const { selectionState, cell, selDispatch, styling, announce } = props;
+    const { selectionstate: selectionState, cell, selectiondispatch: selectionDispatch, styling, announce } = props;
     const handleMouseUp = (evt) =>
-      cell.isDim && evt.button === 0 && selectCell({ selectionState, cell, selDispatch, evt, announce });
+      cell.isDim && evt.button === 0 && selectCell({ selectionState, cell, selectionDispatch, evt, announce });
     const selectionStyling = useMemo(
       () => getSelectionStyle(styling, cell, selectionState),
       [styling, cell, selectionState]
@@ -18,9 +18,9 @@ export default function withSelections(CellComponent) {
 
   HOC.propTypes = {
     styling: PropTypes.object.isRequired,
-    selectionState: PropTypes.object.isRequired,
+    selectionstate: PropTypes.object.isRequired,
     cell: PropTypes.object.isRequired,
-    selDispatch: PropTypes.func.isRequired,
+    selectiondispatch: PropTypes.func.isRequired,
     announce: PropTypes.func.isRequired,
   };
 

--- a/src/table/utils/__tests__/handle-key-press.spec.js
+++ b/src/table/utils/__tests__/handle-key-press.spec.js
@@ -150,7 +150,7 @@ describe('handle-key-press', () => {
     let rootElement = {};
     let selectionState = {};
     let cell = [];
-    let selDispatch;
+    let selectionDispatch;
     let isAnalysisMode;
     let setFocusedCellCoord;
     let isModal;
@@ -186,7 +186,7 @@ describe('handle-key-press', () => {
       };
       cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1, isDim: true };
       keyboard = { enabled: true };
-      selDispatch = sinon.spy();
+      selectionDispatch = sinon.spy();
       isAnalysisMode = true;
       setFocusedCellCoord = sinon.spy();
       announce = sinon.spy();
@@ -223,7 +223,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -233,7 +233,7 @@ describe('handle-key-press', () => {
       expect(evt.stopPropagation).to.have.been.calledOnce;
       expect(selectionState.api.begin).to.have.been.calledOnce;
       expect(selectionState.api.select).to.have.been.calledOnce;
-      expect(selDispatch).to.have.been.calledOnce;
+      expect(selectionDispatch).to.have.been.calledOnce;
       expect(setFocusedCellCoord).to.not.have.been.called;
       expect(announce).to.have.been.calledWith({
         keys: ['SNTable.SelectionLabel.SelectedValue', 'SNTable.SelectionLabel.OneSelectedValue'],
@@ -289,7 +289,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode: false,
         setFocusedCellCoord,
         announce,
@@ -299,7 +299,7 @@ describe('handle-key-press', () => {
       expect(evt.stopPropagation).to.have.been.calledOnce;
       expect(selectionState.api.begin).not.have.been.called;
       expect(selectionState.api.select).not.have.been.called;
-      expect(selDispatch).not.have.been.called;
+      expect(selectionDispatch).not.have.been.called;
       expect(setFocusedCellCoord).to.not.have.been.called;
       expect(announce).not.have.been.called;
     });
@@ -313,7 +313,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode: false,
         setFocusedCellCoord,
         announce,
@@ -323,7 +323,7 @@ describe('handle-key-press', () => {
       expect(evt.stopPropagation).to.have.been.calledOnce;
       expect(selectionState.api.begin).not.have.been.called;
       expect(selectionState.api.select).not.have.been.called;
-      expect(selDispatch).not.have.been.called;
+      expect(selectionDispatch).not.have.been.called;
       expect(setFocusedCellCoord).to.not.have.been.called;
       expect(announce).not.have.been.called;
     });
@@ -337,7 +337,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -359,7 +359,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -382,7 +382,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -405,7 +405,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -428,7 +428,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -452,7 +452,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -474,7 +474,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -496,7 +496,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -518,7 +518,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         isAnalysisMode,
         setFocusedCellCoord,
         announce,
@@ -538,7 +538,7 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         selectionState,
         cell,
-        selDispatch,
+        selectionDispatch,
         setFocusedCellCoord,
         announce,
         keyboard,

--- a/src/table/utils/__tests__/selections-util.spec.js
+++ b/src/table/utils/__tests__/selections-util.spec.js
@@ -12,14 +12,14 @@ describe('selections-utils', () => {
   describe('addSelectionListeners', () => {
     const listenerNames = ['deactivated', 'canceled', 'confirmed', 'cleared'];
     let api;
-    let selDispatch;
+    let selectionDispatch;
     let setShouldRefocus;
     let keyboard;
     let containsActiveElement;
     let tableWrapperRef;
 
     beforeEach(() => {
-      selDispatch = sinon.spy();
+      selectionDispatch = sinon.spy();
       setShouldRefocus = sinon.spy();
       api = {
         on: sinon.spy(),
@@ -40,7 +40,7 @@ describe('selections-utils', () => {
     });
 
     it('should call api.on and api removeListener for all listeners', () => {
-      addSelectionListeners({ api, selDispatch, setShouldRefocus, keyboard, tableWrapperRef })();
+      addSelectionListeners({ api, selectionDispatch, setShouldRefocus, keyboard, tableWrapperRef })();
       listenerNames.forEach((name) => {
         expect(api.on).to.have.been.calledWith(name);
         expect(api.removeListener).to.have.been.calledWith(name);
@@ -49,11 +49,11 @@ describe('selections-utils', () => {
     it('should not call call api.on nor api.removeListener when no api', () => {
       api = undefined;
 
-      const destroyFn = addSelectionListeners({ api, selDispatch, setShouldRefocus, keyboard, tableWrapperRef });
+      const destroyFn = addSelectionListeners({ api, selectionDispatch, setShouldRefocus, keyboard, tableWrapperRef });
       // Not a great check, but this would crash if the this case worked incorrectly
       expect(destroyFn).to.be.a('function');
     });
-    it('should call api.on with the same callback for all listener names, that calls selDispatch', () => {
+    it('should call api.on with the same callback for all listener names, that calls selectionDispatch', () => {
       const callbacks = [];
       api = {
         on: (name, cb) => {
@@ -62,10 +62,10 @@ describe('selections-utils', () => {
         removeListener: () => {},
       };
 
-      addSelectionListeners({ api, selDispatch, setShouldRefocus, keyboard, tableWrapperRef });
+      addSelectionListeners({ api, selectionDispatch, setShouldRefocus, keyboard, tableWrapperRef });
       callbacks.forEach((cb) => {
         cb();
-        expect(selDispatch).to.have.been.calledWith({ type: 'reset' });
+        expect(selectionDispatch).to.have.been.calledWith({ type: 'reset' });
       });
       // only for confirm events
       expect(setShouldRefocus).to.have.been.calledOnce;
@@ -81,7 +81,7 @@ describe('selections-utils', () => {
         removeListener: () => {},
       };
 
-      addSelectionListeners({ api, selDispatch, setShouldRefocus, keyboard, tableWrapperRef });
+      addSelectionListeners({ api, selectionDispatch, setShouldRefocus, keyboard, tableWrapperRef });
       confirmCallback();
       expect(setShouldRefocus).to.not.have.been.called;
       expect(keyboard.blur).to.have.been.calledOnce;
@@ -98,7 +98,7 @@ describe('selections-utils', () => {
         removeListener: () => {},
       };
 
-      addSelectionListeners({ api, selDispatch, setShouldRefocus, keyboard, tableWrapperRef });
+      addSelectionListeners({ api, selectionDispatch, setShouldRefocus, keyboard, tableWrapperRef });
       confirmCallback();
       expect(setShouldRefocus).to.not.have.been.called;
       expect(keyboard.blur).to.not.have.been.called;
@@ -273,7 +273,7 @@ describe('selections-utils', () => {
     const event = {};
     let selectionState;
     let cell;
-    let selDispatch;
+    let selectionDispatch;
     let announce;
 
     beforeEach(() => {
@@ -287,18 +287,18 @@ describe('selections-utils', () => {
         },
       };
       cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1 };
-      selDispatch = sinon.spy();
+      selectionDispatch = sinon.spy();
       announce = sinon.spy();
     });
 
-    it('should call begin, selDispatch and selectHyperCubeCells when no previous selections and also announce it to the user', () => {
+    it('should call begin, selectionDispatch and selectHyperCubeCells when no previous selections and also announce it to the user', () => {
       const params = ['/qHyperCubeDef', [cell.rowIdx], [cell.colIdx]];
       const payload = { colIdx: cell.colIdx, rows: [{ qElemNumber: cell.qElemNumber, rowIdx: cell.rowIdx }] };
 
-      selectCell({ selectionState, cell, selDispatch, evt: event, announce });
+      selectCell({ selectionState, cell, selectionDispatch, evt: event, announce });
       expect(selectionState.api.begin).to.have.been.calledOnce;
       expect(selectionState.api.select).to.have.been.calledWith({ method: 'selectHyperCubeCells', params });
-      expect(selDispatch).to.have.been.calledWith({ type: 'select', payload });
+      expect(selectionDispatch).to.have.been.calledWith({ type: 'select', payload });
       expect(selectionState.api.cancel).to.not.have.been.called;
       expect(announce).to.have.been.calledOnce;
     });
@@ -306,10 +306,10 @@ describe('selections-utils', () => {
       selectionState.rows = [{ qElemNumber: 1, rowIdx: 1 }];
       selectionState.colIdx = 1;
 
-      selectCell({ selectionState, cell, selDispatch, evt: event, announce });
+      selectCell({ selectionState, cell, selectionDispatch, evt: event, announce });
       expect(selectionState.api.begin).to.not.have.been.called;
       expect(selectionState.api.cancel).to.have.been.calledOnce;
-      expect(selDispatch).to.not.have.been.called;
+      expect(selectionDispatch).to.not.have.been.called;
       expect(selectionState.api.select).to.not.have.been.called;
       expect(announce).to.have.been.calledOnce;
     });
@@ -318,10 +318,10 @@ describe('selections-utils', () => {
       selectionState.colIdx = 1;
       cell.colIdx = 2;
 
-      selectCell({ selectionState, cell, selDispatch, evt: event, announce });
+      selectCell({ selectionState, cell, selectionDispatch, evt: event, announce });
       expect(selectionState.api.begin).to.not.have.been.called;
       expect(selectionState.api.cancel).to.not.have.been.called;
-      expect(selDispatch).to.not.have.been.called;
+      expect(selectionDispatch).to.not.have.been.called;
       expect(selectionState.api.select).to.not.have.been.called;
       expect(announce).to.not.have.been.called;
     });

--- a/src/table/utils/handle-key-press.js
+++ b/src/table/utils/handle-key-press.js
@@ -135,7 +135,7 @@ export const bodyHandleKeyPress = ({
   cellCoord,
   selectionState,
   cell,
-  selDispatch,
+  selectionDispatch,
   isAnalysisMode,
   setFocusedCellCoord,
   announce,
@@ -152,7 +152,7 @@ export const bodyHandleKeyPress = ({
     // Space bar: Selects value.
     case ' ': {
       preventDefaultBehavior(evt);
-      cell?.isDim && isAnalysisMode && selectCell({ selectionState, cell, selDispatch, evt, announce });
+      cell?.isDim && isAnalysisMode && selectCell({ selectionState, cell, selectionDispatch, evt, announce });
       break;
     }
     // Enter: Confirms selections.

--- a/src/table/utils/selections-utils.js
+++ b/src/table/utils/selections-utils.js
@@ -1,9 +1,9 @@
-export function addSelectionListeners({ api, selDispatch, setShouldRefocus, keyboard, tableWrapperRef }) {
+export function addSelectionListeners({ api, selectionDispatch, setShouldRefocus, keyboard, tableWrapperRef }) {
   const resetSelections = () => {
-    selDispatch({ type: 'reset' });
+    selectionDispatch({ type: 'reset' });
   };
   const clearSelections = () => {
-    selDispatch({ type: 'clear' });
+    selectionDispatch({ type: 'clear' });
   };
   const resetSelectionsAndSetupRefocus = () => {
     // if there is focus in the chart, set shouldRefocus so that we should either focus or just set the tabstop, after data has reloaded.
@@ -82,7 +82,7 @@ export const getSelectedRows = ({ selectedRows, qElemNumber, rowIdx, evt }) => {
   return selectedRows;
 };
 
-export function selectCell({ selectionState, cell, selDispatch, evt, announce }) {
+export function selectCell({ selectionState, cell, selectionDispatch, evt, announce }) {
   const { api, rows } = selectionState;
   const { rowIdx, colIdx, qElemNumber } = cell;
   let selectedRows = [];
@@ -103,7 +103,7 @@ export function selectCell({ selectionState, cell, selDispatch, evt, announce })
   });
 
   if (selectedRows.length) {
-    selDispatch({ type: 'select', payload: { rows: selectedRows, colIdx } });
+    selectionDispatch({ type: 'select', payload: { rows: selectedRows, colIdx } });
     api.select({
       method: 'selectHyperCubeCells',
       params: ['/qHyperCubeDef', selectedRows.map((r) => r.rowIdx), [colIdx]],


### PR DESCRIPTION
<img width="611" alt="Screenshot 2022-01-27 at 21 16 14" src="https://user-images.githubusercontent.com/4471489/151441906-01b730f1-b965-411c-a368-7115f153065d.png">

1. React does not like capital letters. Updating all props names into lowercase
2. Renaming `selDispatch` to `selectionDispatch`
3. The default value of `direction` is null
4. `tableData.columns` to be `columns`
5. `onPageChange` is required in `TablePagination`

More to read:
https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html#changes-in-detail