### PR TITLE
fix: pressing esc in selection mode blurs everything

### DIFF
--- a/src/table/components/TableBodyWrapper.jsx
+++ b/src/table/components/TableBodyWrapper.jsx
@@ -21,14 +21,16 @@ function TableBodyWrapper({
   announce,
 }) {
   const { rows, columns, paginationNeeded, totalsPosition } = tableData;
+  const columnsStylingInfoJSON = JSON.stringify(columns.map((column) => column.stylingInfo));
   const setFocusedCellCoord = useContextSelector(TableContext, (value) => value.setFocusedCellCoord);
   const selectionDispatch = useContextSelector(TableContext, (value) => value.selectionDispatch);
   // active: turn off interactions that affect the state of the visual representation including selection, zoom, scroll, etc.
   // select: turn off selections.
   const selectionsEnabled = !!selectionsAPI && !constraints.active && !constraints.select;
   const columnRenderers = useMemo(
-    () => columns.map((column) => getCellRenderer(!!column.stylingInfo.length, selectionsEnabled)),
-    [columns, selectionsEnabled]
+    () =>
+      JSON.parse(columnsStylingInfoJSON).map((stylingInfo) => getCellRenderer(!!stylingInfo.length, selectionsEnabled)),
+    [columnsStylingInfoJSON, selectionsEnabled]
   );
   const bodyCellStyle = useMemo(() => getBodyCellStyle(layout, theme), [layout, theme]);
   const hoverEffect = layout.components?.[0]?.content?.hoverEffect;


### PR DESCRIPTION
Fix #571,  when you exit selection mode, pressing ESC in selection mode blurs everything.

whenever the layout updates, `manageData` will run and there will be a new instance of `columns`, which triggers the effect to be executed, which means we get new column renderers and the cells lose their reference, thus losing focus. 


