### PR TITLE
feat: adjust the sort label color based on the header background color

### DIFF
--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -49,7 +49,7 @@ export default async function manageData(model, layout, pageInfo, setPageInfo) {
     setPageInfo({ ...pageInfo, page: 0 });
     return null;
   }
-  // If the number of cells exceeds 10k then we need to lower the rows per page to the maximum possible value
+  // If the number of cells exceeds 10k then you need to lower the rows per page to the maximum possible value
   if (height * width > MAX_CELLS) {
     setPageInfo({ ...pageInfo, rowsPerPage: getHighestPossibleRpp(width, rowsPerPageOptions), page: 0 });
     return null;

--- a/src/locale/src/index.js
+++ b/src/locale/src/index.js
@@ -7,7 +7,7 @@ export default function registerLocale(translator) {
     const g = translator.get(t);
 
     // if the translated string is different from its id,
-    // we assume the translations already exist for current locale
+    // you assume the translations already exist for current locale
     if (g !== t) {
       return;
     }

--- a/src/table/components/TableBodyWrapper.jsx
+++ b/src/table/components/TableBodyWrapper.jsx
@@ -87,7 +87,7 @@ function TableBodyWrapper({
                   key={column.id}
                   align={column.align}
                   styling={{ color: bodyStyle.color }}
-                  tableBackgroundColor={theme.backgroundColor}
+                  themeBackgroundColor={theme.backgroundColor}
                   selectionState={selectionState}
                   selectionDispatch={selectionDispatch}
                   tabIndex={-1}

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -40,7 +40,15 @@ function TableHeadWrapper({
     },
   };
   const headerStyle = useMemo(() => getHeaderStyle(layout, theme), [layout, theme.name()]);
-
+  // When you set the header font color,
+  // the sort label color should be same.
+  // When there is no header content color setting,
+  // the sort label color is depending on the header background color.
+  const tableSortLabelStyle = {
+    '&.Mui-active .MuiTableSortLabel-icon': {
+      color: headerStyle.color ? headerStyle.color : headerStyle.sortLabelColor,
+    },
+  };
   return (
     <TableHead>
       <TableRow sx={headRowStyle} className="sn-table-row">
@@ -73,7 +81,12 @@ function TableHeadWrapper({
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
               onClick={() => !selectionsAPI.isModal() && !constraints.active && changeSortOrder(layout, column)}
             >
-              <TableSortLabel active={isCurrentColumnActive} direction={column.sortDirection} tabIndex={-1}>
+              <TableSortLabel
+                sx={tableSortLabelStyle}
+                active={isCurrentColumnActive}
+                direction={column.sortDirection}
+                tabIndex={-1}
+              >
                 {column.label}
                 {isFocusInHead && (
                   <VisuallyHidden data-testid={`VHL-for-col-${columnIndex}`}>

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -46,7 +46,7 @@ function TableHeadWrapper({
   // the sort label color is depending on the header background color.
   const tableSortLabelStyle = {
     '&.Mui-active .MuiTableSortLabel-icon': {
-      color: headerStyle.color ? headerStyle.color : headerStyle.sortLabelColor,
+      color: headerStyle.color ?? headerStyle.sortLabelColor,
     },
   };
   return (

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -8,7 +8,6 @@ import TableSortLabel from '@mui/material/TableSortLabel';
 import { getHeadStyle } from '../utils/styling-utils';
 import { headHandleKeyPress } from '../utils/handle-key-press';
 import { handleClickToFocusHead } from '../utils/handle-accessibility';
-import { isDarkColor } from '../utils/color-utils';
 
 const VisuallyHidden = styled('span')({
   border: 0,
@@ -40,14 +39,7 @@ function TableHeadWrapper({
       borderRight: 0,
     },
   };
-
   const headCellStyle = useMemo(() => getHeadStyle(layout, theme), [layout, theme.name()]);
-  const setBackgroundColor = isDarkColor(headCellStyle.color) ? '#FAFAFA' : '#323232';
-  // When the table background color from sense theme is transparent, there is a default background color for the header
-  // to avoid seeing the table body through the header
-  const backgroundColor = theme.backgroundColor === 'transparent' ? setBackgroundColor : theme.backgroundColor;
-  headCellStyle.backgroundColor = backgroundColor;
-  headCellStyle.borderTop = theme.isBackgroundDarkColor ? '1px solid #F2F2F3' : '1px solid #D9D9D9';
 
   return (
     <TableHead sx={headStyle}>

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -40,15 +40,12 @@ function TableHeadWrapper({
     },
   };
   const headerStyle = useMemo(() => getHeaderStyle(layout, theme), [layout, theme.name()]);
-  // When you set the header font color,
-  // the sort label color should be same.
-  // When there is no header content color setting,
-  // the sort label color is depending on the header background color.
   const tableSortLabelStyle = {
     '&.Mui-active .MuiTableSortLabel-icon': {
-      color: headerStyle.color ?? headerStyle.sortLabelColor,
+      color: headerStyle.sortLabelColor,
     },
   };
+
   return (
     <TableHead>
       <TableRow sx={headRowStyle} className="sn-table-row">

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -8,6 +8,7 @@ import TableSortLabel from '@mui/material/TableSortLabel';
 import { getHeadStyle } from '../utils/styling-utils';
 import { headHandleKeyPress } from '../utils/handle-key-press';
 import { handleClickToFocusHead } from '../utils/handle-accessibility';
+import { isDarkColor } from '../utils/color-utils';
 
 const VisuallyHidden = styled('span')({
   border: 0,
@@ -34,16 +35,17 @@ function TableHeadWrapper({
   setFocusedCellCoord,
   keyboard,
 }) {
-  // When the table background color from sense theme is transparent, there is a default background color for the header
-  // to avoid seeing the table body through the header
-  const backgroundColor = theme.backgroundColor === 'transparent' ? '#FAFAFA' : theme.backgroundColor;
   const headStyle = {
     'tr :last-child': {
       borderRight: 0,
     },
-    backgroundColor,
   };
+
   const headCellStyle = useMemo(() => getHeadStyle(layout, theme), [layout, theme.name()]);
+  const setBackgroundColor = isDarkColor(headCellStyle.color) ? '#FAFAFA' : '#323232';
+  // When the table background color from sense theme is transparent, there is a default background color for the header
+  // to avoid seeing the table body through the header
+  const backgroundColor = theme.backgroundColor === 'transparent' ? setBackgroundColor : theme.backgroundColor;
   headCellStyle.backgroundColor = backgroundColor;
   headCellStyle.borderTop = theme.isBackgroundDarkColor ? '1px solid #F2F2F3' : '1px solid #D9D9D9';
 

--- a/src/table/components/__tests__/TableHeadWrapper.spec.jsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.jsx
@@ -176,7 +176,7 @@ describe('<TableHeadWrapper />', () => {
     expect(handleAccessibility.handleClickToFocusHead).to.have.been.calledOnce;
   });
 
-  it('should change `aria-pressed` and `aria-sort` when we sort by second column', () => {
+  it('should change `aria-pressed` and `aria-sort` when you sort by second column', () => {
     tableData = {
       columns: [
         { ...tableData.columns[0], sortDirection: 'desc' },
@@ -237,7 +237,7 @@ describe('<TableHeadWrapper />', () => {
     expect(tableColumnSortlabel).to.have.text('SNTable.SortLabel.PressSpaceToSort');
   });
 
-  it('should not render visually hidden text while we are out of table header', () => {
+  it('should not render visually hidden text while you are out of table header', () => {
     focusedCellCoord = [1, 1];
     const { queryByTestId } = render(
       <TableHeadWrapper

--- a/src/table/components/withSelections.jsx
+++ b/src/table/components/withSelections.jsx
@@ -10,18 +10,17 @@ export default function withSelections(CellComponent) {
       cell,
       selectionDispatch,
       styling,
-      tableBackgroundColor,
+      themeBackgroundColor,
       announce,
       column,
       ...passThroughProps
     } = props;
-
     const handleMouseUp = (evt) =>
       cell.isDim && evt.button === 0 && selectCell({ selectionState, cell, selectionDispatch, evt, announce });
 
     const selectionStyling = useMemo(
-      () => getSelectionStyle(styling, cell, selectionState, tableBackgroundColor),
-      [styling, cell, selectionState, tableBackgroundColor]
+      () => getSelectionStyle(styling, cell, selectionState, themeBackgroundColor),
+      [styling, cell, selectionState, themeBackgroundColor]
     );
 
     return <CellComponent {...passThroughProps} styling={selectionStyling} onMouseUp={handleMouseUp} />;
@@ -29,12 +28,12 @@ export default function withSelections(CellComponent) {
 
   HOC.defaultProps = {
     column: null,
-    tableBackgroundColor: null,
+    themeBackgroundColor: null,
   };
 
   HOC.propTypes = {
     styling: PropTypes.object.isRequired,
-    tableBackgroundColor: PropTypes.string,
+    themeBackgroundColor: PropTypes.string,
     selectionState: PropTypes.object.isRequired,
     cell: PropTypes.object.isRequired,
     selectionDispatch: PropTypes.func.isRequired,

--- a/src/table/utils/__tests__/handle-key-press.spec.js
+++ b/src/table/utils/__tests__/handle-key-press.spec.js
@@ -80,7 +80,7 @@ describe('handle-key-press', () => {
       expect(nextCol).to.eql(0);
     });
 
-    it('should move to the next row when we reach to the end of the current row', () => {
+    it('should move to the next row when you reach to the end of the current row', () => {
       evt.key = 'ArrowRight';
       rowAndColumnCount.rowCount = 3;
       rowAndColumnCount.columnCount = 3;
@@ -91,7 +91,7 @@ describe('handle-key-press', () => {
       expect(nextCol).to.eql(0);
     });
 
-    it('should move to the prev row when we reach to the beganing of the current row', () => {
+    it('should move to the prev row when you reach to the beganing of the current row', () => {
       evt.key = 'ArrowLeft';
       rowAndColumnCount.rowCount = 3;
       rowAndColumnCount.columnCount = 3;
@@ -102,7 +102,7 @@ describe('handle-key-press', () => {
       expect(nextCol).to.eql(2);
     });
 
-    it('should stay at the first row and first col of table when we reached to the beganing of the table', () => {
+    it('should stay at the first row and first col of table when you reached to the beganing of the table', () => {
       evt.key = 'ArrowLeft';
       rowAndColumnCount.rowCount = 2;
       rowAndColumnCount.columnCount = 2;
@@ -113,7 +113,7 @@ describe('handle-key-press', () => {
       expect(nextCol).to.eql(0);
     });
 
-    it('should stay at the end row and end col of table when we reached to the end of the table', () => {
+    it('should stay at the end row and end col of table when you reached to the end of the table', () => {
       evt.key = 'ArrowRight';
       rowAndColumnCount.rowCount = 2;
       rowAndColumnCount.columnCount = 2;
@@ -781,7 +781,7 @@ describe('handle-key-press', () => {
       expect(keyboard.blur).to.have.been.calledOnceWith(true);
     });
 
-    it('should ignore keyboard.blur while we are focusing on the pagination and pressing Esc key', () => {
+    it('should ignore keyboard.blur while you are focusing on the pagination and pressing Esc key', () => {
       evt = {
         key: 'Escape',
         stopPropagation: sinon.spy(),

--- a/src/table/utils/__tests__/selections-util.spec.js
+++ b/src/table/utils/__tests__/selections-util.spec.js
@@ -219,7 +219,7 @@ describe('selections-utils', () => {
       });
     });
 
-    it('should announce deselected value and exited selection mode when we have deselected the last value', () => {
+    it('should announce deselected value and exited selection mode when you have deselected the last value', () => {
       rowsLength = 0;
       isAddition = false;
       handleAnnounceSelectionStatus({ announce, rowsLength, isAddition });

--- a/src/table/utils/__tests__/styling-utils.spec.js
+++ b/src/table/utils/__tests__/styling-utils.spec.js
@@ -279,7 +279,7 @@ describe('styling-utils', () => {
 
     it('should return styling with both new fontColor and backgroundColor when selected', () => {
       const columnStyle = getColumnStyle(styling, qAttrExps, stylingInfo);
-      expect(columnStyle.background).to.equal('#dddddd');
+      expect(columnStyle.backgroundColor).to.equal('#dddddd');
       expect(columnStyle.color).to.equal('#111111');
     });
     it('should return styling with new fontColor', () => {
@@ -287,7 +287,7 @@ describe('styling-utils', () => {
       stylingInfo = [stylingInfo[1]];
 
       const columnStyle = getColumnStyle(styling, qAttrExps, stylingInfo);
-      expect(columnStyle.background).to.equal(undefined);
+      expect(columnStyle.backgroundColor).to.equal(undefined);
       expect(columnStyle.color).to.equal('#111111');
     });
     it('should return styling with backgroundColor', () => {
@@ -295,7 +295,7 @@ describe('styling-utils', () => {
       stylingInfo = [stylingInfo[0]];
 
       const columnStyle = getColumnStyle(styling, qAttrExps, stylingInfo);
-      expect(columnStyle.background).to.equal('#dddddd');
+      expect(columnStyle.backgroundColor).to.equal('#dddddd');
       expect(columnStyle.color).to.equal(STYLING_DEFAULTS.FONT_COLOR);
     });
     it('should return styling unchanged', () => {
@@ -303,7 +303,7 @@ describe('styling-utils', () => {
       stylingInfo = [];
 
       const columnStyle = getColumnStyle(styling, qAttrExps, stylingInfo);
-      expect(columnStyle.background).to.equal(undefined);
+      expect(columnStyle.backgroundColor).to.equal(undefined);
       expect(columnStyle.color).to.equal('someFontColor');
     });
   });
@@ -312,42 +312,42 @@ describe('styling-utils', () => {
     let selectionState;
     let cell;
     let background;
-    let tableBackgroundColor;
+    let themeBackgroundColor;
 
     beforeEach(() => {
       background = undefined;
       selectionState = { colIdx: 1, rows: [{ qElemNumber: 1, rowIdx: 1 }], api: { isModal: () => true } };
       cell = { qElemNumber: 1, colIdx: 1 };
-      tableBackgroundColor = '#123456';
+      themeBackgroundColor = '#123456';
     });
 
     it('should return selected when selected styling', () => {
-      const selectionClass = getSelectionColors(cell, selectionState, background, tableBackgroundColor);
+      const selectionClass = getSelectionColors(cell, selectionState, background, themeBackgroundColor);
       expect(selectionClass).to.equal(SELECTION_STYLING.SELECTED);
     });
     it('should return excluded styling when other column', () => {
       cell.colIdx = 2;
 
-      const selectionClass = getSelectionColors(cell, selectionState, background, tableBackgroundColor);
+      const selectionClass = getSelectionColors(cell, selectionState, background, themeBackgroundColor);
       expect(selectionClass).to.eql({ background: `${STYLING_DEFAULTS.EXCLUDED_BACKGROUND}, #123456` });
     });
     it('should return excluded styling with columns background when other column and background color exists', () => {
       cell.colIdx = 2;
       background = 'someColor';
 
-      const selectionClass = getSelectionColors(cell, selectionState, background, tableBackgroundColor);
+      const selectionClass = getSelectionColors(cell, selectionState, background, themeBackgroundColor);
       expect(selectionClass).to.eql({ background: `${STYLING_DEFAULTS.EXCLUDED_BACKGROUND}, someColor` });
     });
     it('should return possible styling when active and available to select', () => {
       cell.qElemNumber = 2;
 
-      const selectionClass = getSelectionColors(cell, selectionState, background, tableBackgroundColor);
+      const selectionClass = getSelectionColors(cell, selectionState, background, themeBackgroundColor);
       expect(selectionClass).to.equal(SELECTION_STYLING.POSSIBLE);
     });
     it('should return empty object when no active selections', () => {
       selectionState = { rows: [], api: { isModal: () => false } };
 
-      const selectionClass = getSelectionColors(cell, selectionState, background, tableBackgroundColor);
+      const selectionClass = getSelectionColors(cell, selectionState, background, themeBackgroundColor);
       expect(selectionClass).to.eql({});
     });
   });

--- a/src/table/utils/__tests__/styling-utils.spec.js
+++ b/src/table/utils/__tests__/styling-utils.spec.js
@@ -29,6 +29,7 @@ describe('styling-utils', () => {
       }
     },
     getStyle: () => {},
+    backgroundColor: '#323232',
   };
 
   describe('getColor', () => {
@@ -133,16 +134,18 @@ describe('styling-utils', () => {
       };
     });
 
-    it('should return empty object as the padding and font size are from sprout theme', () => {
+    it('should return empty object except backgroundColor and border as the padding and font size are from sprout theme', () => {
       layout = {};
 
       const resultStyling = getHeadStyle(layout, theme);
       expect(resultStyling).to.eql({
+        backgroundColor: '#323232',
         borderBottom: '1px solid #D9D9D9',
         borderRight: '1px solid #D9D9D9',
+        borderTop: '1px solid #D9D9D9',
       });
     });
-    it('should return header style with only fontColor', () => {
+    it('should return header style with only fontColor except backgroundColor and border', () => {
       layout = {
         components: [
           {
@@ -156,18 +159,22 @@ describe('styling-utils', () => {
       const resultStyling = getHeadStyle(layout, theme);
       expect(resultStyling).to.eql({
         color: '#404040',
+        backgroundColor: '#323232',
         borderBottom: '1px solid #D9D9D9',
         borderRight: '1px solid #D9D9D9',
+        borderTop: '1px solid #D9D9D9',
       });
     });
-    it('should return header style from layout', () => {
+    it('should return all header style from layout', () => {
       const resultStyling = getHeadStyle(layout, theme);
       expect(resultStyling).to.eql({
         color: '#404040',
         fontSize: 44,
         padding: '22px 44px',
+        backgroundColor: '#323232',
         borderBottom: '1px solid #D9D9D9',
         borderRight: '1px solid #D9D9D9',
+        borderTop: '1px solid #D9D9D9',
       });
     });
   });

--- a/src/table/utils/__tests__/styling-utils.spec.js
+++ b/src/table/utils/__tests__/styling-utils.spec.js
@@ -143,6 +143,7 @@ describe('styling-utils', () => {
         borderBottom: '1px solid #D9D9D9',
         borderRight: '1px solid #D9D9D9',
         borderTop: '1px solid #D9D9D9',
+        sortLabelColor: 'rgba(255,255,255,0.9)',
       });
     });
     it('should return header style with only fontColor except backgroundColor and border', () => {
@@ -163,6 +164,7 @@ describe('styling-utils', () => {
         borderBottom: '1px solid #D9D9D9',
         borderRight: '1px solid #D9D9D9',
         borderTop: '1px solid #D9D9D9',
+        sortLabelColor: 'rgba(255,255,255,0.9)',
       });
     });
     it('should return all header style from layout', () => {
@@ -175,6 +177,7 @@ describe('styling-utils', () => {
         borderBottom: '1px solid #D9D9D9',
         borderRight: '1px solid #D9D9D9',
         borderTop: '1px solid #D9D9D9',
+        sortLabelColor: 'rgba(255,255,255,0.9)',
       });
     });
   });

--- a/src/table/utils/handle-accessibility.js
+++ b/src/table/utils/handle-accessibility.js
@@ -52,7 +52,7 @@ export const handleResetFocus = ({
   announce,
 }) => {
   updateFocus({ focusType: 'removeTab', providedCell: findCellWithTabStop(rootElement) });
-  // If we have selections ongoing, we want to stay on the same column
+  // If you have selections ongoing, you want to stay on the same column
   const nextCell = hasSelections ? [1, focusedCellCoord[1]] : [0, 0];
   if (shouldAddTabstop) {
     // Only run this if updates come from inside table

--- a/src/table/utils/selections-utils.js
+++ b/src/table/utils/selections-utils.js
@@ -6,8 +6,8 @@ export function addSelectionListeners({ api, selectionDispatch, setShouldRefocus
     selectionDispatch({ type: 'clear' });
   };
   const resetSelectionsAndSetupRefocus = () => {
-    // if there is focus in the chart, set shouldRefocus so that we should either focus or just set the tabstop, after data has reloaded.
-    // if there is no focus on the chart, make sure we blur and focus the entire chart
+    // if there is focus in the chart, set shouldRefocus so that you should either focus or just set the tabstop, after data has reloaded.
+    // if there is no focus on the chart, make sure you blur and focus the entire chart
     if (tableWrapperRef.current?.contains(document.activeElement)) {
       setShouldRefocus();
     } else if (keyboard.enabled) {

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -68,6 +68,9 @@ export function getHeaderStyle(layout, theme) {
   const headerBackgroundColor = isDarkColor(headerStyle.color) ? '#FAFAFA' : '#323232';
   headerStyle.backgroundColor = theme.backgroundColor === 'transparent' ? headerBackgroundColor : theme.backgroundColor;
   headerStyle.borderTop = theme.isBackgroundDarkColor ? '1px solid #F2F2F3' : '1px solid #D9D9D9';
+  headerStyle.sortLabelColor = isDarkColor(headerStyle.backgroundColor)
+    ? 'rgba(255,255,255,0.9)'
+    : 'rgba(0, 0, 0, 0.54)';
   return headerStyle;
 }
 

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -60,8 +60,14 @@ export const isUnset = (prop) => !prop || JSON.stringify(prop) === JSON.stringif
 
 export function getHeadStyle(layout, theme) {
   const header = layout.components?.[0]?.header;
-
-  return getBaseStyling(header, 'header', theme);
+  const headStyle = getBaseStyling(header, 'header', theme);
+  const setBackgroundColor = isDarkColor(headStyle.color) ? '#FAFAFA' : '#323232';
+  // When the table background color from sense theme is transparent,
+  // there is a default background color for the header
+  // to avoid seeing the table body through the header
+  headStyle.backgroundColor = theme.backgroundColor === 'transparent' ? setBackgroundColor : theme.backgroundColor;
+  headStyle.borderTop = theme.isBackgroundDarkColor ? '1px solid #F2F2F3' : '1px solid #D9D9D9';
+  return headStyle;
 }
 
 export function getBodyStyle(layout, theme) {

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -110,6 +110,33 @@ export function getBodyStyle(layout, theme) {
   };
 }
 
+/**
+ * We can set the background color expression or text color expression\
+ * for measure data or dimension data.
+ * Ex:
+ * {"qHyperCubeDef": {
+ *     "qDimensions": [{
+ *        "qAttributeExpressions": [
+          {
+            "qExpression": "rgb(4,4,4)",
+            "qAttribute": true,
+            "id": "cellBackgroundColor"
+          },
+          {
+            "qExpression": "rgb(219, 42, 42)",
+            "qAttribute": true,
+            "id": "cellForegroundColor"
+          }
+        ],
+ *     }]
+ * }}
+ *
+ * get style from qAttributeExpressions in qDimensions or qMeasures
+ * @param {Object} styling - style from styling in CellRenderer in TableBodyWrapper
+ * @param {?Object} qAttrExps - qAttributeExpressions from each cell
+ * @param {Array} stylingInfo - stylingInfo from each column
+ * @returns {Object} cell font color and background color used for cells in specific columns
+ */
 export function getColumnStyle(styling, qAttrExps, stylingInfo) {
   const columnColors = {};
   qAttrExps?.qValues.forEach((val, i) => {
@@ -122,19 +149,31 @@ export function getColumnStyle(styling, qAttrExps, stylingInfo) {
   return {
     ...styling,
     color: columnColors.cellForegroundColor || styling.color,
-    background: columnColors.cellBackgroundColor,
+    backgroundColor: columnColors.cellBackgroundColor,
   };
 }
 
-export function getSelectionColors(cell, selectionState, background, tableBackgroundColor) {
+/**
+ * Get different styles for cells based on wether they are
+ * selected or possible to be selected or not possible to be selected
+ * @param {Object} cell - each cell in the table body
+ * @param {Object} selectionState - the selected cell
+ * @param {?String} columnBackgroundColor - the background color from qAttributeExpressions in qDimensions or qMeasures
+ * @param {?String} themeBackgroundColor - the background color from nebula theme or sense theme
+ * @returns {Object} different set of styles for different state of cells
+ */
+export function getSelectionColors(
+  cell,
+  selectionState,
+  columnBackgroundColor,
+  themeBackgroundColor = STYLING_DEFAULTS.WHITE
+) {
   const { colIdx, rows, api } = selectionState;
 
   if (api.isModal()) {
     if (colIdx !== cell.colIdx)
       return {
-        background: `${STYLING_DEFAULTS.EXCLUDED_BACKGROUND}, ${
-          background || tableBackgroundColor || STYLING_DEFAULTS.WHITE
-        }`,
+        background: `${STYLING_DEFAULTS.EXCLUDED_BACKGROUND}, ${columnBackgroundColor || themeBackgroundColor}`,
       };
 
     const match = (row) => row.qElemNumber === cell.qElemNumber;
@@ -146,6 +185,9 @@ export function getSelectionColors(cell, selectionState, background, tableBackgr
   return {};
 }
 
-export function getSelectionStyle(styling, cell, selectionState, tableBackgroundColor) {
-  return { ...styling, ...getSelectionColors(cell, selectionState, styling.background, tableBackgroundColor) };
+export function getSelectionStyle(styling, cell, selectionState, themeBackgroundColor) {
+  return {
+    ...styling,
+    ...getSelectionColors(cell, selectionState, styling.backgroundColor, themeBackgroundColor),
+  };
 }

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -111,8 +111,8 @@ export function getBodyStyle(layout, theme) {
 }
 
 /**
- * We can set the background color expression or text color expression\
- * for measure data or dimension data.
+ * You can set the background color expression and/or text color expression
+ * for measure data and/or dimension data.
  * Ex:
  * {"qHyperCubeDef": {
  *     "qDimensions": [{
@@ -154,13 +154,13 @@ export function getColumnStyle(styling, qAttrExps, stylingInfo) {
 }
 
 /**
- * Get different styles for cells based on wether they are
+ * Get the style for one cell based on wether it is
  * selected or possible to be selected or not possible to be selected
- * @param {Object} cell - each cell in the table body
- * @param {Object} selectionState - the selected cell
- * @param {?String} columnBackgroundColor - the background color from qAttributeExpressions in qDimensions or qMeasures
- * @param {?String} themeBackgroundColor - the background color from nebula theme or sense theme
- * @returns {Object} different set of styles for different state of cells
+ * @param {Object} cell - The info of one cell in the table body
+ * @param {Object} selectionState - The info of which cells are selected
+ * @param {?String} columnBackgroundColor - The background color from qAttributeExpressions in qDimensions or qMeasures
+ * @param {?String} [themeBackgroundColor='#fff'] - The background color from nebula theme or sense theme
+ * @returns {Object} The style for the provided cell
  */
 export function getSelectionColors(
   cell,
@@ -169,7 +169,7 @@ export function getSelectionColors(
   themeBackgroundColor = STYLING_DEFAULTS.WHITE
 ) {
   const { colIdx, rows, api } = selectionState;
-
+  window.console.log({ selectionState });
   if (api.isModal()) {
     if (colIdx !== cell.colIdx)
       return {

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -68,9 +68,12 @@ export function getHeaderStyle(layout, theme) {
   const headerBackgroundColor = isDarkColor(headerStyle.color) ? '#FAFAFA' : '#323232';
   headerStyle.backgroundColor = theme.backgroundColor === 'transparent' ? headerBackgroundColor : theme.backgroundColor;
   headerStyle.borderTop = theme.isBackgroundDarkColor ? '1px solid #F2F2F3' : '1px solid #D9D9D9';
-  headerStyle.sortLabelColor = isDarkColor(headerStyle.backgroundColor)
-    ? 'rgba(255,255,255,0.9)'
-    : 'rgba(0, 0, 0, 0.54)';
+  // When you set the header font color,
+  // the sort label color should be same.
+  // When there is no header content color setting,
+  // the sort label color is depending on the header background color.
+  headerStyle.sortLabelColor =
+    headerStyle.color ?? isDarkColor(headerStyle.backgroundColor) ? 'rgba(255,255,255,0.9)' : 'rgba(0, 0, 0, 0.54)';
   return headerStyle;
 }
 


### PR DESCRIPTION
When you set the color of header content, the color of the sort label should be the same as that.
When there is no header content color setting, the sort label color is kind of white in the dark background color and black in the light background color.