### PR TITLE
feat: generate typescript definitions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-
 dist
 coverage
 node_modules
@@ -6,3 +5,4 @@ src/table/mui-config.json
 src/locale/locales/*.json
 src/locale/*.json
 src/locale/*.md
+types

--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -1,5 +1,5 @@
 {
-  "scriptappy": "1.0.0",
+  "scriptappy": "1.1.0",
   "info": {
     "name": "@nebula.js/sn-table:properties",
     "description": "Table generic object definition",
@@ -9,176 +9,227 @@
     "x-qlik-visibility": "public"
   },
   "entries": {
-    "properties": {
+    "Properties": {
       "extends": [
         {
-          "type": "GenericObjectProperties"
+          "type": "EngineAPI.IGenericObjectProperties"
         }
       ],
-      "kind": "object",
-      "entries": {
-        "components": {
-          "description": "Holds general styling",
-          "kind": "array",
-          "items": {
-            "type": "#/definitions/Styling"
-          }
-        },
-        "footnote": {
-          "description": "Visualization footnote",
-          "optional": true,
-          "defaultValue": "",
-          "kind": "union",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "StringExpression"
-            }
-          ],
-          "type": "any"
-        },
-        "qHyperCubeDef": {
-          "description": "Extends HyperCubeDef, see Engine API: HyperCubeDef",
-          "extends": [
-            {
-              "type": "HyperCubeDef"
-            }
-          ],
-          "kind": "object",
-          "entries": {
-            "columnWidths": {
-              "kind": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            "qColumnOrder": {
-              "kind": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            "qDimensions": {
-              "description": "The maximum amount of dimensions is 1000",
-              "kind": "array",
-              "items": {
-                "type": "#/definitions/DimensionProperties"
-              }
-            },
-            "qMeasures": {
-              "description": "The maximum amount of measures is 1000",
-              "kind": "array",
-              "items": {
-                "type": "#/definitions/MeasureProperties"
-              }
-            },
-            "qMode": {
-              "defaultValue": "S",
-              "type": "schemasNxHypercubeMode"
-            },
-            "qSuppressMissing": {
-              "defaultValue": true,
-              "type": "boolean"
-            },
-            "qSuppressZero": {
-              "defaultValue": false,
-              "type": "boolean"
-            }
-          }
-        },
-        "showTitles": {
-          "description": "Show title for the visualization",
-          "optional": true,
-          "defaultValue": true,
-          "type": "boolean"
-        },
-        "subtitle": {
-          "description": "Visualization subtitle",
-          "optional": true,
-          "defaultValue": "",
-          "kind": "union",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "StringExpression"
-            }
-          ],
-          "type": "any"
-        },
-        "title": {
-          "description": "Visualization title",
-          "optional": true,
-          "defaultValue": "",
-          "kind": "union",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "StringExpression"
-            }
-          ],
-          "type": "any"
-        },
-        "totals": {
-          "description": "totals settings",
-          "kind": "object",
-          "entries": {
-            "label": {
-              "description": "The label of the totals row, shown in the leftmost column",
-              "optional": true,
-              "defaultValue": "Totals",
-              "type": "string"
-            },
-            "position": {
-              "description": "The position of the totals row, hiding it if set to `noTotals`",
-              "optional": true,
-              "defaultValue": "noTotals",
-              "kind": "union",
-              "items": [
-                {
-                  "kind": "literal",
-                  "value": "'top'"
-                },
-                {
-                  "kind": "literal",
-                  "value": "'bottom'"
-                },
-                {
-                  "kind": "literal",
-                  "value": "'noTotals'"
-                }
-              ],
-              "type": "string"
-            },
-            "show": {
-              "description": "Determines if the way totals row is showing is handle automatically, if `true` the `position` prop will be ignored",
-              "optional": true,
-              "defaultValue": true,
-              "type": "boolean"
-            }
-          }
-        },
-        "version": {
-          "description": "Current version of this generic object definition",
-          "type": "string"
-        }
-      }
+      "kind": "interface",
+      "entries": {}
     }
   },
   "definitions": {
+    "properties.version": {
+      "description": "Current version of this generic object definition",
+      "type": "string"
+    },
+    "HyperCubeProperties": {
+      "description": "Extends HyperCubeDef, see Engine API: HyperCubeDef",
+      "extends": [
+        {
+          "type": "EngineAPI.IHyperCubeDef"
+        }
+      ],
+      "kind": "interface",
+      "entries": {}
+    },
+    "properties.qHyperCubeDef.qDimensions": {
+      "description": "The maximum amount of dimensions is 1000",
+      "kind": "array",
+      "items": {
+        "type": "#/definitions/DimensionProperties"
+      }
+    },
+    "properties.qHyperCubeDef.qMeasures": {
+      "description": "The maximum amount of measures is 1000",
+      "kind": "array",
+      "items": {
+        "type": "#/definitions/MeasureProperties"
+      }
+    },
+    "properties.qHyperCubeDef.qMode": {
+      "defaultValue": "S",
+      "type": "EngineAPI.INxHypercubeMode"
+    },
+    "properties.qHyperCubeDef.qSuppressZero": {
+      "defaultValue": false,
+      "type": "boolean"
+    },
+    "properties.qHyperCubeDef.qSuppressMissing": {
+      "defaultValue": true,
+      "type": "boolean"
+    },
+    "properties.qHyperCubeDef.qColumnOrder": {
+      "kind": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "properties.qHyperCubeDef.columnWidths": {
+      "kind": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "properties.showTitles": {
+      "description": "Show title for the visualization",
+      "optional": true,
+      "defaultValue": true,
+      "type": "boolean"
+    },
+    "properties.title": {
+      "description": "Visualization title",
+      "optional": true,
+      "defaultValue": "",
+      "kind": "union",
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "EngineAPI.IStringExpression"
+        }
+      ]
+    },
+    "properties.subtitle": {
+      "description": "Visualization subtitle",
+      "optional": true,
+      "defaultValue": "",
+      "kind": "union",
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "EngineAPI.IStringExpression"
+        }
+      ]
+    },
+    "properties.footnote": {
+      "description": "Visualization footnote",
+      "optional": true,
+      "defaultValue": "",
+      "kind": "union",
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "EngineAPI.IStringExpression"
+        }
+      ]
+    },
+    "Totals": {
+      "description": "totals settings",
+      "kind": "alias",
+      "items": {
+        "type": "object"
+      }
+    },
+    "properties.totals.show": {
+      "description": "Determines if the way totals row is showing is handle automatically, if `true` the `position` prop will be ignored",
+      "optional": true,
+      "defaultValue": true,
+      "type": "boolean"
+    },
+    "properties.totals.position": {
+      "description": "The position of the totals row, hiding it if set to `noTotals`",
+      "optional": true,
+      "defaultValue": "noTotals",
+      "kind": "union",
+      "items": [
+        {
+          "kind": "literal",
+          "value": "'top'"
+        },
+        {
+          "kind": "literal",
+          "value": "'bottom'"
+        },
+        {
+          "kind": "literal",
+          "value": "'noTotals'"
+        }
+      ]
+    },
+    "properties.totals.label": {
+      "description": "The label of the totals row, shown in the leftmost column",
+      "optional": true,
+      "defaultValue": "Totals",
+      "type": "string"
+    },
+    "properties.components": {
+      "description": "Holds general styling",
+      "nullable": true,
+      "kind": "array",
+      "items": {
+        "type": "#/definitions/Styling"
+      }
+    },
+    "DimensionProperties": {
+      "description": "Extends `NxDimension`, see Engine API: `NxDimension`",
+      "extends": [
+        {
+          "type": "EngineAPI.INxDimension"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "qDef": {
+          "type": "#/definitions/NxInlineMeasureDef"
+        },
+        "qAttributeExpressions": {
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/AttributeExpressionProperties"
+          }
+        }
+      }
+    },
+    "MeasureProperties": {
+      "description": "Extends `NxMeasure`, see Engine API: `NxMeasure`",
+      "extends": [
+        {
+          "type": "EngineAPI.INxMeasure"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "qDef": {
+          "type": "#/definitions/NxInlineMeasureDef"
+        },
+        "qAttributeExpressions": {
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/AttributeExpressionProperties"
+          }
+        }
+      }
+    },
+    "NxInlineMeasureDef": {
+      "description": "Extends `NxInlineMeasureDef`, see Engine API: `NxInlineMeasureDef`.",
+      "extends": [
+        {
+          "type": "EngineAPI.INxInlineMeasureDef"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "textAlign": {
+          "optional": true,
+          "type": "#/definitions/TextAlign"
+        }
+      }
+    },
     "AttributeExpressionProperties": {
       "description": "Extends `NxAttrExprDef`, see Engine API: `NxAttrExprDef`.\nColumn specific styling overrides general styling, that is defined in `components`.",
       "extends": [
         {
-          "type": "NxAttrExprDef"
+          "type": "EngineAPI.INxAttrExprDef"
         }
       ],
-      "kind": "object",
+      "kind": "interface",
       "entries": {
         "id": {
           "description": "specifying what the color applies to",
@@ -192,14 +243,50 @@
               "kind": "literal",
               "value": "'cellBackgroundColor'"
             }
-          ],
+          ]
+        }
+      }
+    },
+    "TextAlign": {
+      "description": "Holds text alignment for a specific column.",
+      "extends": [
+        {
+          "type": "EngineAPI.INxInlineDimensionDef"
+        }
+      ],
+      "kind": "interface",
+      "entries": {
+        "auto": {
+          "description": "If true, sets the alignment based on the type of column (left for dimension, right for measure)",
+          "type": "boolean"
+        },
+        "align": {
+          "description": "Is used (and mandatory) if `auto` is false",
+          "type": "boolean"
+        }
+      }
+    },
+    "Styling": {
+      "description": "General styling for all columns.\nSplit up into header and content (body) styling.\nIf any property is not set, default values specific for each property is used.",
+      "kind": "interface",
+      "entries": {
+        "key": {
+          "description": "This should be set to `theme`",
           "type": "string"
+        },
+        "content": {
+          "optional": true,
+          "type": "#/definitions/ContentStyling"
+        },
+        "header": {
+          "optional": true,
+          "type": "#/definitions/HeaderStyling"
         }
       }
     },
     "ContentStyling": {
       "description": "Holds properties for font size, font color and hover styling.",
-      "kind": "object",
+      "kind": "interface",
       "entries": {
         "fontSize": {
           "description": "Defaults to `14`",
@@ -228,29 +315,9 @@
         }
       }
     },
-    "DimensionProperties": {
-      "description": "Extends `NxDimension`, see Engine API: `NxDimension`",
-      "extends": [
-        {
-          "type": "NxDimension"
-        }
-      ],
-      "kind": "object",
-      "entries": {
-        "qDef": {
-          "type": "#/definitions/InlineDimensionDef"
-        },
-        "qAttributeExpressions": {
-          "kind": "array",
-          "items": {
-            "type": "#/definitions/AttributeExpressionProperties"
-          }
-        }
-      }
-    },
     "HeaderStyling": {
       "description": "Holds properties for font size and color.",
-      "kind": "object",
+      "kind": "interface",
       "entries": {
         "fontSize": {
           "description": "Defaults to `14`",
@@ -264,59 +331,9 @@
         }
       }
     },
-    "InlineDimensionDef": {
-      "description": "Extends `NxInlineDimensionDef`, see Engine API: `NxInlineDimensionDef`.",
-      "extends": [
-        {
-          "type": "NxInlineDimensionDef"
-        }
-      ],
-      "kind": "object",
-      "entries": {
-        "textAlign": {
-          "optional": true,
-          "type": "#/definitions/TextAlign"
-        }
-      }
-    },
-    "InlineMeasureDef": {
-      "description": "Extends `NxInlineMeasureDef`, see Engine API: `NxInlineMeasureDef`.",
-      "extends": [
-        {
-          "type": "NxInlineMeasureDef"
-        }
-      ],
-      "kind": "object",
-      "entries": {
-        "textAlign": {
-          "optional": true,
-          "type": "#/definitions/TextAlign"
-        }
-      }
-    },
-    "MeasureProperties": {
-      "description": "Extends `NxMeasure`, see Engine API: `NxMeasure`",
-      "extends": [
-        {
-          "type": "NxMeasure"
-        }
-      ],
-      "kind": "object",
-      "entries": {
-        "qDef": {
-          "type": "NxInlineMeasureDef"
-        },
-        "qAttributeExpressions": {
-          "kind": "array",
-          "items": {
-            "type": "#/definitions/AttributeExpressionProperties"
-          }
-        }
-      }
-    },
     "PaletteColor": {
       "description": "Color information structure. Holds the actual color and index in palette",
-      "kind": "object",
+      "kind": "interface",
       "entries": {
         "color": {
           "description": "Color as hex string (mandatory if index: -1)",
@@ -324,58 +341,6 @@
         },
         "index": {
           "description": "Index in palette",
-          "type": "number"
-        }
-      }
-    },
-    "Styling": {
-      "description": "General styling for all columns.\nSplit up into header and content (body) styling.\nIf any property is not set, default values specific for each property is used.",
-      "kind": "object",
-      "entries": {
-        "key": {
-          "description": "This should be set to `theme`",
-          "type": "string"
-        },
-        "content": {
-          "optional": true,
-          "type": "#/definitions/ContentStyling"
-        },
-        "header": {
-          "optional": true,
-          "type": "#/definitions/HeaderStyling"
-        }
-      }
-    },
-    "TextAlign": {
-      "description": "Holds text alignment for a specific column.",
-      "extends": [
-        {
-          "type": "NxInlineDimensionDef"
-        }
-      ],
-      "kind": "object",
-      "entries": {
-        "auto": {
-          "description": "If true, sets the alignment based on the type of column (left for dimension, right for measure)",
-          "type": "boolean"
-        },
-        "align": {
-          "description": "Is used (and mandatory) if `auto` is false",
-          "kind": "union",
-          "items": [
-            {
-              "kind": "literal",
-              "value": "'left'"
-            },
-            {
-              "kind": "literal",
-              "value": "'center'"
-            },
-            {
-              "kind": "literal",
-              "value": "'right'"
-            }
-          ],
           "type": "string"
         }
       }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "type": "git",
     "url": "https://github.com/qlik-oss/sn-table.git"
   },
+  "types": "types/index.d.ts",
   "files": [
     "dist",
     "api-specifications",
     "core",
-    "sn-table-ext"
+    "sn-table-ext",
+    "types"
   ],
   "engines": {
     "node": ">=16"
@@ -44,12 +46,13 @@
     "copy:ext": "node ./tools/copy-ext.js",
     "locale:verify": "node src/locale/tools/verify-translations.ts",
     "locale:generate": "node src/locale/scripts/generate-all.mjs",
-    "spec": "scriptappy-from-jsdoc -c ./spec-configs/props.conf.js",
+    "spec": "sy from-jsdoc -c ./spec-configs/props.conf.js",
+    "dts": "sy to-dts -c ./spec-configs/props.conf.js",
     "test:unit": "jest",
     "test:rendering": "playwright test",
     "test:local:rendering": "./test/rendering/scripts/run-rendering-test.sh",
     "test:local:update:screenshots": "./test/rendering/scripts/update-screenshots.sh",
-    "prepublishOnly": "NODE_ENV=production yarn run build && yarn spec",
+    "prepublishOnly": "NODE_ENV=production yarn run build && yarn spec && yarn dts",
     "prepack": "./tools/prepare-sn-pack.js",
     "prepare": "husky install",
     "preversion": "yarn build",
@@ -114,7 +117,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.69.4",
-    "scriptappy-from-jsdoc": "0.7.0",
+    "@scriptappy/cli": "0.1.0",
+    "@scriptappy/to-dts": "1.0.0-beta.4",
     "shx": "0.3.4",
     "styled-components": "5.3.5",
     "stylis": "3.5.4",

--- a/spec-configs/props.conf.js
+++ b/spec-configs/props.conf.js
@@ -3,53 +3,61 @@ const path = require('path');
 const pkg = require(path.resolve(__dirname, '../package.json')); // eslint-disable-line
 
 module.exports = {
-  glob: ['./src/qae/object-properties.js'],
-  package: path.resolve(__dirname, '../package.json'),
-  api: {
-    stability: 'experimental',
-    properties: {
-      'x-qlik-visibility': 'public',
+  fromJsdoc: {
+    glob: ['./src/qae/object-properties.js'],
+    package: path.resolve(__dirname, '../package.json'),
+    api: {
+      stability: 'experimental',
+      properties: {
+        'x-qlik-visibility': 'public',
+      },
+      visibility: 'public',
+      name: `${pkg.name}:properties`,
+      version: pkg.version,
+      description: 'Table generic object definition',
     },
-    visibility: 'public',
-    name: `${pkg.name}:properties`,
-    version: pkg.version,
-    description: 'Table generic object definition',
+    output: {
+      file: path.resolve(__dirname, '../api-specifications/properties.json'),
+    },
+    parse: {
+      types: {
+        'EngineAPI.IGenericObjectProperties': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FGenericObjectProperties',
+        },
+        'EngineAPI.INxDimension': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxDimension',
+        },
+        'EngineAPI.INxMeasure': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxMeasure',
+        },
+        'EngineAPI.IHyperCubeDef': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FHyperCubeDef',
+        },
+        'EngineAPI.INxHypercubeMode': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxHypercubeMode',
+        },
+        'EngineAPI.IStringExpression': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas/#%23%2Fdefinitions%2Fschemas%2Fentries%2FStringExpression',
+        },
+        'EngineAPI.INxAttrExprDef': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxAttrExprDef',
+        },
+        'EngineAPI.INxInlineDimensionDef': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxInlineDimensionDef',
+        },
+        'EngineAPI.INxInlineMeasureDef': {
+          url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxInlineMeasureDef',
+        },
+      },
+    },
   },
-  output: {
-    file: path.resolve(__dirname, '../api-specifications/properties.json'),
-  },
-  parse: {
-    types: {
-      GenericObjectProperties: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FGenericObjectProperties',
-      },
-      NxDimension: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxDimension',
-      },
-      NxMeasure: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxMeasure',
-      },
-      HyperCubeDef: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FHyperCubeDef',
-      },
-      NxHypercubeMode: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxHypercubeMode',
-      },
-      StringExpression: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas/#%23%2Fdefinitions%2Fschemas%2Fentries%2FStringExpression',
-      },
-      schemasNxHypercubeMode: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas/#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxHypercubeMode',
-      },
-      NxAttrExprDef: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxAttrExprDef',
-      },
-      NxInlineDimensionDef: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxInlineDimensionDef',
-      },
-      NxInlineMeasureDef: {
-        url: 'https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxInlineMeasureDef',
-      },
+  toDts: {
+    spec: './api-specifications/properties.json',
+    output: {
+      file: './types/index.d.ts',
+    },
+    dependencies: {
+      references: ['qlik-engineapi'],
     },
   },
 };

--- a/src/qae/object-properties.js
+++ b/src/qae/object-properties.js
@@ -1,5 +1,6 @@
 /**
- * @extends {GenericObjectProperties}
+ * @interface Properties
+ * @extends {EngineAPI.IGenericObjectProperties}
  * @entry
  */
 const properties = {
@@ -11,7 +12,8 @@ const properties = {
   version: JSON.stringify(process.env.PACKAGE_VERSION),
   /**
    * Extends HyperCubeDef, see Engine API: HyperCubeDef
-   * @extends {HyperCubeDef}
+   * @interface HyperCubeProperties
+   * @extends {EngineAPI.IHyperCubeDef}
    */
   qHyperCubeDef: {
     /**
@@ -24,7 +26,7 @@ const properties = {
      * @type {MeasureProperties[]}
      */
     qMeasures: [],
-    /** @type {schemasNxHypercubeMode} */
+    /** @type {EngineAPI.INxHypercubeMode} */
     qMode: 'S',
     /** @type {boolean} */
     qSuppressZero: false,
@@ -42,22 +44,22 @@ const properties = {
   showTitles: true,
   /**
    * Visualization title
-   * @type {(string|StringExpression)=}
+   * @type {(string|EngineAPI.IStringExpression)=}
    */
   title: '',
   /**
    * Visualization subtitle
-   * @type {(string|StringExpression)=}
+   * @type {(string|EngineAPI.IStringExpression)=}
    */
   subtitle: '',
   /**
    * Visualization footnote
-   * @type {(string|StringExpression)=}
+   * @type {(string|EngineAPI.IStringExpression)=}
    */
   footnote: '',
   /**
    * totals settings
-   * @type {object}
+   * @typedef {object} Totals
    */
   totals: {
     /**
@@ -85,46 +87,39 @@ const properties = {
 
 /**
  * Extends `NxDimension`, see Engine API: `NxDimension`
- * @typedef {object} DimensionProperties
- * @extends NxDimension
- * @property {InlineDimensionDef} qDef
- * @property {AttributeExpressionProperties[]} qAttributeExpressions
- */
-
-/**
- * Extends `NxMeasure`, see Engine API: `NxMeasure`
- * @typedef {object} MeasureProperties
- * @extends NxMeasure
+ * @interface DimensionProperties
+ * @extends EngineAPI.INxDimension
  * @property {NxInlineMeasureDef} qDef
  * @property {AttributeExpressionProperties[]} qAttributeExpressions
  */
 
 /**
- * Extends `NxInlineDimensionDef`, see Engine API: `NxInlineDimensionDef`.
- * @typedef {object} InlineDimensionDef
- * @extends NxInlineDimensionDef
- * @property {TextAlign=} textAlign
+ * Extends `NxMeasure`, see Engine API: `NxMeasure`
+ * @interface MeasureProperties
+ * @extends EngineAPI.INxMeasure
+ * @property {NxInlineMeasureDef} qDef
+ * @property {AttributeExpressionProperties[]} qAttributeExpressions
  */
 
 /**
  * Extends `NxInlineMeasureDef`, see Engine API: `NxInlineMeasureDef`.
- * @typedef {object} InlineMeasureDef
- * @extends NxInlineMeasureDef
+ * @interface NxInlineMeasureDef
+ * @extends EngineAPI.INxInlineMeasureDef
  * @property {TextAlign=} textAlign
  */
 
 /**
  * Extends `NxAttrExprDef`, see Engine API: `NxAttrExprDef`.
  * Column specific styling overrides general styling, that is defined in `components`.
- * @typedef {object} AttributeExpressionProperties
- * @extends NxAttrExprDef - expression resolving into a valid color
+ * @interface AttributeExpressionProperties
+ * @extends EngineAPI.INxAttrExprDef - expression resolving into a valid color
  * @property {('cellForegroundColor'|'cellBackgroundColor')} id - specifying what the color applies to
  */
 
 /**
  * Holds text alignment for a specific column.
- * @typedef {object} TextAlign
- * @extends NxInlineDimensionDef
+ * @interface TextAlign
+ * @extends EngineAPI.INxInlineDimensionDef
  * @property {boolean} auto - If true, sets the alignment based on the type of column (left for dimension, right for measure)
  * @property {('left'|'center'|'right')} align - Is used (and mandatory) if `auto` is false
  */
@@ -133,7 +128,7 @@ const properties = {
  * General styling for all columns.
  * Split up into header and content (body) styling.
  * If any property is not set, default values specific for each property is used.
- * @typedef {object} Styling
+ * @interface Styling
  * @property {string} key - This should be set to `theme`
  * @property {ContentStyling=} content
  * @property {HeaderStyling=} header
@@ -141,7 +136,7 @@ const properties = {
 
 /**
  * Holds properties for font size, font color and hover styling.
- * @typedef {object} ContentStyling
+ * @interface ContentStyling
  * @property {number=} fontSize - Defaults to `14`
  * @property {PaletteColor=} fontColor - Defaults to `#404040`
  * @property {boolean=} hoverEffect - Toggles hover effect
@@ -151,14 +146,14 @@ const properties = {
 
 /**
  * Holds properties for font size and color.
- * @typedef {object} HeaderStyling
+ * @interface HeaderStyling
  * @property {number=} fontSize - Defaults to `14`
  * @property {PaletteColor=} fontColor - Defaults to `#404040`
  */
 
 /**
  * Color information structure. Holds the actual color and index in palette
- * @typedef {object} PaletteColor
+ * @interface PaletteColor
  * @property {string} color - Color as hex string (mandatory if index: -1)
  * @property {number} index - Index in palette
  */

--- a/tools/validate-nebula-package.js
+++ b/tools/validate-nebula-package.js
@@ -5,7 +5,7 @@ const validateScripts = (pkg) => {
   if (pkg.scripts.build !== 'yarn run locale:generate && node ./tools/build.js --core --ext && shx cp assets/* dist') {
     throw new Error('package.json does not have correct build script');
   }
-  if (pkg.scripts.prepublishOnly !== 'NODE_ENV=production yarn run build && yarn spec') {
+  if (pkg.scripts.prepublishOnly !== 'NODE_ENV=production yarn run build && yarn spec && yarn dts') {
     throw new Error('package.json does not have correct prepublishOnly script');
   }
   if (pkg.scripts.prepack !== './tools/prepare-sn-pack.js') {
@@ -45,11 +45,12 @@ const validateFiles = (pkg) => {
     'bugs',
     'repository',
     'files',
+    'types',
     'main',
     'peerDependencies',
   ];
   // files
-  const mustHaveFiles = ['dist', 'core', 'api-specifications', 'sn-table-ext'];
+  const mustHaveFiles = ['dist', 'core', 'api-specifications', 'sn-table-ext', 'types'];
   const allowedFiles = ['assets', ...mustHaveFiles];
   const missing = mustHaveFiles.filter((f) => (pkg.files || []).indexOf(f) === -1);
   if (missing.length) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,130 @@
+// File generated automatically by "@scriptappy/to-dts"; DO NOT EDIT.
+/// <reference types="qlik-engineapi" />
+export = Properties;
+
+declare interface Properties extends EngineAPI.IGenericObjectProperties{
+}
+
+declare namespace Properties {
+    type properties.version = string;
+
+    /**
+     * Extends HyperCubeDef, see Engine API: HyperCubeDef
+     */
+    interface HyperCubeProperties extends EngineAPI.IHyperCubeDef{
+    }
+
+    type properties.qHyperCubeDef.qDimensions = Properties.DimensionProperties[];
+
+    type properties.qHyperCubeDef.qMeasures = Properties.MeasureProperties[];
+
+    type properties.qHyperCubeDef.qMode = EngineAPI.INxHypercubeMode;
+
+    type properties.qHyperCubeDef.qSuppressZero = boolean;
+
+    type properties.qHyperCubeDef.qSuppressMissing = boolean;
+
+    type properties.qHyperCubeDef.qColumnOrder = number[];
+
+    type properties.qHyperCubeDef.columnWidths = number[];
+
+    type properties.showTitles = boolean;
+
+    type properties.title = string | EngineAPI.IStringExpression;
+
+    type properties.subtitle = string | EngineAPI.IStringExpression;
+
+    type properties.footnote = string | EngineAPI.IStringExpression;
+
+    /**
+     * totals settings
+     */
+    type Totals = object;
+
+    type properties.totals.show = boolean;
+
+    type properties.totals.position = "top" | "bottom" | "noTotals";
+
+    type properties.totals.label = string;
+
+    type properties.components = Properties.Styling[];
+
+    /**
+     * Extends `NxDimension`, see Engine API: `NxDimension`
+     */
+    interface DimensionProperties extends EngineAPI.INxDimension{
+        qDef: Properties.NxInlineMeasureDef;
+        qAttributeExpressions: Properties.AttributeExpressionProperties[];
+    }
+
+    /**
+     * Extends `NxMeasure`, see Engine API: `NxMeasure`
+     */
+    interface MeasureProperties extends EngineAPI.INxMeasure{
+        qDef: Properties.NxInlineMeasureDef;
+        qAttributeExpressions: Properties.AttributeExpressionProperties[];
+    }
+
+    /**
+     * Extends `NxInlineMeasureDef`, see Engine API: `NxInlineMeasureDef`.
+     */
+    interface NxInlineMeasureDef extends EngineAPI.INxInlineMeasureDef{
+        textAlign?: Properties.TextAlign;
+    }
+
+    /**
+     * Extends `NxAttrExprDef`, see Engine API: `NxAttrExprDef`.
+     * Column specific styling overrides general styling, that is defined in `components`.
+     */
+    interface AttributeExpressionProperties extends EngineAPI.INxAttrExprDef{
+        id: "cellForegroundColor" | "cellBackgroundColor";
+    }
+
+    /**
+     * Holds text alignment for a specific column.
+     */
+    interface TextAlign extends EngineAPI.INxInlineDimensionDef{
+        auto: boolean;
+        align: boolean;
+    }
+
+    /**
+     * General styling for all columns.
+     * Split up into header and content (body) styling.
+     * If any property is not set, default values specific for each property is used.
+     */
+    interface Styling {
+        key: string;
+        content?: Properties.ContentStyling;
+        header?: Properties.HeaderStyling;
+    }
+
+    /**
+     * Holds properties for font size, font color and hover styling.
+     */
+    interface ContentStyling {
+        fontSize?: number;
+        fontColor?: Properties.PaletteColor;
+        hoverEffect?: boolean;
+        hoverColor?: Properties.PaletteColor;
+        hoverFontColor?: Properties.PaletteColor;
+    }
+
+    /**
+     * Holds properties for font size and color.
+     */
+    interface HeaderStyling {
+        fontSize?: number;
+        fontColor?: Properties.PaletteColor;
+    }
+
+    /**
+     * Color information structure. Holds the actual color and index in palette
+     */
+    interface PaletteColor {
+        color: string;
+        index: string;
+    }
+
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1756,14 +1756,6 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@mrmlnc/readdir-enhanced@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
-  integrity sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==
-  dependencies:
-    call-me-maybe "^1.0.1"
-    glob-to-regexp "^0.3.0"
-
 "@mui/base@5.0.0-alpha.92":
   version "5.0.0-alpha.92"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.92.tgz#5c2ca31801fe21a8fec9bfda2cf5f44b1e3c7284"
@@ -1957,11 +1949,6 @@
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
-
-"@nodelib/fs.stat@^1.1.2":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
-  integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@nodelib/fs.walk@^1.2.3":
   version "1.2.8"
@@ -2238,6 +2225,41 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@scriptappy/cli@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@scriptappy/cli/-/cli-0.1.0.tgz#f496790457a3e4c99c720eabeca4f6499f7300ab"
+  integrity sha512-bTLWKMz4XexH+D01/cr8VhTbP/+yxhULVn/znBxYbG4BqJiZzp2Vy5e3vwVE4mLhzNySk5SWSTiy9oK+mS14bg==
+  dependencies:
+    "@scriptappy/from-jsdoc" "0.8.0"
+    import-cwd "3.0.0"
+    yargs "11.0.0"
+
+"@scriptappy/from-jsdoc@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@scriptappy/from-jsdoc/-/from-jsdoc-0.8.0.tgz#4b2aab4ac510e2574767a9015b9f5b96d0db1352"
+  integrity sha512-C8tt0HLHumsXOXPlXdlTVUI4YIbS6Y7Ti1cy7LvYkxEl/CCcP67NWcIPHhW99VE6wxRfAvgwnYm8fxonPX95yg==
+  dependencies:
+    "@scriptappy/schema" "1.1.0"
+    chokidar "3.5.2"
+    extend "3.0.2"
+    globby "11.0.0"
+    jsdoc "3.6.7"
+    scriptappy-tools "0.5.0"
+    yargs "15.1.0"
+
+"@scriptappy/schema@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scriptappy/schema/-/schema-1.1.0.tgz#ad3ddffb81ed0e3ffdbfb9e86ef575f3feb0429e"
+  integrity sha512-HiiW0niupVqK3qbIyWyMLIQoyjCjAzl2DqwSdWap6Cm97xN3XqW2wDKMIzsGCeSYCjaMY+dGaRK2ENSMW2mdlA==
+
+"@scriptappy/to-dts@1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@scriptappy/to-dts/-/to-dts-1.0.0-beta.4.tgz#0b366a62022f87a17b1abde1964656df8a121a56"
+  integrity sha512-YbaoUzQrwxePOFCqVtlbrdsmrP4u5haBp5seHEw5WdrZx/jEALeEenw63xLkLQmUfTPLZ+R8rRSZFyvFb7z8SQ==
+  dependencies:
+    dts-dom "^3.1.0"
+    extend "3.0.2"
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
@@ -2468,14 +2490,6 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/glob@^7.1.1":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
-  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.2", "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -2541,33 +2555,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/linkify-it@*":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
-  integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
-
-"@types/markdown-it@^12.2.3":
-  version "12.2.3"
-  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-12.2.3.tgz#0d6f6e5e413f8daaa26522904597be3d6cd93b51"
-  integrity sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==
-  dependencies:
-    "@types/linkify-it" "*"
-    "@types/mdurl" "*"
-
-"@types/mdurl@*":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
-  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
-
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
-
-"@types/minimatch@*":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
-  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -3252,22 +3243,10 @@ array-includes@^3.1.4, array-includes@^3.1.5:
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
-array-union@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  integrity sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==
-  dependencies:
-    array-uniq "^1.0.1"
-
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-  integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -3728,11 +3707,6 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-call-me-maybe@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
-  integrity sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw==
-
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -3851,7 +3825,22 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@3.5.3, chokidar@^3.0.0, chokidar@^3.4.0, chokidar@^3.5.3:
+chokidar@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -3954,15 +3943,6 @@ cliui@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
-
-cliui@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
-  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
-  dependencies:
-    string-width "^3.1.0"
-    strip-ansi "^5.2.0"
-    wrap-ansi "^5.1.0"
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -4796,13 +4776,6 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-dir-glob@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
-  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
-  dependencies:
-    path-type "^3.0.0"
-
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -4908,6 +4881,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dts-dom@^3.1.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/dts-dom/-/dts-dom-3.6.0.tgz#0e8beaf6240e699d623bf4d7dcf0e6216222459a"
+  integrity sha512-on5jxTgt+A6r0Zyyz6ZRHXaAO7J1VPnOd6+AmvI1vH440AlAZZNc5rUHzgPuTjGlrVr1rOWQYNl7ZJK6rDohbw==
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -4934,11 +4912,6 @@ emittery@^0.10.2:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.2.tgz#902eec8aedb8c41938c46e9385e9db7e03182933"
   integrity sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==
-
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -4975,10 +4948,10 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
-  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+entities@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 envinfo@^7.7.2:
   version "7.8.1"
@@ -5563,19 +5536,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
-  integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
-  dependencies:
-    "@mrmlnc/readdir-enhanced" "^2.2.1"
-    "@nodelib/fs.stat" "^1.1.2"
-    glob-parent "^3.1.0"
-    is-glob "^4.0.0"
-    merge2 "^1.2.3"
-    micromatch "^3.1.10"
-
-fast-glob@^3.2.11, fast-glob@^3.2.9:
+fast-glob@^3.1.1, fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -5987,14 +5948,6 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
-  integrity sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==
-  dependencies:
-    is-glob "^3.1.0"
-    path-dirname "^1.0.0"
-
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -6008,11 +5961,6 @@ glob-parent@^6.0.1:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
-
-glob-to-regexp@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
-  integrity sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -6050,6 +5998,18 @@ globals@^13.15.0:
   dependencies:
     type-fest "^0.20.2"
 
+globby@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
+  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz#29047105582427ab6eca4f905200667b056da515"
@@ -6072,20 +6032,6 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
-
-globby@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
-  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
-  dependencies:
-    "@types/glob" "^7.1.1"
-    array-union "^1.0.2"
-    dir-glob "^2.2.2"
-    fast-glob "^2.2.6"
-    glob "^7.1.3"
-    ignore "^4.0.3"
-    pify "^4.0.1"
-    slash "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -6412,12 +6358,7 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
-  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
-ignore@^5.2.0:
+ignore@^5.1.4, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -6686,7 +6627,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.0, is-extglob@^2.1.1:
+is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
@@ -6717,13 +6658,6 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
-
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  integrity sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==
-  dependencies:
-    is-extglob "^2.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
@@ -7457,7 +7391,7 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js2xmlparser@^4.0.2:
+js2xmlparser@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-4.0.2.tgz#2a1fdf01e90585ef2ae872a01bc169c6a8d5e60a"
   integrity sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==
@@ -7494,26 +7428,25 @@ jscodeshift@^0.13.1:
     temp "^0.8.4"
     write-file-atomic "^2.3.0"
 
-jsdoc@^3.6.2:
-  version "3.6.11"
-  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.6.11.tgz#8bbb5747e6f579f141a5238cbad4e95e004458ce"
-  integrity sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==
+jsdoc@3.6.7:
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.6.7.tgz#00431e376bed7f9de4716c6f15caa80e64492b89"
+  integrity sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==
   dependencies:
     "@babel/parser" "^7.9.4"
-    "@types/markdown-it" "^12.2.3"
     bluebird "^3.7.2"
     catharsis "^0.9.0"
     escape-string-regexp "^2.0.0"
-    js2xmlparser "^4.0.2"
+    js2xmlparser "^4.0.1"
     klaw "^3.0.0"
-    markdown-it "^12.3.2"
-    markdown-it-anchor "^8.4.1"
-    marked "^4.0.10"
+    markdown-it "^10.0.0"
+    markdown-it-anchor "^5.2.7"
+    marked "^2.0.3"
     mkdirp "^1.0.4"
     requizzle "^0.2.3"
     strip-json-comments "^3.1.0"
     taffydb "2.6.2"
-    underscore "~1.13.2"
+    underscore "~1.13.1"
 
 jsdom@^19.0.0:
   version "19.0.0"
@@ -7734,10 +7667,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
   dependencies:
     uc.micro "^1.0.1"
 
@@ -7981,26 +7914,26 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it-anchor@^8.4.1:
-  version "8.6.4"
-  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz#affb8aa0910a504c114e9fcad53ac3a5b907b0e6"
-  integrity sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==
+markdown-it-anchor@^5.2.7:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz#d549acd64856a8ecd1bea58365ef385effbac744"
+  integrity sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==
 
-markdown-it@^12.3.2:
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
-  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
   dependencies:
-    argparse "^2.0.1"
-    entities "~2.1.0"
-    linkify-it "^3.0.1"
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-marked@^4.0.10:
-  version "4.0.18"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.18.tgz#cd0ac54b2e5610cfb90e8fd46ccaa8292c9ed569"
-  integrity sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==
+marked@^2.0.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
+  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -8070,7 +8003,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
+merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -9008,11 +8941,6 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
-
-path-dirname@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
-  integrity sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -10223,25 +10151,7 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
-scriptappy-from-jsdoc@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/scriptappy-from-jsdoc/-/scriptappy-from-jsdoc-0.7.0.tgz#6ef2b88ddf1e189fb29e4076fd97af48a5d1bdc6"
-  integrity sha512-xKmeI9OVBl6DzbmDvLMSuHyiahSpkza2Q0BANcVH7xIIdj4wxFPkFTL6cIZXYzB8Rv4ENcWzXAr7LpSrH2gP/w==
-  dependencies:
-    chokidar "^3.0.0"
-    extend "^3.0.1"
-    globby "^9.2.0"
-    jsdoc "^3.6.2"
-    scriptappy-schema "^1.0.0"
-    scriptappy-tools "^0.5.0"
-    yargs "^13.2.4"
-
-scriptappy-schema@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/scriptappy-schema/-/scriptappy-schema-1.0.0.tgz#3900fc28c64048fbb49135726da59631b26774f7"
-  integrity sha512-RuKjLaP56rL04GcBNs3jU18h7Nk8Ltulz1FppHMq6yepXZBIWPiiuWwkhHoPTJCCJvOqCrCrYx6tlQ8acoSrwA==
-
-scriptappy-tools@^0.5.0:
+scriptappy-tools@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/scriptappy-tools/-/scriptappy-tools-0.5.0.tgz#b06b4a15ac83b3ee399a01a1b07d7aae0b226eba"
   integrity sha512-hmxNBjuYNAdLCBcPCmcMund2FORT5agtqDcvudXqW+JSbCXPVhF8zSPdcRH+n/D908LWL5ZE+Pp6t8tZz+QhDQ==
@@ -10764,15 +10674,6 @@ string-width@^2.0.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0, string-width@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -10851,7 +10752,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -11382,7 +11283,7 @@ unbzip2-stream@1.4.3:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore@~1.13.2:
+underscore@~1.13.1:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.4.tgz#7886b46bbdf07f768e0052f1828e1dcab40c0dee"
   integrity sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==
@@ -11771,15 +11672,6 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
-  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
-  dependencies:
-    ansi-styles "^3.2.0"
-    string-width "^3.0.0"
-    strip-ansi "^5.0.0"
-
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -11912,10 +11804,10 @@ yaml@^2.1.1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
   integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
 
-yargs-parser@^13.1.2:
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
-  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -11944,6 +11836,48 @@ yargs-parser@^8.1.0:
   integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha512-CswCfdOgCr4MMsT1GzbEJ7Z2uYudWyrGX8Bgh/0eyCzj/DXWdKq6a/ADufkzI1WAOIW6jYaXJvRyLhDO0kfqBw==
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  integrity sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
+
+yargs@15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
+  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^16.1.0"
 
 yargs@17.4.1:
   version "17.4.1"
@@ -11988,22 +11922,6 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
-
-yargs@^13.2.4:
-  version "13.3.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
-  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
-  dependencies:
-    cliui "^5.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^13.1.2"
 
 yargs@^15.1.0, yargs@^15.3.1:
   version "15.4.1"


### PR DESCRIPTION
To generate a TypeScript Declaration File for sn-table
- Using @scriptappy/cli(includes @scriptappy/from-jsdoc) to generate a scriptappy definition in JSON (api-specifications/properties.json) from JSDoc (src/qae/object-properties.js)
- Using @scriptappy/cli and @scriptappy/to-dts to generate a TypeScript Declaration File (types/index.d.ts) from the scriptappy definition 
