### PR TITLE
refactor: put select logic on reducer

### DIFF
--- a/src/table/components/__tests__/withSelections.spec.jsx
+++ b/src/table/components/__tests__/withSelections.spec.jsx
@@ -68,6 +68,14 @@ describe('withSelections', () => {
     fireEvent.mouseUp(queryByText(value));
 
     expect(selectionDispatch).toHaveBeenCalledTimes(1);
+    expect(selectionDispatch).toHaveBeenCalledWith({
+      type: 'select',
+      payload: {
+        cell,
+        announce,
+        evt: expect.anything(),
+      },
+    });
   });
 
   it('should not call selectCell on mouseUp when measure', () => {

--- a/src/table/components/__tests__/withSelections.spec.jsx
+++ b/src/table/components/__tests__/withSelections.spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import * as withSelections from '../withSelections';
-import * as selectionsUtils from '../../utils/selections-utils';
 
 describe('withSelections', () => {
   let HOC;
@@ -17,7 +16,6 @@ describe('withSelections', () => {
 
   beforeEach(() => {
     HOC = withSelections.default((props) => <div {...props}>{props.value}</div>);
-    jest.spyOn(selectionsUtils, 'selectCell').mockImplementation(() => jest.fn());
 
     value = '100';
     cell = {
@@ -28,7 +26,7 @@ describe('withSelections', () => {
       colIdx: -1,
       api: { isModal: () => true },
     };
-    selectionDispatch = () => {};
+    selectionDispatch = jest.fn();
     evt = { button: 0 };
     styling = {};
     announce = jest.fn();
@@ -54,6 +52,7 @@ describe('withSelections', () => {
 
     expect(queryByText(value)).toBeVisible();
   });
+
   it('should call selectCell on mouseUp', () => {
     const { queryByText } = render(
       <HOC
@@ -68,16 +67,9 @@ describe('withSelections', () => {
     );
     fireEvent.mouseUp(queryByText(value));
 
-    expect(selectionsUtils.selectCell).toHaveBeenCalledTimes(1);
-    expect(selectionsUtils.selectCell).toHaveBeenCalledWith(
-      expect.objectContaining({
-        selectionState: expect.anything(),
-        cell: expect.anything(),
-        evt: expect.anything(),
-        announce: expect.anything(),
-      })
-    );
+    expect(selectionDispatch).toHaveBeenCalledTimes(1);
   });
+
   it('should not call selectCell on mouseUp when measure', () => {
     cell.isDim = false;
 
@@ -94,8 +86,9 @@ describe('withSelections', () => {
     );
     fireEvent.mouseUp(queryByText(value));
 
-    expect(selectionsUtils.selectCell).not.toHaveBeenCalled();
+    expect(selectionDispatch).not.toHaveBeenCalled();
   });
+
   it('should not call selectCell on mouseUp when right button', () => {
     evt.button = 2;
 
@@ -112,6 +105,6 @@ describe('withSelections', () => {
     );
     fireEvent.mouseUp(queryByText(value), evt);
 
-    expect(selectionsUtils.selectCell).not.toHaveBeenCalled();
+    expect(selectionDispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/table/components/withSelections.jsx
+++ b/src/table/components/withSelections.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { selectCell } from '../utils/selections-utils';
 import { getSelectionStyle } from '../utils/styling-utils';
 
 export default function withSelections(CellComponent) {
@@ -16,7 +15,7 @@ export default function withSelections(CellComponent) {
       ...passThroughProps
     } = props;
     const handleMouseUp = (evt) =>
-      cell.isDim && evt.button === 0 && selectCell({ selectionState, cell, selectionDispatch, evt, announce });
+      cell.isDim && evt.button === 0 && selectionDispatch({ type: 'select', payload: { cell, evt, announce } });
 
     const selectionStyling = useMemo(
       () => getSelectionStyle(styling, cell, selectionState, themeBackgroundColor),

--- a/src/table/utils/__tests__/handle-key-press.spec.js
+++ b/src/table/utils/__tests__/handle-key-press.spec.js
@@ -176,8 +176,6 @@ describe('handle-key-press', () => {
         api: {
           confirm: jest.fn(),
           cancel: jest.fn(),
-          begin: jest.fn(),
-          select: jest.fn(),
           isModal: () => isModal,
         },
         rows: [],
@@ -227,13 +225,8 @@ describe('handle-key-press', () => {
       });
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
-      expect(selectionState.api.begin).toHaveBeenCalledTimes(1);
-      expect(selectionState.api.select).toHaveBeenCalledTimes(1);
-      expect(selectionDispatch).toHaveBeenCalledTimes(1);
       expect(setFocusedCellCoord).not.toHaveBeenCalled();
-      expect(announce).toHaveBeenCalledWith({
-        keys: ['SNTable.SelectionLabel.SelectedValue', 'SNTable.SelectionLabel.OneSelectedValue'],
-      });
+      expect(selectionDispatch).toHaveBeenCalledTimes(1);
     });
 
     it('when moving to a cell on a dimension column which is selected, also have some selections already, should announce the value is selected', () => {
@@ -293,11 +286,8 @@ describe('handle-key-press', () => {
       });
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
-      expect(selectionState.api.begin).not.toHaveBeenCalled();
-      expect(selectionState.api.select).not.toHaveBeenCalled();
       expect(selectionDispatch).not.toHaveBeenCalled();
       expect(setFocusedCellCoord).not.toHaveBeenCalled();
-      expect(announce).not.toHaveBeenCalled();
     });
 
     it('when press space bar key not in analysis mode, should not select value for measure ', () => {
@@ -317,11 +307,8 @@ describe('handle-key-press', () => {
       });
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
-      expect(selectionState.api.begin).not.toHaveBeenCalled();
-      expect(selectionState.api.select).not.toHaveBeenCalled();
       expect(selectionDispatch).not.toHaveBeenCalled();
       expect(setFocusedCellCoord).not.toHaveBeenCalled();
-      expect(announce).not.toHaveBeenCalled();
     });
 
     it('when press enter key, should confirms selections', () => {
@@ -368,7 +355,7 @@ describe('handle-key-press', () => {
       expect(announce).not.toHaveBeenCalled();
     });
 
-    it('when press cancel key, should cancel selection', () => {
+    it('when press esc key, should cancel selection', () => {
       isModal = true;
       evt.key = 'Escape';
       selectionState.rows = [{}];
@@ -391,7 +378,7 @@ describe('handle-key-press', () => {
       expect(announce).toHaveBeenCalledWith({ keys: 'SNTable.SelectionLabel.ExitedSelectionMode' });
     });
 
-    it('when press cancel key not in analysis mode, should not cancel selection', () => {
+    it('when press esc key not in analysis mode, should not cancel selection', () => {
       isModal = true;
       evt.key = 'Escape';
       isAnalysisMode = false;
@@ -414,7 +401,7 @@ describe('handle-key-press', () => {
       expect(announce).not.toHaveBeenCalled();
     });
 
-    it('when press ArrowRight and shift and ctrl key, should not update the sorting', () => {
+    it('when press ArrowRight and shift and ctrl key, should not update the focus', () => {
       evt.key = 'ArrowRight';
       evt.shiftKey = true;
       evt.ctrlKey = true;

--- a/src/table/utils/handle-key-press.js
+++ b/src/table/utils/handle-key-press.js
@@ -1,4 +1,3 @@
-import { selectCell } from './selections-utils';
 import { updateFocus, focusSelectionToolbar } from './handle-accessibility';
 
 const isCtrlShift = (evt) => evt.shiftKey && (evt.ctrlKey || evt.metaKey);
@@ -152,7 +151,7 @@ export const bodyHandleKeyPress = ({
     // Space bar: Selects value.
     case ' ': {
       preventDefaultBehavior(evt);
-      cell?.isDim && isAnalysisMode && selectCell({ selectionState, cell, selectionDispatch, evt, announce });
+      cell?.isDim && isAnalysisMode && selectionDispatch({ type: 'select', payload: { cell, evt, announce } });
       break;
     }
     // Enter: Confirms selections.

--- a/src/table/utils/selections-utils.js
+++ b/src/table/utils/selections-utils.js
@@ -107,6 +107,6 @@ export function reducer(state, action) {
     case 'set-enabled':
       return { ...state, isEnabled };
     default:
-      return state;
+      throw new Error('reducer called with invalid action type');
   }
 }


### PR DESCRIPTION
This makes way more sense to me, instead of having a seperate function that we need to pass both the state and the dispatcher to.