### PR TITLE
chore: sync playwright version between installed package and script files

### DIFF
--- a/.github/CONTRIBUTION.md
+++ b/.github/CONTRIBUTION.md
@@ -23,8 +23,8 @@ Run rendering tests with:
     # Build nebula.js visualization
     yarn build
 
-    chmod 777 ./test/rendering/commands/run-rendering-test.sh
-    ./test/rendering/commands/run-rendering-test.sh
+    chmod 777 ./test/rendering/scripts/run-rendering-test.sh
+    ./test/rendering/scripts/run-rendering-test.sh
 
 Look into [overview and guide](../test/rendering/README.md) to learn more about the rendering test
 

--- a/test/rendering/README.md
+++ b/test/rendering/README.md
@@ -27,8 +27,8 @@ If you've updated the UI, you need to run the update-screenshots.sh script:
     # Build nebula.js visualization
     yarn build
 
-    chmod 777 ./test/rendering/commands/update-screenshots.sh
-    ./test/rendering/commands/update-screenshots.sh
+    chmod 777 ./test/rendering/scripts/update-screenshots.sh
+    ./test/rendering/scripts/update-screenshots.sh
 
 It will spin up a docker container with playwright and enable us to emulate our CI server for updating the reference screenshots. The `--update-snapshots` will generate new screenshots for you.
 

--- a/test/rendering/scripts/run-rendering-test.sh
+++ b/test/rendering/scripts/run-rendering-test.sh
@@ -4,14 +4,16 @@
 # To know the error location in the running code
 set -e
 
+playwrightVersion=$(npm info playwright version)
+
 # Create and start the container with the name *sn-tale-playwright*
 # using the Docker host network stack and binding your current directory
 # in the background in a “detached” mod and remove the container once it exits/stops
 # The -it instructs Docker to allocate a pseudo-TTY connected to the container’s stdin;
 # creating an interactive bash shell in the container
-docker run -d --name sn-tale-playwright  --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v1.19.2-focal
+docker run -d --name sn-tale-playwright  --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v$playwrightVersion-focal
 
-# The actual generate/update the reference screenshots is running from the machine running this shell script
-docker exec sn-tale-playwright /bin/sh -c "yarn test:rendering --update-snapshots"
+# The actual rendering test is running from the machine running this shell script
+docker exec sn-tale-playwright /bin/sh -c "yarn test:rendering"
 
 docker stop sn-tale-playwright

--- a/test/rendering/scripts/update-screenshots.sh
+++ b/test/rendering/scripts/update-screenshots.sh
@@ -4,14 +4,16 @@
 # To know the error location in the running code
 set -e
 
+playwrightVersion=$(npm info playwright version)
+
 # Create and start the container with the name *sn-tale-playwright*
 # using the Docker host network stack and binding your current directory
 # in the background in a “detached” mod and remove the container once it exits/stops
 # The -it instructs Docker to allocate a pseudo-TTY connected to the container’s stdin;
 # creating an interactive bash shell in the container
-docker run -d --name sn-tale-playwright  --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v1.19.2-focal
+docker run -d --name sn-tale-playwright  --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v$playwrightVersion-focal
 
-# The actual rendering test is running from the machine running this shell script
-docker exec sn-tale-playwright /bin/sh -c "yarn test:rendering"
+# The actual generate/update the reference screenshots is running from the machine running this shell script
+docker exec sn-tale-playwright /bin/sh -c "yarn test:rendering --update-snapshots"
 
 docker stop sn-tale-playwright


### PR DESCRIPTION
when the playwright is updated, the script file is broken.