### PR TITLE
fix: block ArrowUp on header

### DIFF
--- a/src/table/utils/__tests__/handle-key-press.spec.ts
+++ b/src/table/utils/__tests__/handle-key-press.spec.ts
@@ -392,6 +392,15 @@ describe('handle-key-press', () => {
       expect(changeSortOrder).not.toHaveBeenCalled();
       expect(setFocusedCellCoord).not.toHaveBeenCalled();
     });
+
+    it('when press ArrowUp should call nothing but preventDefaultBehavior', () => {
+      evt.key = 'ArrowUp';
+      callHandleHeadKeyDown();
+      expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+      expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(changeSortOrder).not.toHaveBeenCalled();
+      expect(setFocusedCellCoord).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleTotalKeyDown', () => {

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -128,6 +128,9 @@ export const handleHeadKeyDown = ({
   setFocusedCellCoord,
 }: HandleHeadKeyDownProps) => {
   switch (evt.key) {
+    case 'ArrowUp':
+      preventDefaultBehavior(evt);
+      break;
     case 'ArrowDown':
     case 'ArrowRight':
     case 'ArrowLeft':


### PR DESCRIPTION
This bubbled to somewhere and made the focus go left for some reason.