### PR TITLE
fix: properly focus cell on click

### DIFF
--- a/src/table/utils/__tests__/accessiblity-utils.spec.ts
+++ b/src/table/utils/__tests__/accessiblity-utils.spec.ts
@@ -542,7 +542,7 @@ describe('handle-accessibility', () => {
       expect(keyboard.focus).not.toHaveBeenCalled();
     });
 
-    it('should call update setFocusedCellCoord but no keyboard.focus when keyboard.enabled is true and active is true', () => {
+    it('should call update setFocusedCellCoord but not keyboard.focus when keyboard.enabled is true and active is true', () => {
       keyboard.active = true;
       accessibilityUtils.removeTabAndFocusCell(newCoord, rootElement, setFocusedCellCoord, keyboard);
       expect(setFocusedCellCoord).toHaveBeenCalledWith(newCoord);

--- a/src/table/utils/__tests__/accessiblity-utils.spec.ts
+++ b/src/table/utils/__tests__/accessiblity-utils.spec.ts
@@ -542,7 +542,14 @@ describe('handle-accessibility', () => {
       expect(keyboard.focus).not.toHaveBeenCalled();
     });
 
-    it('should call update setFocusedCellCoord and keyboard.focus when keyboard.enabled is true', () => {
+    it('should call update setFocusedCellCoord but no keyboard.focus when keyboard.enabled is true and active is true', () => {
+      keyboard.active = true;
+      accessibilityUtils.removeTabAndFocusCell(newCoord, rootElement, setFocusedCellCoord, keyboard);
+      expect(setFocusedCellCoord).toHaveBeenCalledWith(newCoord);
+      expect(keyboard.focus).not.toHaveBeenCalled();
+    });
+
+    it('should call update setFocusedCellCoord and keyboard.focus when keyboard.enabled is true and active is false', () => {
       accessibilityUtils.removeTabAndFocusCell(newCoord, rootElement, setFocusedCellCoord, keyboard);
       expect(setFocusedCellCoord).toHaveBeenCalledWith(newCoord);
       expect(keyboard.focus).toHaveBeenCalledTimes(1);

--- a/src/table/utils/accessibility-utils.ts
+++ b/src/table/utils/accessibility-utils.ts
@@ -119,7 +119,11 @@ export const removeTabAndFocusCell = (
 ) => {
   updateFocus({ focusType: 'removeTab', cell: findCellWithTabStop(rootElement) });
   setFocusedCellCoord(newCoord);
-  keyboard.enabled && keyboard.focus?.();
+  if (keyboard.enabled && !keyboard.active) {
+    keyboard.focus?.();
+  } else {
+    updateFocus({ focusType: 'focus', cell: getCellElement(rootElement, newCoord) });
+  }
 };
 
 /**

--- a/src/table/utils/accessibility-utils.ts
+++ b/src/table/utils/accessibility-utils.ts
@@ -122,7 +122,7 @@ export const removeTabAndFocusCell = (
   if (keyboard.enabled && !keyboard.active) {
     keyboard.focus?.();
   } else {
-    updateFocus({ focusType: 'focus', cell: getCellElement(rootElement, newCoord) });
+    updateFocus({ focusType: 'addTab', cell: getCellElement(rootElement, newCoord) });
   }
 };
 


### PR DESCRIPTION
When clicking a cell to focus it, you remove the tab-index for the one the cell that has a tab stop already. When keyboard.focus does not run, the tab-index is still -1 for the new focused cell. Need to make sure it is added manually. 