### PR TITLE
chore: revert jest-junit version

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "globby": "13.1.2",
     "husky": "8.0.1",
     "jest": "27.5.1",
-    "jest-junit": "14.0.0",
+    "jest-junit": "13.2.0",
     "lint-staged": "13.0.3",
     "prettier": "2.7.1",
     "prop-types": "15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7917,10 +7917,10 @@ jest-jasmine2@^27.5.1:
     pretty-format "^27.5.1"
     throat "^6.0.1"
 
-jest-junit@14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-14.0.0.tgz#f69fc31bab32224848f443480c2c808fccb2a802"
-  integrity sha512-kALvBDegstTROfDGXH71UGD7k5g7593Y1wuX1wpWT+QTYcBbmtuGOA8UlAt56zo/B2eMIOcaOVEON3j0VXVa4g==
+jest-junit@13.2.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-13.2.0.tgz#66eeb86429aafac8c1745a70f44ace185aacb943"
+  integrity sha512-B0XNlotl1rdsvFZkFfoa19mc634+rrd8E4Sskb92Bb8MmSXeWV9XJGUyctunZS1W410uAxcyYuPUGVnbcOH8cg==
   dependencies:
     mkdirp "^1.0.4"
     strip-ansi "^6.0.1"


### PR DESCRIPTION
fix the ci issue
<img width="1090" alt="Screenshot 2022-06-29 at 12 40 24" src="https://user-images.githubusercontent.com/4471489/176423187-02dac135-f9d1-4c99-a147-5e046701348f.png">
