### PR TITLE
fix: move total to reduce rerenders

### DIFF
--- a/src/table/components/TableBodyWrapper.tsx
+++ b/src/table/components/TableBodyWrapper.tsx
@@ -8,6 +8,7 @@ import { handleBodyKeyDown, handleBodyKeyUp } from '../utils/handle-key-press';
 import { handleClickToFocusBody } from '../utils/handle-accessibility';
 import { Cell } from '../../types';
 import { TableBodyWrapperProps } from '../types';
+import TableTotals from './TableTotals';
 
 function TableBodyWrapper({
   rootElement,
@@ -20,7 +21,6 @@ function TableBodyWrapper({
   keyboard,
   tableWrapperRef,
   announce,
-  children,
 }: TableBodyWrapperProps) {
   const { rows, columns, paginationNeeded, totalsPosition } = tableData;
   const columnsStylingIDsJSON = JSON.stringify(columns.map((column) => column.stylingIDs));
@@ -50,9 +50,13 @@ function TableBodyWrapper({
     });
   }, []);
 
+  const totals = (
+    <TableTotals rootElement={rootElement} tableData={tableData} theme={theme} layout={layout} keyboard={keyboard} />
+  );
+
   return (
     <StyledTableBody paginationNeeded={paginationNeeded} bodyCellStyle={bodyCellStyle}>
-      {totalsPosition === 'top' ? children : undefined}
+      {totalsPosition === 'top' ? totals : undefined}
       {rows.map((row) => (
         <StyledBodyRow
           bodyCellStyle={bodyCellStyle}
@@ -106,7 +110,7 @@ function TableBodyWrapper({
           })}
         </StyledBodyRow>
       ))}
-      {totalsPosition === 'bottom' ? children : undefined}
+      {totalsPosition === 'bottom' ? totals : undefined}
     </StyledTableBody>
   );
 }

--- a/src/table/components/TableWrapper.tsx
+++ b/src/table/components/TableWrapper.tsx
@@ -4,7 +4,6 @@ import Table from '@mui/material/Table';
 import AnnounceElements from './AnnounceElements';
 import TableBodyWrapper from './TableBodyWrapper';
 import TableHeadWrapper from './TableHeadWrapper';
-import TableTotals from './TableTotals';
 import FooterWrapper from './FooterWrapper';
 import { useContextSelector, TableContext } from '../context';
 import { StyledTableContainer, StyledTableWrapper } from '../styles';
@@ -119,9 +118,7 @@ export default function TableWrapper(props: TableWrapperProps) {
       >
         <Table stickyHeader aria-label={tableAriaLabel}>
           <TableHeadWrapper {...props} />
-          <TableBodyWrapper {...props} setShouldRefocus={setShouldRefocus} tableWrapperRef={tableWrapperRef}>
-            <TableTotals {...props} />
-          </TableBodyWrapper>
+          <TableBodyWrapper {...props} setShouldRefocus={setShouldRefocus} tableWrapperRef={tableWrapperRef} />
         </Table>
       </StyledTableContainer>
       {!constraints.active && (

--- a/src/table/components/__tests__/TableBodyWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableBodyWrapper.spec.tsx
@@ -24,7 +24,6 @@ describe('<TableBodyWrapper />', () => {
   let selectionsAPI: ExtendedSelectionAPI;
   let layout: TableLayout;
   let theme: ExtendedTheme;
-  let children: JSX.Element;
   let tableFirstRow: Cell;
   let tableSecondRow: Cell;
 
@@ -42,9 +41,7 @@ describe('<TableBodyWrapper />', () => {
           keyboard={keyboard}
           tableWrapperRef={tableWrapperRef}
           announce={announce}
-        >
-          {children}
-        </TableBodyWrapper>
+        />
       </TableContextProvider>
     );
 

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -182,7 +182,6 @@ export interface TableBodyWrapperProps extends CommonTableProps {
   announce: Announce;
   setShouldRefocus(): void;
   tableWrapperRef: React.MutableRefObject<HTMLDivElement | undefined>;
-  children: JSX.Element;
 }
 
 export interface TableTotalsProps extends CommonTableProps {


### PR DESCRIPTION
Previously the totals component was passed as a child to the body. This was to reduce props drilling. Totals is memoed using React.memo and it used to work works. This is what the profiler looks like, the totals don't rerender when the body does. But it is the children property that makes the body update (I have a snippet to test this). Feels really backwards to me, but maybe that is how is should work. Anyway, adding totals inside the body component instead, works!