### PR TITLE
fix: pass isInSelectionMode explicitly

### DIFF
--- a/src/table/components/PaginationContent.jsx
+++ b/src/table/components/PaginationContent.jsx
@@ -48,7 +48,7 @@ function PaginationContent({
   translator,
   constraints,
   footerContainer,
-  selectionsAPI,
+  isInSelectionMode,
   rect,
   handleChangePage,
   announce,
@@ -63,7 +63,7 @@ function PaginationContent({
   const tabIndex = !keyboard.enabled || keyboard.active ? 0 : -1;
   const width = footerContainer ? footerContainer.getBoundingClientRect().width : rect.width;
   const showFirstAndLast = shouldShow('firstLast', width);
-  const showRowsPerPage = !selectionsAPI.isModal() && shouldShow('rppOptions', width) && totalColumnCount <= 100;
+  const showRowsPerPage = !isInSelectionMode && shouldShow('rppOptions', width) && totalColumnCount <= 100;
   const displayedRowsText = translator.get('SNTable.Pagination.DisplayedRowsLabel', [
     `${page * rowsPerPage + 1} - ${Math.min((page + 1) * rowsPerPage, totalRowCount)}`,
     totalRowCount,
@@ -76,7 +76,7 @@ function PaginationContent({
 
   const handleSelectPage = (event) => handleChangePage(+event.target.value);
 
-  const handleLastButtonTab = keyboard.enabled ? (event) => handleLastTab(event, selectionsAPI.isModal()) : null;
+  const handleLastButtonTab = keyboard.enabled ? (event) => handleLastTab(event, isInSelectionMode) : null;
 
   const selectStyle = {
     backgroundColor: 'inherit',
@@ -177,12 +177,12 @@ PaginationContent.propTypes = {
   keyboard: PropTypes.object.isRequired,
   translator: PropTypes.object.isRequired,
   constraints: PropTypes.object.isRequired,
-  selectionsAPI: PropTypes.object.isRequired,
-  direction: PropTypes.string,
-  footerContainer: PropTypes.object,
+  isInSelectionMode: PropTypes.bool.isRequired,
   rect: PropTypes.object.isRequired,
   handleChangePage: PropTypes.func.isRequired,
   announce: PropTypes.func.isRequired,
+  direction: PropTypes.string,
+  footerContainer: PropTypes.object,
 };
 
 export default memo(PaginationContent);

--- a/src/table/components/TableWrapper.jsx
+++ b/src/table/components/TableWrapper.jsx
@@ -160,7 +160,12 @@ export default function TableWrapper(props) {
       </TableContainer>
       {!constraints.active && (
         <FooterWrapper theme={theme} footerContainer={footerContainer}>
-          <PaginationContent {...props} handleChangePage={handleChangePage} announce={announce} />
+          <PaginationContent
+            {...props}
+            handleChangePage={handleChangePage}
+            isInSelectionMode={selectionsAPI.isModal()}
+            announce={announce}
+          />
         </FooterWrapper>
       )}
     </Paper>

--- a/src/table/components/__tests__/PaginationContent.spec.jsx
+++ b/src/table/components/__tests__/PaginationContent.spec.jsx
@@ -14,8 +14,7 @@ describe('<PaginationContent />', () => {
   let handleChangePage;
   let rect;
   let translator;
-  let isModal;
-  let selectionsAPI;
+  let isInSelectionMode;
   let keyboard;
   let constraints;
   let footerContainer;
@@ -33,7 +32,7 @@ describe('<PaginationContent />', () => {
         translator={translator}
         constraints={constraints}
         footerContainer={footerContainer}
-        selectionsAPI={selectionsAPI}
+        isInSelectionMode={isInSelectionMode}
         rect={rect}
         handleChangePage={handleChangePage}
         announce={announce}
@@ -66,8 +65,7 @@ describe('<PaginationContent />', () => {
     handleChangePage = jest.fn();
     rect = { width: 750 };
     translator = { get: (s) => s };
-    isModal = false;
-    selectionsAPI = { isModal: () => isModal };
+    isInSelectionMode = false;
     keyboard = { enabled: true };
     constraints = {};
     announce = jest.fn();
@@ -197,7 +195,7 @@ describe('<PaginationContent />', () => {
     });
 
     it('should not call focusSelectionToolbar when pressing shift + tab on last page button and isInSelectionMode is true', () => {
-      isModal = true;
+      isInSelectionMode = true;
 
       const { queryByTitle } = renderPagination();
       fireEvent.keyDown(queryByTitle('SNTable.Pagination.LastPage'), { key: 'Tab', shiftKey: true });
@@ -205,7 +203,7 @@ describe('<PaginationContent />', () => {
     });
 
     it('should call focusSelectionToolbar when pressing tab on last page button and isInSelectionMode is true', () => {
-      isModal = true;
+      isInSelectionMode = true;
 
       const { queryByTitle } = renderPagination();
       fireEvent.keyDown(queryByTitle('SNTable.Pagination.LastPage'), { key: 'Tab' });
@@ -213,7 +211,7 @@ describe('<PaginationContent />', () => {
     });
 
     it('should call focusSelectionToolbar when pressing tab on next page button, isInSelectionMode is true and tableWidth < 350', () => {
-      isModal = true;
+      isInSelectionMode = true;
       rect.width = 300;
 
       const { queryByTitle } = renderPagination();


### PR DESCRIPTION
since we use memo and no props change when you start selection mode, the rows per page option was not hidden but it should. Passing `isInSelectionMode` explicitly makes sure we keep the memo and it updates when you go in and out of selection mode