### PR TITLE
refactor: break out click functions to seperate file and move focus stuff to a11y file

### DIFF
--- a/src/table/components/TableBodyWrapper.tsx
+++ b/src/table/components/TableBodyWrapper.tsx
@@ -5,7 +5,7 @@ import { StyledTableBody, StyledBodyRow } from '../styles';
 import { addSelectionListeners } from '../utils/selections-utils';
 import { getBodyCellStyle } from '../utils/styling-utils';
 import { handleBodyKeyDown, handleBodyKeyUp } from '../utils/handle-key-press';
-import { handleClickToFocusBody } from '../utils/handle-accessibility';
+import { handleClickToFocusBody } from '../utils/handle-click';
 import { Cell } from '../../types';
 import { TableBodyWrapperProps } from '../types';
 import TableTotals from './TableTotals';

--- a/src/table/components/TableHeadWrapper.tsx
+++ b/src/table/components/TableHeadWrapper.tsx
@@ -6,7 +6,7 @@ import { useContextSelector, TableContext } from '../context';
 import { VisuallyHidden, StyledHeadRow, StyledSortLabel } from '../styles';
 import { getHeaderStyle } from '../utils/styling-utils';
 import { handleHeadKeyDown } from '../utils/handle-key-press';
-import { handleMouseDownLabelToFocusHeadCell, handleClickToFocusHead } from '../utils/handle-accessibility';
+import { handleMouseDownLabelToFocusHeadCell, handleClickToFocusHead } from '../utils/handle-click';
 import { TableHeadWrapperProps } from '../types';
 
 function TableHeadWrapper({

--- a/src/table/components/TableTotals.tsx
+++ b/src/table/components/TableTotals.tsx
@@ -2,7 +2,7 @@ import React, { memo, useMemo } from 'react';
 import { useContextSelector, TableContext } from '../context';
 import { getTotalsCellStyle } from '../utils/styling-utils';
 import { handleTotalKeyDown } from '../utils/handle-key-press';
-import { removeAndFocus } from '../utils/handle-accessibility';
+import { removeTabAndFocusCell } from '../utils/accessibility-utils';
 import { StyledHeadRow, StyledTotalsCell } from '../styles';
 import { TableTotalsProps } from '../types';
 
@@ -30,7 +30,7 @@ function TableTotals({ rootElement, tableData, theme, layout, keyboard, selectio
               handleTotalKeyDown(e, rootElement, cellCoord, setFocusedCellCoord, selectionsAPI.isModal());
             }}
             onMouseDown={() => {
-              removeAndFocus(cellCoord, rootElement, setFocusedCellCoord, keyboard);
+              removeTabAndFocusCell(cellCoord, rootElement, setFocusedCellCoord, keyboard);
             }}
           >
             {column.totalInfo}

--- a/src/table/components/TableWrapper.tsx
+++ b/src/table/components/TableWrapper.tsx
@@ -13,7 +13,7 @@ import useDidUpdateEffect from '../hooks/use-did-update-effect';
 import useFocusListener from '../hooks/use-focus-listener';
 import useScrollListener from '../hooks/use-scroll-listener';
 import { handleWrapperKeyDown } from '../utils/handle-key-press';
-import { updateFocus, handleResetFocus, getCellElement } from '../utils/handle-accessibility';
+import { updateFocus, resetFocus, getCellElement } from '../utils/accessibility-utils';
 import { TableWrapperProps } from '../types';
 
 export default function TableWrapper(props: TableWrapperProps) {
@@ -82,7 +82,7 @@ export default function TableWrapper(props: TableWrapperProps) {
   // Except for first render, whenever the size of the data (number of rows per page, rows, columns) or page changes,
   // reset tabindex to first cell. If some cell had focus, focus the first cell as well.
   useDidUpdateEffect(() => {
-    handleResetFocus({
+    resetFocus({
       focusedCellCoord,
       rootElement,
       shouldRefocus,

--- a/src/table/components/__tests__/PaginationContent.spec.tsx
+++ b/src/table/components/__tests__/PaginationContent.spec.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { stardust } from '@nebula.js/stardust';
 
 import PaginationContent from '../PaginationContent';
-import * as handleAccessibility from '../../utils/handle-accessibility';
+import * as handleAccessibility from '../../utils/accessibility-utils';
 import { Announce, ExtendedTheme, ExtendedTranslator, PageInfo, SetPageInfo, TableData } from '../../../types';
 
 describe('<PaginationContent />', () => {

--- a/src/table/components/__tests__/TableBodyWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableBodyWrapper.spec.tsx
@@ -8,7 +8,7 @@ import TableBodyWrapper from '../TableBodyWrapper';
 import * as selectionsUtils from '../../utils/selections-utils';
 import * as getCellRenderer from '../../utils/get-cell-renderer';
 import * as handleKeyPress from '../../utils/handle-key-press';
-import * as handleAccessibility from '../../utils/handle-accessibility';
+import * as handleClick from '../../utils/handle-click';
 import { TableData, ExtendedSelectionAPI, TableLayout, ExtendedTheme, PageInfo, Cell } from '../../../types';
 
 describe('<TableBodyWrapper />', () => {
@@ -91,12 +91,12 @@ describe('<TableBodyWrapper />', () => {
   });
 
   it('should call handleClickToFocusBody on mouseDown', () => {
-    jest.spyOn(handleAccessibility, 'handleClickToFocusBody').mockImplementation();
+    jest.spyOn(handleClick, 'handleClickToFocusBody').mockImplementation();
 
     const { getByText } = renderTableBody();
     fireEvent.mouseDown(getByText(tableFirstRow.qText as string));
 
-    expect(handleAccessibility.handleClickToFocusBody).toHaveBeenCalledTimes(1);
+    expect(handleClick.handleClickToFocusBody).toHaveBeenCalledTimes(1);
   });
 
   it('should call handleBodyKeyUp on key up', () => {

--- a/src/table/components/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from '@testing-library/react';
 import TableHeadWrapper from '../TableHeadWrapper';
 import { TableContextProvider } from '../../context';
 import * as handleKeyPress from '../../utils/handle-key-press';
-import * as handleAccessibility from '../../utils/handle-accessibility';
+import * as handleClick from '../../utils/handle-click';
 import {
   TableData,
   TableLayout,
@@ -117,14 +117,14 @@ describe('<TableHeadWrapper />', () => {
   });
 
   it('should call handleClickToFocusHead and handleMouseDownLabelToFocusHeadCell when clicking a header cell label', () => {
-    jest.spyOn(handleAccessibility, 'handleClickToFocusHead').mockImplementation(() => jest.fn());
-    jest.spyOn(handleAccessibility, 'handleMouseDownLabelToFocusHeadCell').mockImplementation(() => jest.fn());
+    jest.spyOn(handleClick, 'handleClickToFocusHead').mockImplementation(() => jest.fn());
+    jest.spyOn(handleClick, 'handleMouseDownLabelToFocusHeadCell').mockImplementation(() => jest.fn());
 
     const { getByText } = renderTableHead();
     fireEvent.mouseDown(getByText(tableData.columns[0].label));
 
-    expect(handleAccessibility.handleClickToFocusHead).toHaveBeenCalledTimes(1);
-    expect(handleAccessibility.handleMouseDownLabelToFocusHeadCell).toHaveBeenCalledTimes(1);
+    expect(handleClick.handleClickToFocusHead).toHaveBeenCalledTimes(1);
+    expect(handleClick.handleMouseDownLabelToFocusHeadCell).toHaveBeenCalledTimes(1);
   });
 
   it('should change `aria-pressed` and `aria-sort` when you sort by second column', () => {

--- a/src/table/components/__tests__/TableTotals.spec.tsx
+++ b/src/table/components/__tests__/TableTotals.spec.tsx
@@ -5,7 +5,7 @@ import TableTotals from '../TableTotals';
 import { TableContextProvider } from '../../context';
 import { getTotalPosition } from '../../../handle-data';
 import * as handleKeyPress from '../../utils/handle-key-press';
-import * as handleAccessibility from '../../utils/handle-accessibility';
+import * as handleAccessibility from '../../utils/accessibility-utils';
 import { generateLayout } from '../../../__test__/generate-test-data';
 import { TableData, ExtendedTheme, TableLayout, ExtendedSelectionAPI } from '../../../types';
 
@@ -78,10 +78,10 @@ describe('<TableTotals />', () => {
     });
 
     it('should call removeAndFocus when clicking a total cell', () => {
-      jest.spyOn(handleAccessibility, 'removeAndFocus').mockImplementation(() => jest.fn());
+      jest.spyOn(handleAccessibility, 'removeTabAndFocusCell').mockImplementation(() => jest.fn());
       const { getByText } = renderTableTotals();
       fireEvent.mouseDown(getByText(tableData.columns[0].totalInfo as string));
-      expect(handleAccessibility.removeAndFocus).toHaveBeenCalledTimes(1);
+      expect(handleAccessibility.removeTabAndFocusCell).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/table/hooks/use-focus-listener.ts
+++ b/src/table/hooks/use-focus-listener.ts
@@ -1,6 +1,6 @@
 import { stardust } from '@nebula.js/stardust';
 import { useEffect } from 'react';
-import { handleFocusoutEvent } from '../utils/handle-accessibility';
+import { handleFocusoutEvent } from '../utils/accessibility-utils';
 
 const useFocusListener = (
   tableWrapperRef: React.MutableRefObject<HTMLDivElement | undefined>,

--- a/src/table/utils/__tests__/accessiblity-utils.spec.ts
+++ b/src/table/utils/__tests__/accessiblity-utils.spec.ts
@@ -1,7 +1,7 @@
-import { MouseEvent } from 'react';
 import { stardust } from '@nebula.js/stardust';
-import { Announce, TotalsPosition, Cell } from '../../../types';
-import * as handleAccessibility from '../handle-accessibility';
+import React from 'react';
+import { Announce } from '../../../types';
+import * as accessibilityUtils from '../accessibility-utils';
 
 describe('handle-accessibility', () => {
   let cell: HTMLTableCellElement | undefined;
@@ -9,7 +9,6 @@ describe('handle-accessibility', () => {
   let rootElement: HTMLElement;
   let focusedCellCoord: [number, number];
   let setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
-  let evt: MouseEvent;
 
   beforeEach(() => {
     cell = { focus: jest.fn(), blur: jest.fn(), setAttribute: jest.fn() } as unknown as HTMLTableCellElement;
@@ -37,7 +36,7 @@ describe('handle-accessibility', () => {
     });
 
     it('should focus cell and call setAttribute when focusType is focus', () => {
-      handleAccessibility.updateFocus({ focusType, cell });
+      accessibilityUtils.updateFocus({ focusType, cell });
       expect(cell?.focus).toHaveBeenCalledTimes(1);
       expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '0');
     });
@@ -45,7 +44,7 @@ describe('handle-accessibility', () => {
     it('should blur cell and call setAttribute when focusType is blur', () => {
       focusType = 'blur';
 
-      handleAccessibility.updateFocus({ focusType, cell });
+      accessibilityUtils.updateFocus({ focusType, cell });
       expect(cell?.blur).toHaveBeenCalledTimes(1);
       expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '-1');
     });
@@ -53,7 +52,7 @@ describe('handle-accessibility', () => {
     it('should call setAttribute when focusType is addTab', () => {
       focusType = 'addTab';
 
-      handleAccessibility.updateFocus({ focusType, cell });
+      accessibilityUtils.updateFocus({ focusType, cell });
       expect(cell?.focus).not.toHaveBeenCalled();
       expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '0');
     });
@@ -61,14 +60,14 @@ describe('handle-accessibility', () => {
     it('should call setAttribute when focusType is removeTab', () => {
       focusType = 'removeTab';
 
-      handleAccessibility.updateFocus({ focusType, cell });
+      accessibilityUtils.updateFocus({ focusType, cell });
       expect(cell?.blur).not.toHaveBeenCalled();
       expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '-1');
     });
 
     it('should early return and not throw error when cell is undefined', () => {
       cell = undefined;
-      expect(() => handleAccessibility.updateFocus({ focusType, cell })).not.toThrow();
+      expect(() => accessibilityUtils.updateFocus({ focusType, cell })).not.toThrow();
     });
   });
 
@@ -91,7 +90,7 @@ describe('handle-accessibility', () => {
     it('should return active td element', () => {
       cell = elementCreator('td', '0') as HTMLTableCellElement;
 
-      const cellElement = handleAccessibility.findCellWithTabStop(rootElement);
+      const cellElement = accessibilityUtils.findCellWithTabStop(rootElement);
 
       expect(cellElement).not.toBeNull();
       expect(cellElement.tagName).toBe('TD');
@@ -100,7 +99,7 @@ describe('handle-accessibility', () => {
 
     it('should return active th element', () => {
       cell = elementCreator('th', '0') as HTMLTableCellElement;
-      const cellElement = handleAccessibility.findCellWithTabStop(rootElement);
+      const cellElement = accessibilityUtils.findCellWithTabStop(rootElement);
 
       expect(cellElement).not.toBeNull();
       expect(cellElement.tagName).toBe('TH');
@@ -109,77 +108,8 @@ describe('handle-accessibility', () => {
 
     it('should return null', () => {
       cell = elementCreator('div', '-1') as HTMLTableCellElement;
-      const cellElement = handleAccessibility.findCellWithTabStop(rootElement);
+      const cellElement = accessibilityUtils.findCellWithTabStop(rootElement);
       expect(cellElement).toBeNull();
-    });
-  });
-
-  describe('handleClickToFocusBody', () => {
-    let totalsPosition: TotalsPosition;
-    const cellData = {
-      rawRowIdx: 0,
-      rawColIdx: 0,
-    } as Cell;
-
-    beforeEach(() => {
-      totalsPosition = 'noTotals';
-    });
-
-    it('should indirectly call setFocusedCellCoord with adjusted index, and keyboard.focus', () => {
-      handleAccessibility.handleClickToFocusBody(cellData, rootElement, setFocusedCellCoord, keyboard, totalsPosition);
-      expect(cell?.setAttribute).toHaveBeenCalledTimes(1);
-      expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '-1');
-      expect(setFocusedCellCoord).toHaveBeenCalledTimes(1);
-      expect(setFocusedCellCoord).toHaveBeenCalledWith([1, 0]);
-      expect(keyboard.focus).toHaveBeenCalledTimes(1);
-    });
-
-    it('should indirectly call setFocusedCellCoord with adjusted index, but not keyboard.focus when keyboard.enabled is falsey', () => {
-      keyboard.enabled = false;
-
-      handleAccessibility.handleClickToFocusBody(cellData, rootElement, setFocusedCellCoord, keyboard, totalsPosition);
-      expect(cell?.setAttribute).toHaveBeenCalledTimes(1);
-      expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '-1');
-      expect(setFocusedCellCoord).toHaveBeenCalledTimes(1);
-      expect(setFocusedCellCoord).toHaveBeenCalledWith([1, 0]);
-      expect(keyboard.focus).not.toHaveBeenCalled();
-    });
-
-    it('should indirectly call setFocusedCellCoord with index adjusted for totals on top, and keyboard.focus', () => {
-      totalsPosition = 'top';
-
-      handleAccessibility.handleClickToFocusBody(cellData, rootElement, setFocusedCellCoord, keyboard, totalsPosition);
-      expect(cell?.setAttribute).toHaveBeenCalledTimes(1);
-      expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '-1');
-      expect(setFocusedCellCoord).toHaveBeenCalledTimes(1);
-      expect(setFocusedCellCoord).toHaveBeenCalledWith([2, 0]);
-      expect(keyboard.focus).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('handleClickToFocusHead', () => {
-    const columnIndex = 2;
-
-    it('should indirectly call updateFocus, setFocusedCellCoord and keyboard.focus', () => {
-      handleAccessibility.handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard);
-      expect(cell?.setAttribute).toHaveBeenCalledTimes(1);
-      expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '-1');
-      expect(setFocusedCellCoord).toHaveBeenCalledTimes(1);
-      expect(setFocusedCellCoord).toHaveBeenCalledWith([0, 2]);
-      expect(keyboard.focus).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('handleMouseDownLabelToFocusHeadCell', () => {
-    evt = { preventDefault: jest.fn() } as unknown as MouseEvent;
-    const columnIndex = 0;
-
-    it('should indirectly call updateFocus, setFocusedCellCoord and keyboard.focus', () => {
-      handleAccessibility.handleMouseDownLabelToFocusHeadCell(evt, rootElement, columnIndex);
-      expect(evt.preventDefault).toHaveBeenCalledTimes(1);
-      expect(cell?.focus).toHaveBeenCalledTimes(1);
-      expect(cell?.setAttribute).toHaveBeenCalledTimes(1);
-      expect(cell?.setAttribute).toHaveBeenCalledWith('tabIndex', '0');
     });
   });
 
@@ -190,7 +120,7 @@ describe('handle-accessibility', () => {
     let totalsPosition: string;
 
     const resetFocus = () =>
-      handleAccessibility.handleResetFocus({
+      accessibilityUtils.resetFocus({
         focusedCellCoord,
         rootElement,
         shouldRefocus,
@@ -328,7 +258,7 @@ describe('handle-accessibility', () => {
     });
 
     it('should call blur and remove announcements when currentTarget does not contain relatedTarget, shouldRefocus is false and keyboard.enabled is true', () => {
-      handleAccessibility.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
+      accessibilityUtils.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
       expect(keyboard.blur).toHaveBeenCalledWith(false);
       expect(announcement1.innerHTML).toBe('');
       expect(announcement2.innerHTML).toBe('');
@@ -337,21 +267,21 @@ describe('handle-accessibility', () => {
     it('should not call blur when currentTarget contains relatedTarget', () => {
       containsRelatedTarget = true;
 
-      handleAccessibility.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
+      accessibilityUtils.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
       expect(keyboard.blur).not.toHaveBeenCalled();
     });
 
     it('should not call blur when shouldRefocus is true', () => {
       shouldRefocus.current = true;
 
-      handleAccessibility.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
+      accessibilityUtils.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
       expect(keyboard.blur).not.toHaveBeenCalled();
     });
 
     it('should not call blur when keyboard.enabled is false', () => {
       keyboard.enabled = false;
 
-      handleAccessibility.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
+      accessibilityUtils.handleFocusoutEvent(focusoutEvent, shouldRefocus, keyboard);
       expect(keyboard.blur).not.toHaveBeenCalled();
     });
   });
@@ -370,14 +300,14 @@ describe('handle-accessibility', () => {
     });
 
     it('should call parentElement.focus when clientConfirmButton exists', () => {
-      handleAccessibility.focusSelectionToolbar(element, keyboard, last);
+      accessibilityUtils.focusSelectionToolbar(element, keyboard, last);
       expect(parentElement?.focus).toHaveBeenCalledTimes(1);
       expect(keyboard.focusSelection).not.toHaveBeenCalled();
     });
 
     it("should call keyboard.focusSelection when clientConfirmButton doesn't exist", () => {
       parentElement = null;
-      handleAccessibility.focusSelectionToolbar(element, keyboard, last);
+      accessibilityUtils.focusSelectionToolbar(element, keyboard, last);
       expect(keyboard.focusSelection).toHaveBeenCalledWith(false);
     });
   });
@@ -400,21 +330,205 @@ describe('handle-accessibility', () => {
     });
 
     it('should do nothing when not in selection mode', () => {
-      handleAccessibility.announceSelectionState(announce, nextCell, isSelectionMode);
+      accessibilityUtils.announceSelectionState(announce, nextCell, isSelectionMode);
       expect(announce).not.toHaveBeenCalled();
     });
 
     it('should call announce with SelectedValue key when in selection mode and value is selected', () => {
       isSelectionMode = true;
       isSelected = true;
-      handleAccessibility.announceSelectionState(announce, nextCell, isSelectionMode);
+      accessibilityUtils.announceSelectionState(announce, nextCell, isSelectionMode);
       expect(announce).toHaveBeenCalledWith({ keys: ['SNTable.SelectionLabel.SelectedValue'] });
     });
 
     it('should Call announce with NotSelectedValue key when in selection mode and value is not selected', () => {
       isSelectionMode = true;
-      handleAccessibility.announceSelectionState(announce, nextCell, isSelectionMode);
+      accessibilityUtils.announceSelectionState(announce, nextCell, isSelectionMode);
       expect(announce).toHaveBeenCalledWith({ keys: ['SNTable.SelectionLabel.NotSelectedValue'] });
+    });
+  });
+
+  describe('getNextCellCoord', () => {
+    let rowCount: number;
+    let columnCount: number;
+    let rowIndex: number;
+    let colIndex: number;
+    let evt: React.KeyboardEvent;
+
+    beforeEach(() => {
+      evt = {} as unknown as React.KeyboardEvent;
+      rowCount = 1;
+      columnCount = 1;
+      rootElement = {
+        getElementsByClassName: (className: string) =>
+          className === 'sn-table-row' ? Array(rowCount) : Array(columnCount),
+      } as unknown as HTMLElement;
+      rowIndex = 0;
+      colIndex = 0;
+    });
+
+    it('should stay the current cell when move down', () => {
+      evt.key = 'ArrowDown';
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(0);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should not move to the next row when the totals row is set at the bottom', () => {
+      evt.key = 'ArrowDown';
+      const allowedRows = { top: 0, bottom: 1 };
+      rowCount = 3;
+      rowIndex = 1;
+      colIndex = 0;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(
+        evt,
+        rootElement,
+        [rowIndex, colIndex],
+        allowedRows
+      );
+      expect(nextRow).toBe(1);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should stay the current cell when move up', () => {
+      evt.key = 'ArrowUp';
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(0);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should go to one row down cell', () => {
+      evt.key = 'ArrowDown';
+      rowCount = 2;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(1);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should go to one row up cell', () => {
+      evt.key = 'ArrowUp';
+      rowCount = 2;
+      rowIndex = 1;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(0);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should go to one column left cell', () => {
+      evt.key = 'ArrowLeft';
+      columnCount = 2;
+      colIndex = 1;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(0);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should go to one column right cell', () => {
+      evt.key = 'ArrowRight';
+      columnCount = 2;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(0);
+      expect(nextCol).toBe(1);
+    });
+
+    it('should stay the current cell when other keys are pressed', () => {
+      evt.key = 'Control';
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(0);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should move to the next row when you reach to the end of the current row', () => {
+      evt.key = 'ArrowRight';
+      rowCount = 3;
+      columnCount = 3;
+      rowIndex = 1;
+      colIndex = 3;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(2);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should move to the prev row when we reach to the beginning of the current row', () => {
+      evt.key = 'ArrowLeft';
+      rowCount = 3;
+      columnCount = 3;
+      rowIndex = 2;
+      colIndex = 0;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(1);
+      expect(nextCol).toBe(2);
+    });
+
+    it('should stay at the first row and first col of table when we reached to the beginning of the table', () => {
+      evt.key = 'ArrowLeft';
+      rowCount = 2;
+      columnCount = 2;
+      rowIndex = 0;
+      colIndex = 0;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(0);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should stay at the end row and end col of table when you reached to the end of the table', () => {
+      evt.key = 'ArrowRight';
+      rowCount = 2;
+      columnCount = 2;
+      rowIndex = 1;
+      colIndex = 1;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
+      expect(nextRow).toBe(1);
+      expect(nextCol).toBe(1);
+    });
+
+    it('should stay at the current cell when allowedRows cell index is 1 and trying to move up from rowIdx 1', () => {
+      evt.key = 'ArrowUp';
+      const allowedRows = { top: 1, bottom: 0 };
+      rowCount = 3;
+      rowIndex = 1;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(
+        evt,
+        rootElement,
+        [rowIndex, colIndex],
+        allowedRows
+      );
+      expect(nextRow).toBe(1);
+      expect(nextCol).toBe(0);
+    });
+
+    it('should stay at the current cell when trying to move left and allowedRows is > 0 (i.e in selection mode', () => {
+      evt.key = 'ArrowLeft';
+      const allowedRows = { top: 1, bottom: 0 };
+      rowCount = 3;
+      columnCount = 3;
+      rowIndex = 1;
+      colIndex = 1;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(
+        evt,
+        rootElement,
+        [rowIndex, colIndex],
+        allowedRows
+      );
+      expect(nextRow).toBe(1);
+      expect(nextCol).toBe(1);
+    });
+
+    it('should stay at the current cell when trying to move right and allowedRows is > 0 (i.e in selection mode', () => {
+      evt.key = 'ArrowRight';
+      const allowedRows = { top: 1, bottom: 0 };
+      rowCount = 3;
+      columnCount = 3;
+      rowIndex = 1;
+      colIndex = 1;
+      const [nextRow, nextCol] = accessibilityUtils.getNextCellCoord(
+        evt,
+        rootElement,
+        [rowIndex, colIndex],
+        allowedRows
+      );
+      expect(nextRow).toBe(1);
+      expect(nextCol).toBe(1);
     });
   });
 });

--- a/src/table/utils/__tests__/accessiblity-utils.spec.ts
+++ b/src/table/utils/__tests__/accessiblity-utils.spec.ts
@@ -113,7 +113,7 @@ describe('handle-accessibility', () => {
     });
   });
 
-  describe('handleResetFocus', () => {
+  describe('resetFocus', () => {
     let shouldRefocus: React.MutableRefObject<boolean>;
     let isSelectionMode: boolean;
     let announce: Announce;
@@ -529,6 +529,23 @@ describe('handle-accessibility', () => {
       );
       expect(nextRow).toBe(1);
       expect(nextCol).toBe(1);
+    });
+  });
+
+  describe('removeTabAndFocusCell', () => {
+    const newCoord: [number, number] = [1, 1];
+
+    it('should call setFocusedCellCoord but not keyboard.focus when keyboard.enabled is false', () => {
+      keyboard.enabled = false;
+      accessibilityUtils.removeTabAndFocusCell(newCoord, rootElement, setFocusedCellCoord, keyboard);
+      expect(setFocusedCellCoord).toHaveBeenCalledWith(newCoord);
+      expect(keyboard.focus).not.toHaveBeenCalled();
+    });
+
+    it('should call update setFocusedCellCoord and keyboard.focus when keyboard.enabled is true', () => {
+      accessibilityUtils.removeTabAndFocusCell(newCoord, rootElement, setFocusedCellCoord, keyboard);
+      expect(setFocusedCellCoord).toHaveBeenCalledWith(newCoord);
+      expect(keyboard.focus).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/table/utils/__tests__/handle-click.spec.ts
+++ b/src/table/utils/__tests__/handle-click.spec.ts
@@ -1,0 +1,81 @@
+import { MouseEvent } from 'react';
+import { stardust } from '@nebula.js/stardust';
+import { TotalsPosition, Cell } from '../../../types';
+import { handleClickToFocusBody, handleClickToFocusHead, handleMouseDownLabelToFocusHeadCell } from '../handle-click';
+import * as accessibilityUtils from '../accessibility-utils';
+
+describe('handle-click', () => {
+  const keyboard = {} as unknown as stardust.Keyboard;
+  const rootElement = {} as unknown as HTMLDivElement;
+  const cell = { focus: () => undefined, setAttribute: () => undefined } as unknown as HTMLTableCellElement;
+  let setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
+  let evt: MouseEvent;
+
+  beforeEach(() => {
+    evt = { preventDefault: jest.fn() } as unknown as MouseEvent;
+    setFocusedCellCoord = jest.fn();
+    jest.spyOn(accessibilityUtils, 'removeTabAndFocusCell').mockImplementation(() => undefined);
+    jest.spyOn(accessibilityUtils, 'updateFocus');
+    jest.spyOn(accessibilityUtils, 'getCellElement').mockImplementation(() => cell);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('handleClickToFocusBody', () => {
+    let totalsPosition: TotalsPosition;
+    const cellData = {
+      rawRowIdx: 0,
+      rawColIdx: 0,
+    } as Cell;
+
+    beforeEach(() => {
+      totalsPosition = 'noTotals';
+    });
+
+    it('should call removeTabAndFocusCell with cellCoord [1,0]', () => {
+      handleClickToFocusBody(cellData, rootElement, setFocusedCellCoord, keyboard, totalsPosition);
+      expect(accessibilityUtils.removeTabAndFocusCell).toHaveBeenCalledWith(
+        [1, 0],
+        rootElement,
+        setFocusedCellCoord,
+        keyboard
+      );
+    });
+
+    it('should call removeTabAndFocusCell with cellCoord [2,0] when totals is on top', () => {
+      totalsPosition = 'top';
+      handleClickToFocusBody(cellData, rootElement, setFocusedCellCoord, keyboard, totalsPosition);
+      expect(accessibilityUtils.removeTabAndFocusCell).toHaveBeenCalledWith(
+        [2, 0],
+        rootElement,
+        setFocusedCellCoord,
+        keyboard
+      );
+    });
+  });
+
+  describe('handleClickToFocusHead', () => {
+    const columnIndex = 2;
+
+    it('should call removeTabAndFocusCell with cellCoord [0,2]', () => {
+      handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard);
+      expect(accessibilityUtils.removeTabAndFocusCell).toHaveBeenCalledWith(
+        [0, 2],
+        rootElement,
+        setFocusedCellCoord,
+        keyboard
+      );
+    });
+  });
+
+  describe('handleMouseDownLabelToFocusHeadCell', () => {
+    const columnIndex = 1;
+
+    it('should call updateFocus and getCellElement with head cell at given column', () => {
+      handleMouseDownLabelToFocusHeadCell(evt, rootElement, columnIndex);
+      expect(evt.preventDefault).toHaveBeenCalled();
+      expect(accessibilityUtils.getCellElement).toHaveBeenCalledWith(rootElement, [0, 1]);
+      expect(accessibilityUtils.updateFocus).toHaveBeenCalledWith({ focusType: 'focus', cell });
+    });
+  });
+});

--- a/src/table/utils/__tests__/handle-key-press.spec.ts
+++ b/src/table/utils/__tests__/handle-key-press.spec.ts
@@ -2,16 +2,15 @@ import { stardust } from '@nebula.js/stardust';
 import React from 'react';
 
 import {
-  handleWrapperKeyDown,
-  getNextCellCoord,
   shouldBubble,
+  handleWrapperKeyDown,
   handleBodyKeyDown,
   handleHeadKeyDown,
   handleTotalKeyDown,
   handleLastTab,
   handleBodyKeyUp,
 } from '../handle-key-press';
-import * as handleAccessibility from '../handle-accessibility';
+import * as handleAccessibility from '../accessibility-utils';
 import * as handleScroll from '../handle-scroll';
 import { Announce, Column, ExtendedSelectionAPI, Cell, TableLayout, TotalsPosition } from '../../../types';
 import { TSelectionActions } from '../selections-utils';
@@ -244,171 +243,6 @@ describe('handle-key-press', () => {
       expect(evt.preventDefault).not.toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).not.toHaveBeenCalledTimes(1);
       expect(keyboard.blur).not.toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('getNextCellCoord', () => {
-    let evt: React.KeyboardEvent;
-    let rowCount: number;
-    let columnCount: number;
-    let rowIndex: number;
-    let colIndex: number;
-    let rootElement: HTMLElement;
-
-    beforeEach(() => {
-      evt = {} as unknown as React.KeyboardEvent;
-      rowCount = 1;
-      columnCount = 1;
-      rootElement = {
-        getElementsByClassName: (className: string) =>
-          className === 'sn-table-row' ? Array(rowCount) : Array(columnCount),
-      } as unknown as HTMLElement;
-      rowIndex = 0;
-      colIndex = 0;
-    });
-
-    it('should stay the current cell when move down', () => {
-      evt.key = 'ArrowDown';
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(0);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should not move to the next row when the totals row is set at the bottom', () => {
-      evt.key = 'ArrowDown';
-      const allowedRows = { top: 0, bottom: 1 };
-      rowCount = 3;
-      rowIndex = 1;
-      colIndex = 0;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex], allowedRows);
-      expect(nextRow).toBe(1);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should stay the current cell when move up', () => {
-      evt.key = 'ArrowUp';
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(0);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should go to one row down cell', () => {
-      evt.key = 'ArrowDown';
-      rowCount = 2;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(1);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should go to one row up cell', () => {
-      evt.key = 'ArrowUp';
-      rowCount = 2;
-      rowIndex = 1;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(0);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should go to one column left cell', () => {
-      evt.key = 'ArrowLeft';
-      columnCount = 2;
-      colIndex = 1;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(0);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should go to one column right cell', () => {
-      evt.key = 'ArrowRight';
-      columnCount = 2;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(0);
-      expect(nextCol).toBe(1);
-    });
-
-    it('should stay the current cell when other keys are pressed', () => {
-      evt.key = 'Control';
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(0);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should move to the next row when you reach to the end of the current row', () => {
-      evt.key = 'ArrowRight';
-      rowCount = 3;
-      columnCount = 3;
-      rowIndex = 1;
-      colIndex = 3;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(2);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should move to the prev row when we reach to the beginning of the current row', () => {
-      evt.key = 'ArrowLeft';
-      rowCount = 3;
-      columnCount = 3;
-      rowIndex = 2;
-      colIndex = 0;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(1);
-      expect(nextCol).toBe(2);
-    });
-
-    it('should stay at the first row and first col of table when we reached to the beginning of the table', () => {
-      evt.key = 'ArrowLeft';
-      rowCount = 2;
-      columnCount = 2;
-      rowIndex = 0;
-      colIndex = 0;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(0);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should stay at the end row and end col of table when you reached to the end of the table', () => {
-      evt.key = 'ArrowRight';
-      rowCount = 2;
-      columnCount = 2;
-      rowIndex = 1;
-      colIndex = 1;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex]);
-      expect(nextRow).toBe(1);
-      expect(nextCol).toBe(1);
-    });
-
-    it('should stay at the current cell when allowedRows cell index is 1 and trying to move up from rowIdx 1', () => {
-      evt.key = 'ArrowUp';
-      const allowedRows = { top: 1, bottom: 0 };
-      rowCount = 3;
-      rowIndex = 1;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex], allowedRows);
-      expect(nextRow).toBe(1);
-      expect(nextCol).toBe(0);
-    });
-
-    it('should stay at the current cell when trying to move left and allowedRows is > 0 (i.e in selection mode', () => {
-      evt.key = 'ArrowLeft';
-      const allowedRows = { top: 1, bottom: 0 };
-      rowCount = 3;
-      columnCount = 3;
-      rowIndex = 1;
-      colIndex = 1;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex], allowedRows);
-      expect(nextRow).toBe(1);
-      expect(nextCol).toBe(1);
-    });
-
-    it('should stay at the current cell when trying to move right and allowedRows is > 0 (i.e in selection mode', () => {
-      evt.key = 'ArrowRight';
-      const allowedRows = { top: 1, bottom: 0 };
-      rowCount = 3;
-      columnCount = 3;
-      rowIndex = 1;
-      colIndex = 1;
-      const [nextRow, nextCol] = getNextCellCoord(evt, rootElement, [rowIndex, colIndex], allowedRows);
-      expect(nextRow).toBe(1);
-      expect(nextCol).toBe(1);
     });
   });
 

--- a/src/table/utils/accessibility-utils.ts
+++ b/src/table/utils/accessibility-utils.ts
@@ -11,7 +11,7 @@ export const findCellWithTabStop = (rootElement: HTMLElement) =>
   rootElement.querySelector("td[tabindex='0'], th[tabindex='0']") as HTMLTableCellElement;
 
 /**
- * Removes/adds tab stop and sometimes focuses or blurs the cell, depending on focusTupe
+ * Removes/adds tab stop and sometimes focus/blurs the cell, depending on focusType
  */
 export const updateFocus = ({ focusType, cell }: CellFocusProps) => {
   if (!cell) return;
@@ -109,7 +109,7 @@ export const moveFocus = (
 };
 
 /**
- * Resets and adds new focus to the cell at position newCoord
+ * Resets and adds new focus to the cell at position newCoord. no need for element.focus() since that is done natively
  */
 export const removeTabAndFocusCell = (
   newCoord: [number, number],

--- a/src/table/utils/accessibility-utils.ts
+++ b/src/table/utils/accessibility-utils.ts
@@ -1,6 +1,5 @@
-import { MouseEvent } from 'react';
 import { stardust } from '@nebula.js/stardust';
-import { Announce, Cell, TotalsPosition } from '../../types';
+import { Announce } from '../../types';
 import { CellFocusProps, HandleResetFocusProps } from '../types';
 
 export const getCellElement = (rootElement: HTMLElement, cellCoord: [number, number]) =>
@@ -11,6 +10,9 @@ export const getCellElement = (rootElement: HTMLElement, cellCoord: [number, num
 export const findCellWithTabStop = (rootElement: HTMLElement) =>
   rootElement.querySelector("td[tabindex='0'], th[tabindex='0']") as HTMLTableCellElement;
 
+/**
+ * Removes/adds tab stop and sometimes focuses or blurs the cell, depending on focusTupe
+ */
 export const updateFocus = ({ focusType, cell }: CellFocusProps) => {
   if (!cell) return;
 
@@ -34,7 +36,82 @@ export const updateFocus = ({ focusType, cell }: CellFocusProps) => {
   }
 };
 
-export const removeAndFocus = (
+/**
+ * Calculates the next cell to focus
+ */
+export const getNextCellCoord = (
+  evt: React.KeyboardEvent,
+  rootElement: HTMLElement,
+  cellCoord: [number, number],
+  allowedRows: {
+    top: number;
+    bottom: number;
+  } = { top: 0, bottom: 0 }
+): [number, number] => {
+  const rowCount = rootElement.getElementsByClassName('sn-table-row').length;
+  const columnCount = rootElement.getElementsByClassName('sn-table-head-cell').length;
+  let [nextRow, nextCol] = cellCoord;
+
+  switch (evt.key) {
+    case 'ArrowDown':
+      nextRow < rowCount - 1 - allowedRows.bottom && nextRow++;
+      break;
+    case 'ArrowUp':
+      nextRow > allowedRows.top && nextRow--;
+      break;
+    case 'ArrowRight':
+      // allowedRows.top greater than 0 means we are in selection mode
+      if (allowedRows.top > 0) break;
+      if (nextCol < columnCount - 1) {
+        nextCol++;
+      } else if (nextRow < rowCount - 1) {
+        nextRow++;
+        nextCol = 0;
+      }
+      break;
+    case 'ArrowLeft':
+      // allowedRows.top greater than 0 means we are in selection mode
+      if (allowedRows.top > 0) break;
+      if (nextCol > 0) {
+        nextCol--;
+      } else if (nextRow > 0) {
+        nextRow--;
+        nextCol = columnCount - 1;
+      }
+      break;
+    default:
+      break;
+  }
+
+  return [nextRow, nextCol];
+};
+
+/**
+ * Resets and adds new focus to a table cell based which key is pressed
+ */
+export const moveFocus = (
+  evt: React.KeyboardEvent,
+  rootElement: HTMLElement,
+  cellCoord: [number, number],
+  setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
+  allowedRows?: {
+    top: number;
+    bottom: number;
+  }
+) => {
+  updateFocus({ focusType: 'removeTab', cell: evt.target as HTMLTableCellElement });
+  const nextCellCoord = getNextCellCoord(evt, rootElement, cellCoord, allowedRows);
+  const nextCell = getCellElement(rootElement, nextCellCoord);
+  updateFocus({ focusType: 'focus', cell: nextCell });
+  setFocusedCellCoord(nextCellCoord);
+
+  return nextCell;
+};
+
+/**
+ * Resets and adds new focus to the cell at position newCoord
+ */
+export const removeTabAndFocusCell = (
   newCoord: [number, number],
   rootElement: HTMLElement,
   setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
@@ -45,33 +122,10 @@ export const removeAndFocus = (
   keyboard.enabled && keyboard.focus?.();
 };
 
-export const handleClickToFocusBody = (
-  cell: Cell,
-  rootElement: HTMLElement,
-  setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
-  keyboard: stardust.Keyboard,
-  totalsPosition: TotalsPosition
-) => {
-  const { rawRowIdx, rawColIdx } = cell;
-  const adjustedRowIdx = totalsPosition === 'top' ? rawRowIdx + 2 : rawRowIdx + 1;
-  removeAndFocus([adjustedRowIdx, rawColIdx], rootElement, setFocusedCellCoord, keyboard);
-};
-
-export const handleClickToFocusHead = (
-  columnIndex: number,
-  rootElement: HTMLElement,
-  setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
-  keyboard: stardust.Keyboard
-) => {
-  removeAndFocus([0, columnIndex], rootElement, setFocusedCellCoord, keyboard);
-};
-
-export const handleMouseDownLabelToFocusHeadCell = (evt: MouseEvent, rootElement: HTMLElement, columnIndex: number) => {
-  evt.preventDefault();
-  updateFocus({ focusType: 'focus', cell: getCellElement(rootElement, [0, columnIndex]) });
-};
-
-export const handleResetFocus = ({
+/**
+ * Resets the focus when the data size or page is change, only adds a tab stop when shouldRefocus.current is false
+ */
+export const resetFocus = ({
   focusedCellCoord,
   rootElement,
   shouldRefocus,
@@ -85,6 +139,7 @@ export const handleResetFocus = ({
   // If you have selections ongoing, you want to stay on the same column
   const selectionCellCoord: [number, number] = [totalsPosition === 'top' ? 2 : 1, focusedCellCoord[1]];
   const cellCoord: [number, number] = isSelectionMode ? selectionCellCoord : [0, 0];
+
   if (!keyboard.enabled || keyboard.active) {
     // Only run this if updates come from inside table
     const focusType = shouldRefocus.current ? 'focus' : 'addTab';
@@ -102,9 +157,13 @@ export const handleResetFocus = ({
       });
     }
   }
+
   setFocusedCellCoord(cellCoord);
 };
 
+/**
+ * On focus is no longer in the table, resets the announcer and calls keyboard.blur
+ */
 export const handleFocusoutEvent = (
   evt: FocusEvent,
   shouldRefocus: React.MutableRefObject<boolean>,
@@ -121,6 +180,9 @@ export const handleFocusoutEvent = (
   }
 };
 
+/**
+ * Sets focus to button in the selection toolbar, handles both client and nebula toolbar
+ */
 export const focusSelectionToolbar = (element: HTMLElement, keyboard: stardust.Keyboard, last: boolean) => {
   const clientConfirmButton = element
     .closest('.qv-object-wrapper')
@@ -133,6 +195,9 @@ export const focusSelectionToolbar = (element: HTMLElement, keyboard: stardust.K
   keyboard.focusSelection?.(last);
 };
 
+/**
+ * Updates the announcer with current cell selection state
+ */
 export const announceSelectionState = (
   announce: Announce,
   nextCell: HTMLTableCellElement,

--- a/src/table/utils/accessibility-utils.ts
+++ b/src/table/utils/accessibility-utils.ts
@@ -1,5 +1,5 @@
 import { stardust } from '@nebula.js/stardust';
-import { Announce } from '../../types';
+import { Announce, Cell } from '../../types';
 import { CellFocusProps, HandleResetFocusProps } from '../types';
 
 export const getCellElement = (rootElement: HTMLElement, cellCoord: [number, number]) =>

--- a/src/table/utils/accessibility-utils.ts
+++ b/src/table/utils/accessibility-utils.ts
@@ -162,7 +162,7 @@ export const resetFocus = ({
 };
 
 /**
- * On focus is no longer in the table, resets the announcer and calls keyboard.blur
+ * When focus is no longer in the table, resets the announcer and calls keyboard.blur
  */
 export const handleFocusoutEvent = (
   evt: FocusEvent,

--- a/src/table/utils/handle-click.ts
+++ b/src/table/utils/handle-click.ts
@@ -1,0 +1,30 @@
+import { MouseEvent } from 'react';
+import { stardust } from '@nebula.js/stardust';
+import { Cell, TotalsPosition } from '../../types';
+import { removeTabAndFocusCell, updateFocus, getCellElement } from './accessibility-utils';
+
+export const handleClickToFocusBody = (
+  cell: Cell,
+  rootElement: HTMLElement,
+  setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
+  keyboard: stardust.Keyboard,
+  totalsPosition: TotalsPosition
+) => {
+  const { rawRowIdx, rawColIdx } = cell;
+  const adjustedRowIdx = totalsPosition === 'top' ? rawRowIdx + 2 : rawRowIdx + 1;
+  removeTabAndFocusCell([adjustedRowIdx, rawColIdx], rootElement, setFocusedCellCoord, keyboard);
+};
+
+export const handleClickToFocusHead = (
+  columnIndex: number,
+  rootElement: HTMLElement,
+  setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
+  keyboard: stardust.Keyboard
+) => {
+  removeTabAndFocusCell([0, columnIndex], rootElement, setFocusedCellCoord, keyboard);
+};
+
+export const handleMouseDownLabelToFocusHeadCell = (evt: MouseEvent, rootElement: HTMLElement, columnIndex: number) => {
+  evt.preventDefault();
+  updateFocus({ focusType: 'focus', cell: getCellElement(rootElement, [0, columnIndex]) });
+};

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { stardust } from '@nebula.js/stardust';
 
-import { updateFocus, focusSelectionToolbar, getCellElement, announceSelectionState } from './handle-accessibility';
+import { focusSelectionToolbar, announceSelectionState, moveFocus } from './accessibility-utils';
 import { SelectionActions, TSelectionActions } from './selections-utils';
 import { handleNavigateTop } from './handle-scroll';
 import { HandleWrapperKeyDownProps, HandleHeadKeyDownProps, HandleBodyKeyDownProps } from '../types';
@@ -33,78 +33,6 @@ export const shouldBubble = (
     // ctrl + shift + arrow to change page
     ((evt.key === 'ArrowLeft' || evt.key === 'ArrowRight') && isCtrlShift(evt))
   );
-};
-
-/**
- * Calculates the next cell to focus
- */
-export const getNextCellCoord = (
-  evt: React.KeyboardEvent,
-  rootElement: HTMLElement,
-  cellCoord: [number, number],
-  allowedRows: {
-    top: number;
-    bottom: number;
-  } = { top: 0, bottom: 0 }
-): [number, number] => {
-  const rowCount = rootElement.getElementsByClassName('sn-table-row').length;
-  const columnCount = rootElement.getElementsByClassName('sn-table-head-cell').length;
-  let [nextRow, nextCol] = cellCoord;
-
-  switch (evt.key) {
-    case 'ArrowDown':
-      nextRow < rowCount - 1 - allowedRows.bottom && nextRow++;
-      break;
-    case 'ArrowUp':
-      nextRow > allowedRows.top && nextRow--;
-      break;
-    case 'ArrowRight':
-      // allowedRows.top greater than 0 means we are in selection mode
-      if (allowedRows.top > 0) break;
-      if (nextCol < columnCount - 1) {
-        nextCol++;
-      } else if (nextRow < rowCount - 1) {
-        nextRow++;
-        nextCol = 0;
-      }
-      break;
-    case 'ArrowLeft':
-      // allowedRows.top greater than 0 means we are in selection mode
-      if (allowedRows.top > 0) break;
-      if (nextCol > 0) {
-        nextCol--;
-      } else if (nextRow > 0) {
-        nextRow--;
-        nextCol = columnCount - 1;
-      }
-      break;
-    default:
-      break;
-  }
-
-  return [nextRow, nextCol];
-};
-
-/**
- * resets and adds new focus to a table cell based which key is pressed
- */
-export const moveFocus = (
-  evt: React.KeyboardEvent,
-  rootElement: HTMLElement,
-  cellCoord: [number, number],
-  setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
-  allowedRows?: {
-    top: number;
-    bottom: number;
-  }
-) => {
-  updateFocus({ focusType: 'removeTab', cell: evt.target as HTMLTableCellElement });
-  const nextCellCoord = getNextCellCoord(evt, rootElement, cellCoord, allowedRows);
-  const nextCell = getCellElement(rootElement, nextCellCoord);
-  updateFocus({ focusType: 'focus', cell: nextCell });
-  setFocusedCellCoord(nextCellCoord);
-
-  return nextCell;
 };
 
 /**


### PR DESCRIPTION
Mostly moving code here, no need to look at any logic changes. Changed the tests for the click functions, now only testing with a mocked function. Also added two simple tests for `removeTabAndFocusCell`

- handle-accessibility -> accessibility-utils, it is almost no actual handles in there
- `handleResetFocus` -> `resetFocus`, not an event handler
- `removeAndFocus` -> `removeTabAndFocusCell`. Remove and focus what? I think this is better
- introduce handle-click. Move all click handlers there
- move focus-only related functions to accessibility-utils, since they don't really have anything to do with pressing a key (`getNextCellCoord` and `moveFocus`)

So what needs to reviewed properly is the changes in tests and the new comments