### PR TITLE
fix: sometimes the border color of cell in header disappears

### DIFF
--- a/src/table/utils/styling-utils.js
+++ b/src/table/utils/styling-utils.js
@@ -70,8 +70,10 @@ export const getBaseStyling = (styleObj, objetName, theme) => {
 export function getHeaderStyle(layout, theme) {
   const header = layout.components?.[0]?.header;
   const headerStyle = getBaseStyling(header, 'header', theme);
+
   headerStyle.cursor = 'pointer';
-  headerStyle.borderWidth = '1px 1px 1px 0px';
+  headerStyle.borderTop = '1px solid #D9D9D9';
+  headerStyle.borderLeft = '0px';
 
   // To avoid seeing the table body through the table head:
   // - When the table background color from the sense theme is transparent,


### PR DESCRIPTION
Before:
<img width="822" alt="Screenshot 2022-07-06 at 10 22 30" src="https://user-images.githubusercontent.com/4471489/177504868-e79bddb0-a122-44d1-b9a0-0ff0bd5f64e5.png">
sometimes when you add or remove measure/dimensions, the border color of a cell in header disappears as shown in the iamge above.

Now:
the border color of a cell should always be present.




