### PR TITLE
feat: checking types when committing

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "yarn lint"
+      "yarn lint",
+      "bash -c 'yarn types:check'"
     ],
     "*.{json,css,md}": [
       "yarn format"


### PR DESCRIPTION
lint-staged ignores tsconfig.json when tsc called through git hooks, using a `bash -c` trick
Reference: https://github.com/okonet/lint-staged/issues/825