### PR TITLE
chore: remove extra nebula build

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -58,21 +58,21 @@ const configureReactNative = () => {
 
 const main = async () => {
   console.log('---> BUILDING SUPERNOVA');
+
   const watcher = await build(buildArgs);
   if (buildExt) {
     buildExtension();
     if (watch) {
       watcher.on('event', (event) => {
-        if (event.code === 'BUNDLE_END') {
-          buildExtension();
-        }
+        event.code === 'BUNDLE_END' && buildExtension();
       });
     }
   }
+
   if (reactNative) {
     configureReactNative();
+    await build(buildArgs);
   }
-  build(buildArgs);
 };
 
 main();


### PR DESCRIPTION
`const watcher = await build(buildArgs);` already does the build step
when not in reactNative build, no need to run `build(buildArgs)` again.