### PR TITLE
fix: sanity check to avaoid crash on old nebula versions

### DIFF
--- a/src/nebula-hooks/use-context-menu.ts
+++ b/src/nebula-hooks/use-context-menu.ts
@@ -4,7 +4,7 @@ import { copyCellValue } from '../table/utils/accessibility-utils';
 import { Menu } from '../types';
 
 export default function useContextMenu(areBasicFeaturesEnabled: boolean) {
-  onContextMenu((menu: Menu, event: any) => {
+  onContextMenu?.((menu: Menu, event: any) => {
     areBasicFeaturesEnabled &&
       event.target &&
       menu.addItem({


### PR DESCRIPTION
Seems like it is possible to load the sn-table on the fly and the peerDependencies are not enforced, leading to the table crashing. This is just to make sure it doesn't