### PR TITLE
chore: put jsx-a11y in use

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,8 +10,8 @@
       "presets": ["@babel/preset-react"]
     }
   },
-  "extends": ["airbnb", "prettier", "plugin:react/recommended"],
-  "plugins": ["prettier", "react", "react-hooks"],
+  "extends": ["airbnb", "prettier", "plugin:react/recommended", "plugin:jsx-a11y/recommended"],
+  "plugins": ["prettier", "react", "react-hooks", "jsx-a11y"],
   "settings": {
     "import/resolver": {
       "node": {


### PR DESCRIPTION
eslint-plugin-jsx-a11y was installed before but it is not in use yet.

this PR enables a set of recommended accessibility rules.
