### PR TITLE
refactor: unnecessary tablecell props cleanup

### DIFF
--- a/src/table/components/TableBodyWrapper.jsx
+++ b/src/table/components/TableBodyWrapper.jsx
@@ -83,12 +83,11 @@ function TableBodyWrapper({
                   component={columnIndex === 0 ? 'th' : null}
                   cell={cell}
                   column={column}
-                  value={value}
                   key={column.id}
                   align={column.align}
                   styling={{}}
-                  selectionstate={selectionState}
-                  selectiondispatch={selectionDispatch}
+                  selectionState={selectionState}
+                  selectionDispatch={selectionDispatch}
                   tabIndex={-1}
                   announce={announce}
                   onKeyDown={(evt) =>

--- a/src/table/components/__tests__/TableBodyWrapper.spec.jsx
+++ b/src/table/components/__tests__/TableBodyWrapper.spec.jsx
@@ -45,10 +45,9 @@ describe('<TableBodyWrapper />', async () => {
   });
 
   it('should render 2x2 table body and call CellRenderer', () => {
-    // eslint-disable-next-line react/prop-types
-    sinon.stub(getCellRenderer, 'default').returns(({ value }) => {
+    sinon.stub(getCellRenderer, 'default').returns(({ cell }) => {
       cellRendererSpy();
-      return <td>{value}</td>;
+      return <td>{cell.qText}</td>;
     });
 
     const { queryByText } = render(

--- a/src/table/components/__tests__/withSelections.spec.jsx
+++ b/src/table/components/__tests__/withSelections.spec.jsx
@@ -9,6 +9,7 @@ import * as selectionsUtils from '../../utils/selections-utils';
 
 describe('withSelections', () => {
   let HOC;
+  let value;
   let cell;
   let selectionState;
   let selectionDispatch;
@@ -17,12 +18,12 @@ describe('withSelections', () => {
   let announce;
 
   beforeEach(() => {
-    HOC = withSelections.default((props) => <div {...props}>{props.cell.value}</div>);
+    HOC = withSelections.default((props) => <div {...props}>{props.value}</div>);
     sinon.stub(selectionsUtils, 'selectCell').returns(sinon.spy());
 
+    value = '100';
     cell = {
       isDim: true,
-      value: '100',
     };
     selectionState = {
       rows: [],
@@ -42,22 +43,29 @@ describe('withSelections', () => {
 
   it('should render a mocked component with the passed value', () => {
     const { queryByText } = render(
-      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
+      <HOC
+        value={value}
+        selectionState={selectionState}
+        cell={cell}
+        selectionDispatch={selectionDispatch}
+        styling={styling}
+      />
     );
 
-    expect(queryByText(cell.value)).to.be.visible;
+    expect(queryByText(value)).to.be.visible;
   });
   it('should call selectCell on mouseUp', () => {
     const { queryByText } = render(
       <HOC
-        selectionstate={selectionState}
+        value={value}
+        selectionState={selectionState}
         cell={cell}
         selectionDispatch={selectionDispatch}
         styling={styling}
         announce={announce}
       />
     );
-    fireEvent.mouseUp(queryByText(cell.value));
+    fireEvent.mouseUp(queryByText(value));
 
     expect(selectionsUtils.selectCell).to.have.been.calledWithMatch({ selectionState, cell, evt, announce });
   });
@@ -65,9 +73,15 @@ describe('withSelections', () => {
     cell.isDim = false;
 
     const { queryByText } = render(
-      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
+      <HOC
+        value={value}
+        selectionState={selectionState}
+        cell={cell}
+        selectionDispatch={selectionDispatch}
+        styling={styling}
+      />
     );
-    fireEvent.mouseUp(queryByText(cell.value));
+    fireEvent.mouseUp(queryByText(value));
 
     expect(selectionsUtils.selectCell).to.not.have.been.called;
   });
@@ -75,9 +89,15 @@ describe('withSelections', () => {
     cell.isDim = false;
 
     const { queryByText } = render(
-      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
+      <HOC
+        value={value}
+        selectionState={selectionState}
+        cell={cell}
+        selectionDispatch={selectionDispatch}
+        styling={styling}
+      />
     );
-    fireEvent.mouseUp(queryByText(cell.value), evt);
+    fireEvent.mouseUp(queryByText(value), evt);
 
     expect(selectionsUtils.selectCell).to.not.have.been.called;
   });
@@ -85,9 +105,15 @@ describe('withSelections', () => {
     evt.button = 2;
 
     const { queryByText } = render(
-      <HOC selectionstate={selectionState} cell={cell} selectiondispatch={selectionDispatch} styling={styling} />
+      <HOC
+        value={value}
+        selectionState={selectionState}
+        cell={cell}
+        selectionDispatch={selectionDispatch}
+        styling={styling}
+      />
     );
-    fireEvent.mouseUp(queryByText(cell.value), evt);
+    fireEvent.mouseUp(queryByText(value), evt);
 
     expect(selectionsUtils.selectCell).to.not.have.been.called;
   });

--- a/src/table/components/withColumnStyling.jsx
+++ b/src/table/components/withColumnStyling.jsx
@@ -4,13 +4,14 @@ import { getColumnStyle } from '../utils/styling-utils';
 
 export default function withColumnStyling(CellComponent) {
   const HOC = (props) => {
-    const { cell, column, styling } = props;
+    const { cell, column, styling, ...passThroughProps } = props;
+
     const columnStyling = useMemo(
       () => getColumnStyle(styling, cell.qAttrExps, column.stylingInfo),
       [styling, cell.qAttrExps, column.stylingInfo]
     );
 
-    return <CellComponent {...props} styling={columnStyling} />;
+    return <CellComponent {...passThroughProps} cell={cell} styling={columnStyling} />;
   };
 
   HOC.propTypes = {

--- a/src/table/components/withSelections.jsx
+++ b/src/table/components/withSelections.jsx
@@ -9,6 +9,7 @@ export default function withSelections(CellComponent) {
 
     const handleMouseUp = (evt) =>
       cell.isDim && evt.button === 0 && selectCell({ selectionState, cell, selectionDispatch, evt, announce });
+
     const selectionStyling = useMemo(
       () => getSelectionStyle(styling, cell, selectionState),
       [styling, cell, selectionState]

--- a/src/table/components/withSelections.jsx
+++ b/src/table/components/withSelections.jsx
@@ -5,7 +5,8 @@ import { getSelectionStyle } from '../utils/styling-utils';
 
 export default function withSelections(CellComponent) {
   const HOC = (props) => {
-    const { selectionstate: selectionState, cell, selectiondispatch: selectionDispatch, styling, announce } = props;
+    const { selectionState, cell, selectionDispatch, styling, announce, column, ...passThroughProps } = props;
+
     const handleMouseUp = (evt) =>
       cell.isDim && evt.button === 0 && selectCell({ selectionState, cell, selectionDispatch, evt, announce });
     const selectionStyling = useMemo(
@@ -13,15 +14,20 @@ export default function withSelections(CellComponent) {
       [styling, cell, selectionState]
     );
 
-    return <CellComponent {...props} styling={selectionStyling} onMouseUp={handleMouseUp} />;
+    return <CellComponent {...passThroughProps} styling={selectionStyling} onMouseUp={handleMouseUp} />;
+  };
+
+  HOC.defaultProps = {
+    column: null,
   };
 
   HOC.propTypes = {
     styling: PropTypes.object.isRequired,
-    selectionstate: PropTypes.object.isRequired,
+    selectionState: PropTypes.object.isRequired,
     cell: PropTypes.object.isRequired,
-    selectiondispatch: PropTypes.func.isRequired,
+    selectionDispatch: PropTypes.func.isRequired,
     announce: PropTypes.func.isRequired,
+    column: PropTypes.object,
   };
 
   return HOC;

--- a/src/table/components/withStyling.jsx
+++ b/src/table/components/withStyling.jsx
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 
 export default function withStyling(CellComponent) {
   const HOC = (props) => {
-    const { styling } = props;
+    const { styling, ...passThroughProps } = props;
 
-    return <CellComponent {...props} className={`${styling.selectedCellClass} sn-table-cell`} style={styling} />;
+    return (
+      <CellComponent {...passThroughProps} className={`${styling.selectedCellClass} sn-table-cell`} style={styling} />
+    );
   };
 
   HOC.propTypes = {

--- a/src/table/components/withStyling.jsx
+++ b/src/table/components/withStyling.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 export default function withStyling(CellComponent) {
   const HOC = (props) => {
     const { styling } = props;
+
     return <CellComponent {...props} className={`${styling.selectedCellClass} sn-table-cell`} style={styling} />;
   };
 


### PR DESCRIPTION
<img width="230" alt="Screenshot 2022-01-28 at 16 18 54" src="https://user-images.githubusercontent.com/4471489/151572712-4f1ee475-9cc5-416b-b23a-0fc0ca2c8f73.png">

a better way to fix the react warnings about dom attributes

`selectionState`, `selDispatch`, `announce`, `cell`, `column`, and `value` are not needed to be attached in the dom.