### PR TITLE
fix: next page command and block header to focus in selections

### DIFF
--- a/src/table/utils/__tests__/handle-key-press.spec.js
+++ b/src/table/utils/__tests__/handle-key-press.spec.js
@@ -12,7 +12,7 @@ import * as handleAccessibility from '../handle-accessibility';
 describe('handle-key-press', () => {
   describe('handleTableWrapperKeyDown', () => {
     let evt = {};
-    let totalVerticalCount;
+    let totalRowCount;
     let page;
     let rowsPerPage;
     let handleChangePage;
@@ -35,7 +35,7 @@ describe('handle-key-press', () => {
 
     it('when shift key is not pressed, handleChangePage should not run', () => {
       evt.shiftKey = false;
-      handleTableWrapperKeyDown({ evt, totalVerticalCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
+      handleTableWrapperKeyDown({ evt, totalRowCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
       expect(handleChangePage).not.toHaveBeenCalled();
       expect(setShouldRefocus).not.toHaveBeenCalled();
     });
@@ -43,16 +43,16 @@ describe('handle-key-press', () => {
     it('when ctrl key or meta key is not pressed, handleChangePage should not run', () => {
       evt.ctrlKey = false;
       evt.metaKey = false;
-      handleTableWrapperKeyDown({ evt, totalVerticalCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
+      handleTableWrapperKeyDown({ evt, totalRowCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
       expect(handleChangePage).not.toHaveBeenCalled();
       expect(setShouldRefocus).not.toHaveBeenCalled();
     });
 
     it('when press arrow right key on the first page which contains all rows, handleChangePage should not run', () => {
       page = 0;
-      totalVerticalCount = 40;
+      totalRowCount = 40;
       rowsPerPage = 40;
-      handleTableWrapperKeyDown({ evt, totalVerticalCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
+      handleTableWrapperKeyDown({ evt, totalRowCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
       expect(handleChangePage).not.toHaveBeenCalled();
       expect(setShouldRefocus).not.toHaveBeenCalled();
     });
@@ -60,28 +60,28 @@ describe('handle-key-press', () => {
     it('when press arrow left key on the first page, handleChangePage should not run', () => {
       evt.key = 'ArrowLeft';
       page = 0;
-      totalVerticalCount = 40;
+      totalRowCount = 40;
       rowsPerPage = 10;
-      handleTableWrapperKeyDown({ evt, totalVerticalCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
+      handleTableWrapperKeyDown({ evt, totalRowCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
       expect(handleChangePage).not.toHaveBeenCalled();
       expect(setShouldRefocus).not.toHaveBeenCalled();
     });
 
     it('when press arrow right key on the page whose next page contains rows, should change page', () => {
-      totalVerticalCount = 40;
+      totalRowCount = 40;
       page = 0;
       rowsPerPage = 10;
-      handleTableWrapperKeyDown({ evt, totalVerticalCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
+      handleTableWrapperKeyDown({ evt, totalRowCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
       expect(handleChangePage).toHaveBeenCalledTimes(1);
       expect(setShouldRefocus).toHaveBeenCalledTimes(1);
     });
 
     it('when press arrow left key not on the first page, should change page', () => {
       evt.key = 'ArrowLeft';
-      totalVerticalCount = 40;
+      totalRowCount = 40;
       page = 1;
       rowsPerPage = 40;
-      handleTableWrapperKeyDown({ evt, totalVerticalCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
+      handleTableWrapperKeyDown({ evt, totalRowCount, page, rowsPerPage, handleChangePage, setShouldRefocus });
       expect(handleChangePage).toHaveBeenCalledTimes(1);
       expect(setShouldRefocus).toHaveBeenCalledTimes(1);
     });
@@ -95,7 +95,7 @@ describe('handle-key-press', () => {
       keyboard = { enabled: true, blur: jest.fn() };
       handleTableWrapperKeyDown({
         evt,
-        totalVerticalCount,
+        totalRowCount,
         page,
         rowsPerPage,
         handleChangePage,
@@ -117,7 +117,7 @@ describe('handle-key-press', () => {
       isSelectionActive = true;
       handleTableWrapperKeyDown({
         evt,
-        totalVerticalCount,
+        totalRowCount,
         page,
         rowsPerPage,
         handleChangePage,

--- a/src/table/utils/handle-key-press.js
+++ b/src/table/utils/handle-key-press.js
@@ -9,7 +9,7 @@ export const preventDefaultBehavior = (evt) => {
 
 export const handleTableWrapperKeyDown = ({
   evt,
-  totalVerticalCount,
+  totalRowCount,
   page,
   rowsPerPage,
   handleChangePage,
@@ -20,7 +20,7 @@ export const handleTableWrapperKeyDown = ({
   if (isCtrlShift(evt)) {
     preventDefaultBehavior(evt);
     // ctrl + shift + left/right arrow keys: go to previous/next page
-    const lastPage = Math.ceil(totalVerticalCount / rowsPerPage) - 1;
+    const lastPage = Math.ceil(totalRowCount / rowsPerPage) - 1;
     if (evt.key === 'ArrowRight' && page < lastPage) {
       setShouldRefocus();
       handleChangePage(page + 1);
@@ -34,10 +34,8 @@ export const handleTableWrapperKeyDown = ({
   }
 };
 
-export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, selectionState) => {
+export const arrowKeysNavigation = (evt, rowAndColumnCount, cellCoord, isInSelectionMode) => {
   let [nextRow, nextCol] = cellCoord;
-  // check if you have unconfirmed selections, so one or more cells are selected but not confirmed yet.
-  const isInSelectionMode = selectionState?.api?.isModal();
 
   switch (evt.key) {
     case 'ArrowDown':


### PR DESCRIPTION
- The cmd+shift+arrow command to change page bc of a argument mismatch
- Also an argument with the wrong name resulting in that you could navigate to header in selection mode