### PR TITLE
fix: avoid conflicts when using multiple roots on the same page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import {
   useKeyboard,
   useRect,
   useApp,
+  useId,
 } from '@nebula.js/stardust';
 import registerLocale from './locale/src';
 import properties from './object-properties';
@@ -44,6 +45,7 @@ export default function supernova(env) {
       data: data(env),
     },
     component() {
+      const id = useId();
       const rootElement = useElement();
       const layout = useStaleLayout();
       const { direction, footerContainer } = useOptions();
@@ -76,7 +78,8 @@ export default function supernova(env) {
         if (layout && tableData && !env.carbon) {
           registerLocale(translator);
           const changeSortOrder = sortingFactory(model);
-          render(rootElement, {
+          render({
+            id,
             rootElement,
             layout,
             tableData,

--- a/src/table/Root.jsx
+++ b/src/table/Root.jsx
@@ -7,10 +7,12 @@ import TableWrapper from './components/TableWrapper';
 
 let reactRoot;
 
-export function render(rootElement, props) {
-  const { muiTheme, direction } = props;
-  if (!reactRoot) {
-    reactRoot = createRoot(rootElement);
+export function render(props) {
+  const { muiTheme, direction, rootElement, id } = props;
+
+  // eslint-disable-next-line no-underscore-dangle
+  if (reactRoot?._internalRoot?.identifierPrefix !== id) {
+    reactRoot = createRoot(rootElement, { identifierPrefix: id });
   }
 
   reactRoot.render(


### PR DESCRIPTION
https://reactjs.org/docs/react-dom-client.html#createroot

identifierPrefix: optional prefix React uses for ids generated by React.useId. Useful to avoid conflicts when using multiple roots on the same page. Must be the same prefix used on the server.

We either revert back to react 17 or add useId in nebula.