### PR TITLE
chore!: remove module section from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "node": ">=16"
   },
   "main": "dist/sn-table.js",
-  "module": "core/esm/index.js",
   "scripts": {
     "build": "yarn run locale:generate && node ./tools/build.js --core --ext && shx cp assets/* dist",
     "build:dev": "yarn run locale:generate && node ./tools/build.js --core --ext --mode development && shx cp assets/* dist",


### PR DESCRIPTION
head:
Now the core/esm/index.js does not have react and react-dom code.

BREAK CHANGE:
for the mashup, people have to install react and react-dom if they want to use sn-table using es module.