### PR TITLE
refactor: remove prev/next qElemNumber

### DIFF
--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -131,8 +131,7 @@ export default async function manageData(
         isSelectable: c.isDim && !c.isLocked,
         rawRowIdx: rowIdx,
         rawColIdx: colIdx,
-        prevQElemNumber: dataPages[0].qMatrix[rowIdx - 1]?.[colIdx]?.qElemNumber,
-        nextQElemNumber: dataPages[0].qMatrix[rowIdx + 1]?.[colIdx]?.qElemNumber,
+        isLastRow: rowIdx === height - 1,
       };
     });
     return row;

--- a/src/table/utils/__tests__/handle-key-press.spec.ts
+++ b/src/table/utils/__tests__/handle-key-press.spec.ts
@@ -14,6 +14,7 @@ import * as handleAccessibility from '../accessibility-utils';
 import * as handleScroll from '../handle-scroll';
 import { Announce, Column, ExtendedSelectionAPI, Cell, TableLayout, TotalsPosition } from '../../../types';
 import { SelectionDispatch } from '../../types';
+import { KeyCodes } from '../../constants';
 
 describe('handle-key-press', () => {
   let isFlagEnabled: (flag: string) => boolean;
@@ -32,7 +33,7 @@ describe('handle-key-press', () => {
 
     beforeEach(() => {
       evt = {
-        key: 'Escape',
+        key: KeyCodes.ESC,
         shiftKey: false,
         ctrlKey: false,
         metaKey: false, // cases when meta key is pressed instead of ctrl is not tested here, the test are granular enough anyway
@@ -52,26 +53,26 @@ describe('handle-key-press', () => {
     });
 
     it('should return true when tab is pressed and paginationNeeded is true', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       expect(callShouldBubble()).toBe(true);
     });
 
     it('should return true when tab is pressed, paginationNeeded is false and keyboardEnabled is false but isSelectionMode is true', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       paginationNeeded = false;
       isSelectionMode = true;
       expect(callShouldBubble()).toBe(true);
     });
 
     it('should return true when tab is pressed, paginationNeeded is false and isSelectionMode is false but keyboardEnabled is true', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       paginationNeeded = false;
       keyboardEnabled = true;
       expect(callShouldBubble()).toBe(true);
     });
 
     it('should return false when tab is pressed, paginationNeeded is false and keyboardEnabled && isSelectionMode is true', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       paginationNeeded = false;
       keyboardEnabled = true;
       isSelectionMode = true;
@@ -79,21 +80,21 @@ describe('handle-key-press', () => {
     });
 
     it('should return true when shift + tab is pressed and keyboardEnabled is false but isSelectionMode is true', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       evt.shiftKey = true;
       isSelectionMode = true;
       expect(callShouldBubble()).toBe(true);
     });
 
     it('should return true when shift + tab is pressed and isSelectionMode is false but keyboardEnabled is true', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       evt.shiftKey = true;
       keyboardEnabled = true;
       expect(callShouldBubble()).toBe(true);
     });
 
     it('should return false when shift + tab is pressed and keyboardEnabled && isSelectionMode is true', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       evt.shiftKey = true;
       keyboardEnabled = true;
       isSelectionMode = true;
@@ -101,34 +102,34 @@ describe('handle-key-press', () => {
     });
 
     it('should return true when ctrl + shift + arrowRight is pressed', () => {
-      evt.key = 'ArrowRight';
+      evt.key = KeyCodes.RIGHT;
       evt.shiftKey = true;
       evt.ctrlKey = true;
       expect(callShouldBubble()).toBe(true);
     });
 
     it('should return true when ctrl + shift + arrowLeft is pressed', () => {
-      evt.key = 'ArrowLeft';
+      evt.key = KeyCodes.LEFT;
       evt.shiftKey = true;
       evt.ctrlKey = true;
       expect(callShouldBubble()).toBe(true);
     });
 
     it('should return false when ctrl + shift + some other key is pressed', () => {
-      evt.key = 'ArrowUp';
+      evt.key = KeyCodes.UP;
       evt.shiftKey = true;
       evt.ctrlKey = true;
       expect(callShouldBubble()).toBe(false);
     });
 
     it('should return false when ctrl + arrowLeft but not shift', () => {
-      evt.key = 'ArrowLeft';
+      evt.key = KeyCodes.LEFT;
       evt.ctrlKey = true;
       expect(callShouldBubble()).toBe(false);
     });
 
     it('should return false when shift + arrowLeft but not ctrl', () => {
-      evt.key = 'ArrowLeft';
+      evt.key = KeyCodes.LEFT;
       evt.shiftKey = true;
       expect(callShouldBubble()).toBe(false);
     });
@@ -161,7 +162,7 @@ describe('handle-key-press', () => {
         shiftKey: true,
         ctrlKey: true,
         metaKey: true,
-        key: 'ArrowRight',
+        key: KeyCodes.RIGHT,
         stopPropagation: () => undefined,
         preventDefault: () => undefined,
       } as unknown as React.KeyboardEvent;
@@ -196,7 +197,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press arrow left key on the first page, handleChangePage should not run', () => {
-      evt.key = 'ArrowLeft';
+      evt.key = KeyCodes.LEFT;
       page = 0;
       totalRowCount = 40;
       rowsPerPage = 10;
@@ -215,7 +216,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press arrow left key not on the first page, should change page', () => {
-      evt.key = 'ArrowLeft';
+      evt.key = KeyCodes.LEFT;
       totalRowCount = 40;
       page = 1;
       rowsPerPage = 40;
@@ -226,7 +227,7 @@ describe('handle-key-press', () => {
 
     it('when press escape is pressed and keyboard.enabled is true, should call keyboard.blur', () => {
       evt = {
-        key: 'Escape',
+        key: KeyCodes.ESC,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
       } as unknown as React.KeyboardEvent;
@@ -239,7 +240,7 @@ describe('handle-key-press', () => {
 
     it('should ignore keyboard.blur while you are focusing on the pagination and pressing Esc key', () => {
       evt = {
-        key: 'Escape',
+        key: KeyCodes.ESC,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
       } as unknown as React.KeyboardEvent;
@@ -280,7 +281,7 @@ describe('handle-key-press', () => {
       colIndex = 0;
       column = {} as unknown as Column;
       evt = {
-        key: 'ArrowDown',
+        key: KeyCodes.DOWN,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
         target: {
@@ -309,7 +310,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press space bar key, should update the sorting', () => {
-      evt.key = ' ';
+      evt.key = KeyCodes.SPACE;
       callHandleHeadKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
@@ -318,7 +319,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press enter key, should update the sorting', () => {
-      evt.key = 'Enter';
+      evt.key = KeyCodes.ENTER;
       callHandleHeadKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
@@ -327,7 +328,7 @@ describe('handle-key-press', () => {
     });
 
     it('when pressing a valid key and isInteractionEnabled is false, should only call preventDefaultBehavior', () => {
-      evt.key = ' ';
+      evt.key = KeyCodes.SPACE;
       isInteractionEnabled = false;
       callHandleHeadKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -337,7 +338,7 @@ describe('handle-key-press', () => {
     });
 
     it('when pressing an invalid key, should only call preventDefaultBehavior', () => {
-      evt.key = 'ArrowUp';
+      evt.key = KeyCodes.UP;
       callHandleHeadKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
@@ -355,7 +356,7 @@ describe('handle-key-press', () => {
 
     beforeEach(() => {
       evt = {
-        key: 'ArrowDown',
+        key: KeyCodes.DOWN,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
         target: {
@@ -390,7 +391,7 @@ describe('handle-key-press', () => {
     });
 
     it('should take the default case when the pressed key is not an arrow key', () => {
-      evt.key = 'Enter';
+      evt.key = KeyCodes.ENTER;
       handleTotalKeyDown(evt, rootElement, cellCoord, setFocusedCellCoord, isSelectionMode);
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
@@ -433,7 +434,7 @@ describe('handle-key-press', () => {
       isModal = false;
       isExcluded = false;
       evt = {
-        key: 'ArrowDown',
+        key: KeyCodes.DOWN,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
         target: {
@@ -454,7 +455,7 @@ describe('handle-key-press', () => {
         cancel: jest.fn(),
         isModal: () => isModal,
       } as unknown as ExtendedSelectionAPI;
-      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1, isSelectable: true } as unknown as Cell;
+      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1, isSelectable: true, isLastRow: false, rawRowIdx: 1 } as Cell;
       keyboard = { enabled: true } as unknown as stardust.Keyboard;
       selectionDispatch = jest.fn();
       isSelectionsEnabled = true;
@@ -483,7 +484,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press arrow left key on body cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell', () => {
-      evt.key = 'ArrowLeft';
+      evt.key = KeyCodes.LEFT;
 
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -495,7 +496,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press arrow up key on body cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell and call handleNavigateTop', () => {
-      evt.key = 'ArrowUp';
+      evt.key = KeyCodes.UP;
 
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -507,7 +508,6 @@ describe('handle-key-press', () => {
     });
 
     it('when press shift + arrow down key on body cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell, and select values for dimension', () => {
-      cell.nextQElemNumber = 1;
       evt.shiftKey = true;
 
       runHandleBodyKeyDown();
@@ -521,6 +521,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press shift + arrow down key on the last row cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell, but not select values for dimension', () => {
+      cell.isLastRow = true;
       evt.shiftKey = true;
 
       runHandleBodyKeyDown();
@@ -534,9 +535,8 @@ describe('handle-key-press', () => {
     });
 
     it('when press shift + arrow up key on body cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell, and select values for dimension', () => {
-      cell.prevQElemNumber = 1;
       evt.shiftKey = true;
-      evt.key = 'ArrowUp';
+      evt.key = KeyCodes.UP;
 
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -549,8 +549,9 @@ describe('handle-key-press', () => {
     });
 
     it('when press shift + arrow up key on the second row cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell, but not select values for dimension', () => {
+      cell.rawRowIdx = 0;
       evt.shiftKey = true;
-      evt.key = 'ArrowUp';
+      evt.key = KeyCodes.UP;
 
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -563,7 +564,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press space bar key and dimension, should select value for dimension', () => {
-      evt.key = ' ';
+      evt.key = KeyCodes.SPACE;
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
@@ -572,7 +573,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press space bar key on a cell that is not selectable, should not select value', () => {
-      evt.key = ' ';
+      evt.key = KeyCodes.SPACE;
       cell = {
         isSelectable: false,
       } as Cell;
@@ -585,7 +586,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press space bar key and selections are not enabled, should not select value', () => {
-      evt.key = ' ';
+      evt.key = KeyCodes.SPACE;
       isSelectionsEnabled = false;
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -596,7 +597,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press enter key, should confirms selections', () => {
-      evt.key = 'Enter';
+      evt.key = KeyCodes.ENTER;
       isModal = true;
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -607,7 +608,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press enter key and not in selections mode, should not confirms selections', () => {
-      evt.key = 'Enter';
+      evt.key = KeyCodes.ENTER;
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
@@ -617,7 +618,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press esc key and in selections mode, should cancel selection', () => {
-      evt.key = 'Escape';
+      evt.key = KeyCodes.ESC;
       isModal = true;
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -628,7 +629,7 @@ describe('handle-key-press', () => {
     });
 
     it('when shift + tab is pressed and in selections mode, should prevent default and call focusSelectionToolbar', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       evt.shiftKey = true;
       isModal = true;
       runHandleBodyKeyDown();
@@ -639,7 +640,7 @@ describe('handle-key-press', () => {
     });
 
     it('when tab is pressed, paginationNeeded is false and in selection mode, should prevent default and call focusSelectionToolbar', () => {
-      evt.key = 'Tab';
+      evt.key = KeyCodes.TAB;
       isModal = true;
       paginationNeeded = false;
       runHandleBodyKeyDown();
@@ -650,21 +651,21 @@ describe('handle-key-press', () => {
     });
 
     it('should call copyCellValue when the pressed keys are Ctrl and C keys', () => {
-      evt.key = 'c';
+      evt.key = KeyCodes.C;
       evt.ctrlKey = true;
       runHandleBodyKeyDown();
       expect(handleAccessibility.copyCellValue).toHaveBeenCalled();
     });
 
     it('should call copyCellValue when the pressed keys are Meta and C keys', () => {
-      evt.key = 'c';
+      evt.key = KeyCodes.C;
       evt.metaKey = true;
       runHandleBodyKeyDown();
       expect(handleAccessibility.copyCellValue).toHaveBeenCalled();
     });
 
     it('should not call copyCellValue when the flag is disabled', () => {
-      evt.key = 'c';
+      evt.key = KeyCodes.C;
       evt.metaKey = true;
       isFlagEnabled = (flag: string) => !flag;
       runHandleBodyKeyDown();
@@ -700,7 +701,7 @@ describe('handle-key-press', () => {
 
     beforeEach(() => {
       evt = {
-        key: 'Shift',
+        key: KeyCodes.SHIFT,
       } as unknown as React.KeyboardEvent;
       selectionDispatch = jest.fn();
     });
@@ -727,7 +728,7 @@ describe('handle-key-press', () => {
 
     beforeEach(() => {
       evt = {
-        key: 'Tab',
+        key: KeyCodes.TAB,
         shiftKey: false,
         target: {} as HTMLElement,
         stopPropagation: jest.fn(),

--- a/src/table/utils/__tests__/selections-utils.spec.ts
+++ b/src/table/utils/__tests__/selections-utils.spec.ts
@@ -416,7 +416,7 @@ describe('selections-utils', () => {
     beforeEach(() => {
       allRows = createAllRows(3);
       selectedRows = { '2': 2 };
-      cell = createCell(0);
+      cell = createCell(1);
       evt = {} as React.KeyboardEvent;
       firstCell = undefined;
     });
@@ -424,30 +424,24 @@ describe('selections-utils', () => {
     it('should add the current cell and the next cell to selectedRows when press shift and arrow down key', () => {
       evt.shiftKey = true;
       evt.key = KeyCodes.DOWN;
-      cell.nextQElemNumber = 1;
 
       const updatedSelectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
       expect(updatedSelectedRows).toEqual({
         ...selectedRows,
         [cell.qElemNumber]: cell.rowIdx,
-        [cell.nextQElemNumber]: 1,
+        '1': 1,
       });
     });
 
     it('should add the current cell and the next cell to selectedRows when press shift and arrow up key', () => {
       evt.shiftKey = true;
       evt.key = KeyCodes.UP;
-      cell = {
-        qElemNumber: 1,
-        rowIdx: 1,
-      } as Cell;
-      cell.prevQElemNumber = 0;
 
       const updatedSelectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
       expect(updatedSelectedRows).toEqual({
         ...selectedRows,
         [cell.qElemNumber]: cell.rowIdx,
-        [cell.prevQElemNumber]: 0,
+        '0': 0,
       });
     });
 
@@ -459,7 +453,7 @@ describe('selections-utils', () => {
     it('should return rows updated with all rows between firstCell and cell', () => {
       firstCell = createCell(3);
       const updatedSelectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
-      expect(updatedSelectedRows).toEqual({ '0': 0, '1': 1, '2': 2, '3': 3 });
+      expect(updatedSelectedRows).toEqual({ '1': 1, '2': 2, '3': 3 });
     });
   });
 
@@ -476,7 +470,7 @@ describe('selections-utils', () => {
       } as Cell;
 
       selectionState = {
-        allRows: [],
+        allRows: createAllRows(4),
         colIdx: 1,
         rows: { 1: 1 },
         api: {

--- a/src/table/utils/selections-utils.ts
+++ b/src/table/utils/selections-utils.ts
@@ -170,12 +170,10 @@ export const getMultiSelectedRows = (
 
   if ('key' in evt && isShiftArrow(evt)) {
     newSelectedRows[cell.qElemNumber] = cell.rowIdx;
-    // add the next or previous cell to selectedRows, based on which arrow is pressed
-    if (evt.key === KeyCodes.DOWN) {
-      newSelectedRows[cell.nextQElemNumber as number] = cell.rowIdx + 1;
-    } else {
-      newSelectedRows[cell.prevQElemNumber as number] = cell.rowIdx - 1;
-    }
+    // also add the next or previous cell to selectedRows, based on which arrow is pressed
+    const idxShift = evt.key === KeyCodes.DOWN ? 1 : -1;
+    const nextCell = allRows[cell.rawRowIdx + idxShift][`col-${cell.rawColIdx}`] as Cell;
+    newSelectedRows[nextCell.qElemNumber] = cell.rowIdx + idxShift;
     return newSelectedRows;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,8 +91,7 @@ export interface Cell {
   isSelectable: boolean;
   rawRowIdx: number;
   rawColIdx: number;
-  prevQElemNumber: number | undefined;
-  nextQElemNumber: number | undefined;
+  isLastRow: boolean;
 }
 
 export interface Row {


### PR DESCRIPTION
Since we now store `allRows` on the selection state, no need to store qElemNumber for any neighboring cells on the cell. Replacing with a last row bool, to keep track of when it is bossible to select by shift + arrow down. also:
- use KeyCodes in test file
- breaking out `shouldSelectMultiValues` for readability in `handleBodyKeyPress`