### PR TITLE
feat: make the color of sort label be same as the color of header content

### DIFF
--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -37,15 +37,24 @@ function TableHeadWrapper({
   // When the table background color from sense theme is transparent, there is a default background color for the header
   // to avoid seeing the table body through the header
   const backgroundColor = theme.backgroundColor === 'transparent' ? '#FAFAFA' : theme.backgroundColor;
+  const sortLabelColor = theme.isBackgroundDarkColor ? 'rgba(255,255,255,0.9)' : 'rgba(0, 0, 0, 0.54)';
+
   const headStyle = {
     'tr :last-child': {
       borderRight: 0,
     },
     backgroundColor,
   };
+
   const headCellStyle = useMemo(() => getHeadStyle(layout, theme), [layout, theme.name()]);
   headCellStyle.backgroundColor = backgroundColor;
   headCellStyle.borderTop = theme.isBackgroundDarkColor ? '1px solid #F2F2F3' : '1px solid #D9D9D9';
+
+  const tableSortLabelStyle = {
+    '&.Mui-active .MuiTableSortLabel-icon': {
+      color: headCellStyle.color ? headCellStyle.color : sortLabelColor,
+    },
+  };
 
   return (
     <TableHead sx={headStyle}>
@@ -79,7 +88,12 @@ function TableHeadWrapper({
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
               onClick={() => !selectionsAPI.isModal() && !constraints.active && changeSortOrder(layout, column)}
             >
-              <TableSortLabel active={isCurrentColumnActive} direction={column.sortDirection} tabIndex={-1}>
+              <TableSortLabel
+                sx={tableSortLabelStyle}
+                active={isCurrentColumnActive}
+                direction={column.sortDirection}
+                tabIndex={-1}
+              >
                 {column.label}
                 {isFocusInHead && (
                   <VisuallyHidden data-testid={`VHL-for-col-${columnIndex}`}>


### PR DESCRIPTION
<img width="789" alt="Screenshot 2022-02-25 at 17 59 26" src="https://user-images.githubusercontent.com/4471489/155756065-4586094f-2c1a-4ee9-b3e8-9942ddf68332.png">

When you set the color of header content, the color of the sort label should be the same as that.


When there is no header content color setting, the sort label color is kind of white in the dark header background color and black in the light header background color.