### PR TITLE
fix: clicking the header cell does not always sets the focus

### DIFF
--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -6,7 +6,7 @@ import { useContextSelector, TableContext } from '../context';
 import { VisuallyHidden, StyledHeadRow, StyledSortLabel } from '../styles';
 import { getHeaderStyle } from '../utils/styling-utils';
 import { headHandleKeyPress } from '../utils/handle-key-press';
-import { getCellElement, updateFocus, handleClickToFocusHead } from '../utils/handle-accessibility';
+import { handleMouseDownLabelToFocusHeadCell, handleClickToFocusHead } from '../utils/handle-accessibility';
 
 function TableHeadWrapper({
   rootElement,
@@ -42,11 +42,6 @@ function TableHeadWrapper({
               setFocusedCellCoord,
             });
           };
-          const handleMouseDown = (evt) => {
-            evt.preventDefault();
-            const cell = getCellElement(rootElement, [columnIndex, 0]);
-            updateFocus({ focusType: 'focus', cell });
-          };
 
           return (
             <TableCell
@@ -67,7 +62,7 @@ function TableHeadWrapper({
                 title={!constraints.passive && column.sortDirection} // passive: turn off tooltips.
                 direction={column.sortDirection}
                 tabIndex={-1}
-                onMouseDown={handleMouseDown}
+                onMouseDown={(evt) => handleMouseDownLabelToFocusHeadCell(evt, rootElement, columnIndex)}
               >
                 {column.label}
                 {isFocusInHead && (

--- a/src/table/components/TableHeadWrapper.jsx
+++ b/src/table/components/TableHeadWrapper.jsx
@@ -6,7 +6,7 @@ import { useContextSelector, TableContext } from '../context';
 import { VisuallyHidden, StyledHeadRow, StyledSortLabel } from '../styles';
 import { getHeaderStyle } from '../utils/styling-utils';
 import { headHandleKeyPress } from '../utils/handle-key-press';
-import { handleClickToFocusHead } from '../utils/handle-accessibility';
+import { getCellElement, updateFocus, handleClickToFocusHead } from '../utils/handle-accessibility';
 
 function TableHeadWrapper({
   rootElement,
@@ -42,6 +42,11 @@ function TableHeadWrapper({
               setFocusedCellCoord,
             });
           };
+          const handleMouseDown = (evt) => {
+            evt.preventDefault();
+            const cell = getCellElement(rootElement, [columnIndex, 0]);
+            updateFocus({ focusType: 'focus', cell });
+          };
 
           return (
             <TableCell
@@ -62,6 +67,7 @@ function TableHeadWrapper({
                 title={!constraints.passive && column.sortDirection} // passive: turn off tooltips.
                 direction={column.sortDirection}
                 tabIndex={-1}
+                onMouseDown={handleMouseDown}
               >
                 {column.label}
                 {isFocusInHead && (

--- a/src/table/components/__tests__/TableHeadWrapper.spec.jsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.jsx
@@ -107,17 +107,15 @@ describe('<TableHeadWrapper />', () => {
     expect(handleKeyPress.headHandleKeyPress).toHaveBeenCalledTimes(1);
   });
 
-  it('should call handleClickToFocusHead when clicking a header cell', () => {
+  it('should call handleClickToFocusHead and handleMouseDownLabelToFocusHeadCell when clicking a header cell label', () => {
     jest.spyOn(handleAccessibility, 'handleClickToFocusHead').mockImplementation(() => jest.fn());
-    jest.spyOn(handleAccessibility, 'getCellElement').mockImplementation(() => jest.fn());
-    jest.spyOn(handleAccessibility, 'updateFocus').mockImplementation(() => jest.fn());
+    jest.spyOn(handleAccessibility, 'handleMouseDownLabelToFocusHeadCell').mockImplementation(() => jest.fn());
 
     const { queryByText } = renderTableHead();
     fireEvent.mouseDown(queryByText(tableData.columns[0].label));
 
     expect(handleAccessibility.handleClickToFocusHead).toHaveBeenCalledTimes(1);
-    expect(handleAccessibility.getCellElement).toHaveBeenCalledTimes(1);
-    expect(handleAccessibility.updateFocus).toHaveBeenCalledTimes(1);
+    expect(handleAccessibility.handleMouseDownLabelToFocusHeadCell).toHaveBeenCalledTimes(1);
   });
 
   it('should change `aria-pressed` and `aria-sort` when you sort by second column', () => {

--- a/src/table/components/__tests__/TableHeadWrapper.spec.jsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.jsx
@@ -109,11 +109,15 @@ describe('<TableHeadWrapper />', () => {
 
   it('should call handleClickToFocusHead when clicking a header cell', () => {
     jest.spyOn(handleAccessibility, 'handleClickToFocusHead').mockImplementation(() => jest.fn());
+    jest.spyOn(handleAccessibility, 'getCellElement').mockImplementation(() => jest.fn());
+    jest.spyOn(handleAccessibility, 'updateFocus').mockImplementation(() => jest.fn());
 
     const { queryByText } = renderTableHead();
     fireEvent.mouseDown(queryByText(tableData.columns[0].label));
 
     expect(handleAccessibility.handleClickToFocusHead).toHaveBeenCalledTimes(1);
+    expect(handleAccessibility.getCellElement).toHaveBeenCalledTimes(1);
+    expect(handleAccessibility.updateFocus).toHaveBeenCalledTimes(1);
   });
 
   it('should change `aria-pressed` and `aria-sort` when you sort by second column', () => {

--- a/src/table/utils/__tests__/handle-accessiblity.spec.js
+++ b/src/table/utils/__tests__/handle-accessiblity.spec.js
@@ -146,6 +146,19 @@ describe('handle-accessibility', () => {
     });
   });
 
+  describe('handleMouseDownLabelToFocusHeadCell', () => {
+    const evt = { preventDefault: jest.fn() };
+    const columnIndex = 0;
+
+    it('should indirectly call updateFocus, setFocusedCellCoord and keyboard.focus', () => {
+      handleAccessibility.handleMouseDownLabelToFocusHeadCell(evt, rootElement, columnIndex);
+      expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+      expect(cell.focus).toHaveBeenCalledTimes(1);
+      expect(cell.setAttribute).toHaveBeenCalledTimes(1);
+      expect(cell.setAttribute).toHaveBeenCalledWith('tabIndex', '0');
+    });
+  });
+
   describe('handleResetFocus', () => {
     let shouldRefocus;
     let hasSelections;

--- a/src/table/utils/__tests__/styling-utils.spec.js
+++ b/src/table/utils/__tests__/styling-utils.spec.js
@@ -195,6 +195,7 @@ describe('styling-utils', () => {
         borderColor: '#D9D9D9',
         borderStyle: 'solid',
         borderWidth: '1px 1px 1px 0px',
+        cursor: 'pointer',
         sortLabelColor: 'rgba(255,255,255,0.9)',
       });
     });
@@ -212,6 +213,7 @@ describe('styling-utils', () => {
       const resultStyling = getHeaderStyle(layout, theme);
       expect(resultStyling).toEqual({
         color: '#404040',
+        cursor: 'pointer',
         backgroundColor: '#323232',
         borderColor: '#D9D9D9',
         borderStyle: 'solid',
@@ -223,6 +225,7 @@ describe('styling-utils', () => {
       const resultStyling = getHeaderStyle(layout, theme);
       expect(resultStyling).toEqual({
         color: '#404040',
+        cursor: 'pointer',
         fontSize: 44,
         padding: '22px 44px',
         backgroundColor: '#323232',

--- a/src/table/utils/handle-accessibility.js
+++ b/src/table/utils/handle-accessibility.js
@@ -1,5 +1,5 @@
 export const getCellElement = (rootElement, cellCoord) =>
-  rootElement?.getElementsByClassName('sn-table-row')[cellCoord[0]]?.getElementsByClassName('sn-table-cell')[
+  rootElement.getElementsByClassName('sn-table-row')[cellCoord[0]]?.getElementsByClassName('sn-table-cell')[
     cellCoord[1]
   ];
 
@@ -41,6 +41,11 @@ export const handleClickToFocusBody = (cell, rootElement, setFocusedCellCoord, k
 
 export const handleClickToFocusHead = (columnIndex, rootElement, setFocusedCellCoord, keyboard) => {
   removeAndFocus([0, columnIndex], rootElement, setFocusedCellCoord, keyboard);
+};
+
+export const handleMouseDownLabelToFocusHeadCell = (evt, rootElement, columnIndex) => {
+  evt.preventDefault();
+  updateFocus({ focusType: 'focus', cell: getCellElement(rootElement, [0, columnIndex]) });
 };
 
 export const handleResetFocus = ({

--- a/src/table/utils/handle-accessibility.js
+++ b/src/table/utils/handle-accessibility.js
@@ -1,5 +1,5 @@
 export const getCellElement = (rootElement, cellCoord) =>
-  rootElement.getElementsByClassName('sn-table-row')[cellCoord[0]]?.getElementsByClassName('sn-table-cell')[
+  rootElement?.getElementsByClassName('sn-table-row')[cellCoord[0]]?.getElementsByClassName('sn-table-cell')[
     cellCoord[1]
   ];
 

--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -71,6 +71,7 @@ export const getBaseStyling = (styleObj, objetName, theme) => {
 export function getHeaderStyle(layout, theme) {
   const header = layout.components?.[0]?.header;
   const headerStyle = getBaseStyling(header, 'header', theme);
+  headerStyle.cursor = 'pointer';
   headerStyle.borderWidth = '1px 1px 1px 0px';
 
   // To avoid seeing the table body through the table head:


### PR DESCRIPTION
- When clicking TableSortLabel, it gets focused instead of the header cell.
So adding an explicit click method to TableSortLabel adds focus to the header cell.

- Add a cursor to the head cell
