### PR TITLE
feat: extend copyCellValue via keyDown to Heads and Total cells

### DIFF
--- a/src/nebula-hooks/use-context-menu.ts
+++ b/src/nebula-hooks/use-context-menu.ts
@@ -1,10 +1,9 @@
 // @ts-ignore  TODO: remove tag when onContextMenu is declared in nebula/stardust
 import { onContextMenu } from '@nebula.js/stardust';
 import { copyCellValue } from '../table/utils/accessibility-utils';
-import { Menu } from '../types';
 
 export default function useContextMenu(areBasicFeaturesEnabled: boolean) {
-  onContextMenu?.((menu: Menu, event: any) => {
+  onContextMenu((menu: any, event: any) => {
     areBasicFeaturesEnabled &&
       event.target &&
       menu.addItem({

--- a/src/nebula-hooks/use-context-menu.ts
+++ b/src/nebula-hooks/use-context-menu.ts
@@ -11,7 +11,7 @@ export default function useContextMenu(areBasicFeaturesEnabled: boolean) {
         icon: 'lui-icon lui-icon--copy',
         tid: 'copy-cell-context-item',
         select: async () => {
-          copyCellValue(event.target.firstChild.textContent);
+          copyCellValue(event);
         },
       });
   });

--- a/src/table/components/TableBodyWrapper.tsx
+++ b/src/table/components/TableBodyWrapper.tsx
@@ -59,6 +59,7 @@ function TableBodyWrapper({
       layout={layout}
       keyboard={keyboard}
       selectionsAPI={selectionsAPI}
+      areBasicFeaturesEnabled={areBasicFeaturesEnabled}
     />
   );
 

--- a/src/table/components/TableHeadWrapper.tsx
+++ b/src/table/components/TableHeadWrapper.tsx
@@ -19,6 +19,7 @@ function TableHeadWrapper({
   translator,
   selectionsAPI,
   keyboard,
+  areBasicFeaturesEnabled,
 }: TableHeadWrapperProps) {
   const { columns, paginationNeeded } = tableData;
   const setHeadRowHeight = useContextSelector(TableContext, (value) => value.setHeadRowHeight);
@@ -54,6 +55,7 @@ function TableHeadWrapper({
               layout,
               isInteractionEnabled,
               setFocusedCellCoord,
+              areBasicFeaturesEnabled,
             });
           };
 

--- a/src/table/components/TableTotals.tsx
+++ b/src/table/components/TableTotals.tsx
@@ -6,7 +6,15 @@ import { removeTabAndFocusCell } from '../utils/accessibility-utils';
 import { StyledHeadRow, StyledTotalsCell } from '../styles';
 import { TableTotalsProps } from '../types';
 
-function TableTotals({ rootElement, tableData, theme, layout, keyboard, selectionsAPI }: TableTotalsProps) {
+function TableTotals({
+  rootElement,
+  tableData,
+  theme,
+  layout,
+  keyboard,
+  selectionsAPI,
+  areBasicFeaturesEnabled,
+}: TableTotalsProps) {
   const { columns, paginationNeeded, totalsPosition, rows } = tableData;
   const headRowHeight = useContextSelector(TableContext, (value) => value.headRowHeight);
   const setFocusedCellCoord = useContextSelector(TableContext, (value) => value.setFocusedCellCoord);
@@ -27,7 +35,14 @@ function TableTotals({ rootElement, tableData, theme, layout, keyboard, selectio
             className="sn-table-cell"
             tabIndex={-1}
             onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
-              handleTotalKeyDown(e, rootElement, cellCoord, setFocusedCellCoord, selectionsAPI.isModal());
+              handleTotalKeyDown(
+                e,
+                rootElement,
+                cellCoord,
+                setFocusedCellCoord,
+                selectionsAPI.isModal(),
+                areBasicFeaturesEnabled
+              );
             }}
             onMouseDown={() => {
               removeTabAndFocusCell(cellCoord, rootElement, setFocusedCellCoord, keyboard);

--- a/src/table/components/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.tsx
@@ -24,6 +24,7 @@ describe('<TableHeadWrapper />', () => {
   let selectionsAPI: ExtendedSelectionAPI;
   let keyboard: stardust.Keyboard;
   let translator: ExtendedTranslator;
+  let areBasicFeaturesEnabled: boolean;
 
   const renderTableHead = (cellCoordMock?: [number, number]) =>
     render(
@@ -38,6 +39,7 @@ describe('<TableHeadWrapper />', () => {
           changeSortOrder={changeSortOrder}
           keyboard={keyboard}
           translator={translator}
+          areBasicFeaturesEnabled={areBasicFeaturesEnabled}
         />
       </TableContextProvider>
     );

--- a/src/table/components/__tests__/TableTotals.spec.tsx
+++ b/src/table/components/__tests__/TableTotals.spec.tsx
@@ -16,6 +16,7 @@ describe('<TableTotals />', () => {
   let layout: TableLayout;
   let selectionsAPI: ExtendedSelectionAPI;
   let keyboard: stardust.Keyboard;
+  let areBasicFeaturesEnabled: boolean;
 
   const renderTableTotals = (cellCoordMock?: [number, number]) =>
     render(
@@ -28,6 +29,7 @@ describe('<TableTotals />', () => {
             layout={layout}
             keyboard={keyboard}
             selectionsAPI={selectionsAPI}
+            areBasicFeaturesEnabled={areBasicFeaturesEnabled}
           />
         ) : (
           <></>

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -114,6 +114,7 @@ export interface HandleHeadKeyDownProps {
   layout: TableLayout;
   isInteractionEnabled: boolean;
   setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
+  areBasicFeaturesEnabled: boolean;
 }
 
 export interface HandleBodyKeyDownProps {
@@ -211,6 +212,7 @@ export interface TableHeadWrapperProps extends CommonTableProps {
   changeSortOrder: ChangeSortOrder;
   constraints: stardust.Constraints;
   translator: ExtendedTranslator;
+  areBasicFeaturesEnabled: boolean;
 }
 
 export interface TableBodyWrapperProps extends CommonTableProps {
@@ -228,6 +230,7 @@ export interface TableTotalsProps extends CommonTableProps {
   rootElement: HTMLElement;
   layout: TableLayout;
   selectionsAPI: ExtendedSelectionAPI;
+  areBasicFeaturesEnabled: boolean;
 }
 
 export interface PaginationContentProps extends CommonTableProps {

--- a/src/table/utils/__tests__/accessiblity-utils.spec.ts
+++ b/src/table/utils/__tests__/accessiblity-utils.spec.ts
@@ -557,9 +557,35 @@ describe('handle-accessibility', () => {
   });
 
   describe('copyCellValue: ', () => {
-    let cellValue: string;
+    let evt: {
+      target: {
+        children: [
+          {
+            firstChild: {
+              textContent: string;
+            };
+          }
+        ];
+        firstChild: {
+          textContent: string;
+        };
+      };
+    };
     beforeEach(() => {
-      cellValue = '';
+      evt = {
+        target: {
+          children: [
+            {
+              firstChild: {
+                textContent: '',
+              },
+            },
+          ],
+          firstChild: {
+            textContent: '',
+          },
+        },
+      };
       console.log = jest.fn();
     });
     it('should copying value to clipboard successfully', () => {
@@ -568,7 +594,7 @@ describe('handle-accessibility', () => {
           writeText: jest.fn().mockReturnValueOnce(Promise.resolve()),
         },
       });
-      accessibilityUtils.copyCellValue(cellValue);
+      accessibilityUtils.copyCellValue(evt);
       expect(console.log).not.toHaveBeenCalled();
     });
   });

--- a/src/table/utils/accessibility-utils.ts
+++ b/src/table/utils/accessibility-utils.ts
@@ -216,9 +216,14 @@ export const announceSelectionState = (
   }
 };
 
-export const copyCellValue = async (value: string) => {
+export const copyCellValue = async (evt: any, isHeadCell: boolean = false) => {
+  const target = evt.target as HTMLElement;
+  const value =
+    isHeadCell && target.children[0].firstChild
+      ? target.children[0].firstChild?.textContent
+      : target.firstChild && target.firstChild?.textContent;
   try {
-    await navigator.clipboard.writeText(value);
+    value && (await navigator.clipboard.writeText(String(value)));
   } catch (error) {
     console.log(error);
   }

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -109,6 +109,7 @@ export const handleHeadKeyDown = ({
   layout,
   isInteractionEnabled,
   setFocusedCellCoord,
+  areBasicFeaturesEnabled,
 }: HandleHeadKeyDownProps) => {
   if (!isInteractionEnabled) {
     preventDefaultBehavior(evt);
@@ -128,6 +129,10 @@ export const handleHeadKeyDown = ({
       // Space bar / Enter: update the sorting
       changeSortOrder(layout, column);
       break;
+    case KeyCodes.C: {
+      areBasicFeaturesEnabled && (evt.ctrlKey || evt.metaKey) && copyCellValue(evt, true);
+      break;
+    }
     default:
       break;
   }
@@ -141,7 +146,8 @@ export const handleTotalKeyDown = (
   rootElement: HTMLElement,
   cellCoord: [number, number],
   setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>,
-  isSelectionMode: boolean
+  isSelectionMode: boolean,
+  areBasicFeaturesEnabled: boolean
 ) => {
   if (isSelectionMode) {
     preventDefaultBehavior(evt);
@@ -156,6 +162,10 @@ export const handleTotalKeyDown = (
     case KeyCodes.UP:
     case KeyCodes.DOWN: {
       moveFocus(evt, rootElement, cellCoord, setFocusedCellCoord);
+      break;
+    }
+    case KeyCodes.C: {
+      areBasicFeaturesEnabled && (evt.ctrlKey || evt.metaKey) && copyCellValue(evt);
       break;
     }
     default:
@@ -241,9 +251,7 @@ export const handleBodyKeyDown = ({
       focusSelectionToolbar(evt.target as HTMLElement, keyboard, evt.shiftKey);
       break;
     case KeyCodes.C:
-      areBasicFeaturesEnabled &&
-        (evt.ctrlKey || evt.metaKey) &&
-        copyCellValue((evt.target as HTMLElement).textContent as string);
+      areBasicFeaturesEnabled && (evt.ctrlKey || evt.metaKey) && copyCellValue(evt);
       break;
     default:
       break;

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,13 +199,3 @@ export interface RenderWithCarbonArguments {
   layout: TableLayout;
   changeSortOrder?: ChangeSortOrder;
 }
-
-interface AddItemProps {
-  translation: string;
-  icon: string;
-  tid: string;
-  select(): Promise<void>;
-}
-export interface Menu {
-  addItem(props: AddItemProps): void;
-}


### PR DESCRIPTION
CopyCellValue via keyDown ( `ctrl + c ` and `meta + c` ) is functioning now on Head and Total cells as well as body cells.