### PR TITLE
Feat: allow padding override of cells

### DIFF
--- a/src/table/utils/__tests__/styling-utils.spec.js
+++ b/src/table/utils/__tests__/styling-utils.spec.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import {
   STYLING_DEFAULTS,
   SELECTION_STYLING,

--- a/src/table/utils/__tests__/styling-utils.spec.js
+++ b/src/table/utils/__tests__/styling-utils.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import {
   STYLING_DEFAULTS,
   SELECTION_STYLING,
@@ -99,6 +100,12 @@ describe('styling-utils', () => {
         fontSize: '14px',
         padding: '7px 14px',
       });
+    });
+    it('should return styling with custom padding', () => {
+      styleObj.padding = '4px';
+
+      const resultStyling = getBaseStyling(styleObj, theme);
+      expect(resultStyling.padding).to.eql('4px');
     });
   });
 

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -36,7 +36,7 @@ export const getAutoFontColor = (backgroundColor) =>
 export const getBaseStyling = (styleObj, theme) => {
   let padding = STYLING_DEFAULTS.PADDING;
   if (styleObj.padding) {
-    padding = styleObj.padding;
+    ({ padding } = styleObj);
   } else if (styleObj.fontSize) {
     padding = `${styleObj.fontSize / 2}px ${styleObj.fontSize}px`;
   }

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -33,11 +33,20 @@ export function getColor(color = {}, defaultColor, theme) {
 export const getAutoFontColor = (backgroundColor) =>
   isDarkColor(backgroundColor) ? STYLING_DEFAULTS.WHITE : STYLING_DEFAULTS.FONT_COLOR;
 
-export const getBaseStyling = (styleObj, theme) => ({
-  color: getColor(styleObj.fontColor, STYLING_DEFAULTS.FONT_COLOR, theme),
-  fontSize: styleObj.fontSize || STYLING_DEFAULTS.FONT_SIZE,
-  padding: styleObj.fontSize ? `${styleObj.fontSize / 2}px ${styleObj.fontSize}px` : STYLING_DEFAULTS.PADDING,
-});
+export const getBaseStyling = (styleObj, theme) => {
+  let padding = STYLING_DEFAULTS.PADDING;
+  if (styleObj.padding) {
+    padding = styleObj.padding;
+  } else if (styleObj.fontSize) {
+    padding = `${styleObj.fontSize / 2}px ${styleObj.fontSize}px`;
+  }
+
+  return {
+    color: getColor(styleObj.fontColor, STYLING_DEFAULTS.FONT_COLOR, theme),
+    fontSize: styleObj.fontSize || STYLING_DEFAULTS.FONT_SIZE,
+    padding,
+  };
+};
 
 // Both index === -1 and color === null must be true for the property to be unset
 export const isUnset = (prop) => !prop || JSON.stringify(prop) === JSON.stringify({ index: -1, color: null });

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -43,13 +43,11 @@ export function getColor(color = {}, defaultColor, theme) {
 export const getAutoFontColor = (backgroundColor) =>
   isDarkColor(backgroundColor) ? STYLING_DEFAULTS.WHITE : STYLING_DEFAULTS.FONT_COLOR;
 
-export const getBaseStyling = (styleObj, theme) => {
-  return {
-    color: getColor(styleObj.fontColor, STYLING_DEFAULTS.FONT_COLOR, theme),
-    fontSize: styleObj.fontSize || STYLING_DEFAULTS.FONT_SIZE,
-    padding: getPadding(styleObj, STYLING_DEFAULTS.PADDING),
-  };
-};
+export const getBaseStyling = (styleObj, theme) => ({
+  color: getColor(styleObj.fontColor, STYLING_DEFAULTS.FONT_COLOR, theme),
+  fontSize: styleObj.fontSize || STYLING_DEFAULTS.FONT_SIZE,
+  padding: getPadding(styleObj, STYLING_DEFAULTS.PADDING),
+});
 
 // Both index === -1 and color === null must be true for the property to be unset
 export const isUnset = (prop) => !prop || JSON.stringify(prop) === JSON.stringify({ index: -1, color: null });

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -25,6 +25,16 @@ export const SELECTION_STYLING = {
   },
 };
 
+export function getPadding(styleObj, defaultPadding) {
+  let padding = defaultPadding;
+  if (styleObj.padding) {
+    ({ padding } = styleObj);
+  } else if (styleObj.fontSize) {
+    padding = `${styleObj.fontSize / 2}px ${styleObj.fontSize}px`;
+  }
+  return padding;
+}
+
 export function getColor(color = {}, defaultColor, theme) {
   const resolvedColor = theme.getColorPickerColor(color);
   return !resolvedColor || resolvedColor === 'none' ? defaultColor : resolvedColor;
@@ -34,17 +44,10 @@ export const getAutoFontColor = (backgroundColor) =>
   isDarkColor(backgroundColor) ? STYLING_DEFAULTS.WHITE : STYLING_DEFAULTS.FONT_COLOR;
 
 export const getBaseStyling = (styleObj, theme) => {
-  let padding = STYLING_DEFAULTS.PADDING;
-  if (styleObj.padding) {
-    ({ padding } = styleObj);
-  } else if (styleObj.fontSize) {
-    padding = `${styleObj.fontSize / 2}px ${styleObj.fontSize}px`;
-  }
-
   return {
     color: getColor(styleObj.fontColor, STYLING_DEFAULTS.FONT_COLOR, theme),
     fontSize: styleObj.fontSize || STYLING_DEFAULTS.FONT_SIZE,
-    padding,
+    padding: getPadding(styleObj, STYLING_DEFAULTS.PADDING),
   };
 };
 


### PR DESCRIPTION
Allow developers to provide custom padding for table headers and cells by overriding baseStyling in the same way color and fontSize can be overridden.