### PR TITLE
refactor: migrate custom hook pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export default function supernova(env: Galaxy) {
       );
 
       useEffect(() => {
-        const isReadyToRender = !env.carbon && reactRoot && layout && tableData && announce && changeSortOrder && theme;
+        const isReadyToRender = !env.carbon && reactRoot && layout && tableData && changeSortOrder && theme;
         isReadyToRender &&
           render(reactRoot, {
             rootElement,

--- a/src/nebula-hooks/use-announce-and-translations.ts
+++ b/src/nebula-hooks/use-announce-and-translations.ts
@@ -1,4 +1,6 @@
-import { useState, useEffect } from '@nebula.js/stardust';
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useMemo } from '@nebula.js/stardust';
+
 import registerLocale from '../locale/src';
 import { AnnounceArgs, ExtendedTranslator, Announce } from '../types';
 
@@ -46,17 +48,10 @@ export const announcementFactory = (
   };
 };
 
-const useAnnounceAndTranslations = (rootElement: HTMLElement, translator: ExtendedTranslator) => {
-  const [announce, setAnnounce] = useState<undefined | Announce>(undefined);
-
-  useEffect(() => {
-    if (rootElement && translator) {
-      registerLocale(translator);
-      setAnnounce(() => announcementFactory(rootElement, translator));
-    }
+const useAnnounceAndTranslations = (rootElement: HTMLElement, translator: ExtendedTranslator) =>
+  useMemo(() => {
+    registerLocale(translator);
+    return () => announcementFactory(rootElement, translator);
   }, [rootElement, translator.language()]);
-
-  return announce;
-};
 
 export default useAnnounceAndTranslations;

--- a/src/nebula-hooks/use-extended-theme.ts
+++ b/src/nebula-hooks/use-extended-theme.ts
@@ -44,12 +44,10 @@ export const tableThemeColors = (theme: ExtendedTheme, rootElement: HTMLElement)
 const useExtendedTheme = (rootElement: HTMLElement): ExtendedTheme => {
   // TODO: add name method to stardust.Theme
   const nebulaTheme = useTheme() as ExtendedTheme;
-  const theme = useMemo(
+  return useMemo(
     () => ({ ...nebulaTheme, table: tableThemeColors(nebulaTheme, rootElement) } as ExtendedTheme),
     [nebulaTheme.name(), rootElement]
   );
-
-  return theme;
 };
 
 export default useExtendedTheme;

--- a/src/nebula-hooks/use-react-root.ts
+++ b/src/nebula-hooks/use-react-root.ts
@@ -1,18 +1,13 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useEffect, useState } from '@nebula.js/stardust';
-import ReactDom, { createRoot } from 'react-dom/client';
+import { useMemo } from '@nebula.js/stardust';
+import { createRoot } from 'react-dom/client';
 
 import { mount } from '../table/Root';
 
-export default function useReactRoot(rootElement: HTMLElement) {
-  const [reactRoot, setReactRoot] = useState<ReactDom.Root | undefined>(undefined);
-
-  useEffect(() => {
-    if (rootElement) {
-      setReactRoot(createRoot(rootElement));
-      mount(rootElement); // only does something in native env
-    }
+const useReactRoot = (rootElement: HTMLElement) =>
+  useMemo(() => {
+    mount(rootElement);
+    return createRoot(rootElement);
   }, [rootElement]);
 
-  return reactRoot;
-}
+export default useReactRoot;

--- a/src/nebula-hooks/use-sorting.ts
+++ b/src/nebula-hooks/use-sorting.ts
@@ -42,10 +42,5 @@ export const sortingFactory = (model?: EngineAPI.IGenericObject) => {
   };
 };
 
-const useSorting = (model?: EngineAPI.IGenericObject) => {
-  const changeSortOrder = useMemo(() => sortingFactory(model), [model]);
-
-  return changeSortOrder;
-};
-
+const useSorting = (model?: EngineAPI.IGenericObject) => useMemo(() => sortingFactory(model), [model]);
 export default useSorting;


### PR DESCRIPTION
Migrate from
```
const [filteredData, setFilteredData] = useState();
useEffect(() => {
  setFilteredData(data.filter(x => isOfSomeType(x)));
}, [data]);
return <List data={filteredData} />;
```

to it
```
const filteredData = useMemo(() => {
  return data.filter(x => isOfSomeType(x));
}, [data]);
return <List data={filteredData} />;
```
Reference: https://jnystad.no/post/not-using-usecallback-is-premature-optimization