### PR TITLE
fix: block left/right movement in selection mode

### DIFF
--- a/src/table/utils/handle-key-press.js
+++ b/src/table/utils/handle-key-press.js
@@ -161,13 +161,13 @@ export const bodyHandleKeyPress = ({
   // Adjust the cellCoord depending on the totals position
   const firstBodyRowIdx = totalsPosition === 'top' ? 2 : 1;
   const cellCoord = [cell.rawRowIdx + firstBodyRowIdx, cell.rawColIdx];
+  // Make sure you can't navigate to header (and totals) in selection mode
+  const topAllowedRow = isSelectionMode ? firstBodyRowIdx : 0;
 
   switch (evt.key) {
     case 'ArrowUp':
     case 'ArrowDown': {
       evt.key === 'ArrowUp' && handleNavigateTop([cell.rawRowIdx, cell.rawColIdx], rootElement);
-      // Make sure you can't navigate to header (and totals) in selection mode
-      const topAllowedRow = isSelectionMode ? firstBodyRowIdx : 0;
       const nextCell = moveFocus(evt, rootElement, cellCoord, setFocusedCellCoord, topAllowedRow);
       // Shift + up/down arrow keys: select multiple values
       // When at the first/last row of the cell, shift + arrow up/down key, no value is selected
@@ -190,7 +190,7 @@ export const bodyHandleKeyPress = ({
     }
     case 'ArrowRight':
     case 'ArrowLeft':
-      !isCtrlShift(evt) && moveFocus(evt, rootElement, cellCoord, setFocusedCellCoord);
+      !isCtrlShift(evt) && moveFocus(evt, rootElement, cellCoord, setFocusedCellCoord, topAllowedRow);
       break;
     // Space bar: Selects value.
     case ' ':


### PR DESCRIPTION
Broken by me from a refactor a while back. We break if topAllowedRow > 0, and it was undefined when moving left/right