### PR TITLE
refactor: rename TableCell type to Cell

### DIFF
--- a/src/__test__/handle-data.spec.ts
+++ b/src/__test__/handle-data.spec.ts
@@ -1,6 +1,6 @@
 import manageData, { getColumnOrder, getColumnInfo, getTotalInfo, getTotalPosition } from '../handle-data';
 import { generateDataPages, generateLayout } from './generate-test-data';
-import { TableLayout, PageInfo, SetPageInfo, TableData, TableCell, ExtendedNxAttrExprInfo } from '../types';
+import { TableLayout, PageInfo, SetPageInfo, TableData, Cell, ExtendedNxAttrExprInfo } from '../types';
 
 describe('handle-data', () => {
   let layout: TableLayout;
@@ -103,8 +103,8 @@ describe('handle-data', () => {
         setPageInfo
       )) as TableData;
 
-      const firstColCell = rows[0]['col-0'] as TableCell;
-      const secondColCell = rows[0]['col-1'] as TableCell;
+      const firstColCell = rows[0]['col-0'] as Cell;
+      const secondColCell = rows[0]['col-1'] as Cell;
 
       expect(totalColumnCount).toBe(layout.qHyperCube.qSize.qcx);
       expect(totalRowCount).toBe(layout.qHyperCube.qSize.qcy);

--- a/src/table/styles.ts
+++ b/src/table/styles.ts
@@ -1,14 +1,12 @@
-import {
-  styled,
-  Paper,
-  TableContainer,
-  TableRow,
-  TableSortLabel,
-  TableBody,
-  Select,
-  IconButton,
-  TableCell,
-} from '@mui/material';
+import styled from '@mui/system/styled';
+import Paper from '@mui/material/Paper';
+import TableContainer from '@mui/material/TableContainer';
+import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
+import TableBody from '@mui/material/TableBody';
+import Select from '@mui/material/Select';
+import IconButton from '@mui/material/IconButton';
+import TableCell from '@mui/material/TableCell';
 
 // ---------- AnnounceWrapper ----------
 

--- a/src/table/utils/__tests__/handle-accessiblity.spec.ts
+++ b/src/table/utils/__tests__/handle-accessiblity.spec.ts
@@ -1,6 +1,6 @@
 import { MouseEvent } from 'react';
 import { stardust } from '@nebula.js/stardust';
-import { Announce, TotalsPosition, TableCell } from '../../../types';
+import { Announce, TotalsPosition, Cell } from '../../../types';
 import * as handleAccessibility from '../handle-accessibility';
 
 describe('handle-accessibility', () => {
@@ -119,7 +119,7 @@ describe('handle-accessibility', () => {
     const cellData = {
       rawRowIdx: 0,
       rawColIdx: 0,
-    } as TableCell;
+    } as Cell;
 
     beforeEach(() => {
       totalsPosition = 'noTotals';

--- a/src/table/utils/__tests__/handle-key-press.spec.ts
+++ b/src/table/utils/__tests__/handle-key-press.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../handle-key-press';
 import * as handleAccessibility from '../handle-accessibility';
 import * as handleScroll from '../handle-scroll';
-import { Announce, Column, ExtendedSelectionAPI, TableCell, TableLayout, TotalsPosition } from '../../../types';
+import { Announce, Column, ExtendedSelectionAPI, Cell, TableLayout, TotalsPosition } from '../../../types';
 import { TSelectionActions } from '../selections-utils';
 
 describe('handle-key-press', () => {
@@ -451,7 +451,7 @@ describe('handle-key-press', () => {
     let evt: React.KeyboardEvent;
     let rootElement: HTMLElement;
     let selectionsAPI: ExtendedSelectionAPI;
-    let cell: TableCell;
+    let cell: Cell;
     let selectionDispatch: React.Dispatch<TSelectionActions>;
     let isSelectionsEnabled: boolean;
     let setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
@@ -496,7 +496,7 @@ describe('handle-key-press', () => {
         cancel: jest.fn(),
         isModal: () => isModal,
       } as unknown as ExtendedSelectionAPI;
-      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1, isSelectable: true } as unknown as TableCell;
+      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1, isSelectable: true } as unknown as Cell;
       keyboard = { enabled: true } as unknown as stardust.Keyboard;
       selectionDispatch = jest.fn();
       isSelectionsEnabled = true;
@@ -602,7 +602,7 @@ describe('handle-key-press', () => {
       evt.key = ' ';
       cell = {
         isSelectable: false,
-      } as TableCell;
+      } as Cell;
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);

--- a/src/table/utils/__tests__/selections-util.spec.ts
+++ b/src/table/utils/__tests__/selections-util.spec.ts
@@ -12,7 +12,7 @@ import {
   ResetAction,
   ClearAction,
 } from '../selections-utils';
-import { TableCell, SelectionState, ExtendedSelectionAPI, Announce, ContextValue } from '../../../types';
+import { Cell, SelectionState, ExtendedSelectionAPI, Announce, ContextValue } from '../../../types';
 
 describe('selections-utils', () => {
   describe('addSelectionListeners', () => {
@@ -106,7 +106,7 @@ describe('selections-utils', () => {
 
   describe('reducer', () => {
     let state: SelectionState;
-    let cell: TableCell;
+    let cell: Cell;
 
     beforeEach(() => {
       state = {
@@ -120,7 +120,7 @@ describe('selections-utils', () => {
         } as unknown as ExtendedSelectionAPI,
         isSelectMultiValues: false,
       };
-      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1 } as TableCell;
+      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1 } as Cell;
     });
 
     afterEach(() => jest.clearAllMocks());
@@ -310,7 +310,7 @@ describe('selections-utils', () => {
 
   describe('getSelectedRows', () => {
     let selectedRows: Record<string, number>;
-    let cell: TableCell;
+    let cell: Cell;
     let evt: React.KeyboardEvent;
 
     beforeEach(() => {
@@ -318,7 +318,7 @@ describe('selections-utils', () => {
       cell = {
         qElemNumber: 0,
         rowIdx: 0,
-      } as TableCell;
+      } as Cell;
       evt = {} as React.KeyboardEvent;
     });
 
@@ -361,7 +361,7 @@ describe('selections-utils', () => {
 
   describe('getCellSelectionState', () => {
     let isModal: boolean;
-    let cell: TableCell;
+    let cell: Cell;
     let value: ContextValue;
 
     beforeEach(() => {
@@ -369,7 +369,7 @@ describe('selections-utils', () => {
       cell = {
         qElemNumber: 1,
         colIdx: 1,
-      } as TableCell;
+      } as Cell;
       value = {
         selectionState: {
           colIdx: 1,

--- a/src/table/utils/handle-accessibility.ts
+++ b/src/table/utils/handle-accessibility.ts
@@ -1,6 +1,6 @@
 import { MouseEvent } from 'react';
 import { stardust } from '@nebula.js/stardust';
-import { Announce, TableCell, TotalsPosition, CellFocusProps, HandleResetFocusProps } from '../../types';
+import { Announce, Cell, TotalsPosition, CellFocusProps, HandleResetFocusProps } from '../../types';
 
 export const getCellElement = (rootElement: HTMLElement, cellCoord: [number, number]) =>
   rootElement.getElementsByClassName('sn-table-row')[cellCoord[0]]?.getElementsByClassName('sn-table-cell')[
@@ -45,7 +45,7 @@ export const removeAndFocus = (
 };
 
 export const handleClickToFocusBody = (
-  cell: TableCell,
+  cell: Cell,
   rootElement: HTMLElement,
   setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
   keyboard: stardust.Keyboard,

--- a/src/table/utils/selections-utils.ts
+++ b/src/table/utils/selections-utils.ts
@@ -1,7 +1,7 @@
 // TODO: add this to global rules
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import { stardust } from '@nebula.js/stardust';
-import { TableCell, SelectionState, ExtendedSelectionAPI, ActionPayload, Announce, ContextValue } from '../../types';
+import { Cell, SelectionState, ExtendedSelectionAPI, ActionPayload, Announce, ContextValue } from '../../types';
 
 export enum SelectionStates {
   SELECTED = 'selected',
@@ -80,7 +80,7 @@ export function addSelectionListeners({
   };
 }
 
-export const getCellSelectionState = (cell: TableCell, value: ContextValue): SelectionStates => {
+export const getCellSelectionState = (cell: Cell, value: ContextValue): SelectionStates => {
   const {
     selectionState: { colIdx, rows, api },
   } = value;
@@ -113,7 +113,7 @@ export const handleAnnounceSelectionStatus = (announce: Announce, rowsLength: nu
 
 export const getSelectedRows = (
   selectedRows: Record<string, number>,
-  cell: TableCell,
+  cell: Cell,
   evt: React.KeyboardEvent | React.MouseEvent
 ): Record<string, number> => {
   const { qElemNumber, rowIdx } = cell;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { stardust } from '@nebula.js/stardust';
 import { TSelectionActions } from './table/utils/selections-utils';
 
-export interface TableCell {
+export interface Cell {
   qText?: string;
   qAttrExps: EngineAPI.INxAttributeExpressionValues;
   qElemNumber: number;
@@ -50,7 +50,7 @@ export interface AnnounceArgs {
 export type Announce = (arg0: AnnounceArgs) => void;
 
 export interface ActionPayload {
-  cell: TableCell;
+  cell: Cell;
   announce: Announce;
   evt: React.KeyboardEvent | React.MouseEvent;
 }
@@ -100,7 +100,7 @@ export type SetPageInfo = stardust.SetStateFn<PageInfo>;
 
 export interface Row {
   // for the row key, string is needed
-  [key: string]: TableCell | string;
+  [key: string]: Cell | string;
 }
 
 export interface Column {
@@ -234,7 +234,7 @@ export type TotalsPosition = 'top' | 'bottom' | 'noTotals';
 export interface HandleBodyKeyDownProps {
   evt: React.KeyboardEvent;
   rootElement: HTMLElement;
-  cell: TableCell;
+  cell: Cell;
   selectionDispatch: React.Dispatch<TSelectionActions>;
   isSelectionsEnabled: boolean;
   setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;


### PR DESCRIPTION
This was conflicting with mui TableCell and more aligned with the naming of `Column` and `Rox`.  Also fixed the imports for styles file