### PR TITLE
fix: block arrow keys from propagating

### DIFF
--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -9,8 +9,10 @@ import { KeyCodes, SelectionActions } from '../constants';
 
 const isCtrlShift = (evt: React.KeyboardEvent) => evt.shiftKey && (evt.ctrlKey || evt.metaKey);
 
-export const isArrowKey = (key: string) =>
+const isArrowKey = (key: string) =>
   [KeyCodes.LEFT, KeyCodes.RIGHT, KeyCodes.UP, KeyCodes.DOWN].includes(key as KeyCodes);
+
+export const isShiftArrow = (evt: React.KeyboardEvent) => evt.shiftKey && isArrowKey(evt.key);
 
 export const preventDefaultBehavior = (evt: React.KeyboardEvent) => {
   evt.stopPropagation();

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -7,17 +7,17 @@ import { HandleWrapperKeyDownProps, HandleHeadKeyDownProps, HandleBodyKeyDownPro
 import { Cell } from '../../types';
 import { KeyCodes, SelectionActions } from '../constants';
 
+const preventDefaultBehavior = (evt: React.KeyboardEvent) => {
+  evt.stopPropagation();
+  evt.preventDefault();
+};
+
 const isCtrlShift = (evt: React.KeyboardEvent) => evt.shiftKey && (evt.ctrlKey || evt.metaKey);
 
 const isArrowKey = (key: string) =>
   [KeyCodes.LEFT, KeyCodes.RIGHT, KeyCodes.UP, KeyCodes.DOWN].includes(key as KeyCodes);
 
 export const isShiftArrow = (evt: React.KeyboardEvent) => evt.shiftKey && isArrowKey(evt.key);
-
-export const preventDefaultBehavior = (evt: React.KeyboardEvent) => {
-  evt.stopPropagation();
-  evt.preventDefault();
-};
 
 /**
  * Checks if events caught by head, totals and body handles should bubble to the wrapper handler or default behavior

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -9,6 +9,9 @@ import { KeyCodes, SelectionActions } from '../constants';
 
 const isCtrlShift = (evt: React.KeyboardEvent) => evt.shiftKey && (evt.ctrlKey || evt.metaKey);
 
+export const isArrowKey = (key: string) =>
+  [KeyCodes.LEFT, KeyCodes.RIGHT, KeyCodes.UP, KeyCodes.DOWN].includes(key as KeyCodes);
+
 export const preventDefaultBehavior = (evt: React.KeyboardEvent) => {
   evt.stopPropagation();
   evt.preventDefault();
@@ -94,6 +97,9 @@ export const handleWrapperKeyDown = ({
     preventDefaultBehavior(evt);
     // @ts-ignore TODO: fix nebula api so that blur has the correct argument type
     keyboard.blur?.(true);
+  } else if (isArrowKey(evt.key)) {
+    // Arrow key events should never bubble out of the table
+    preventDefaultBehavior(evt);
   }
 };
 

--- a/src/table/utils/selections-utils.ts
+++ b/src/table/utils/selections-utils.ts
@@ -2,7 +2,7 @@ import { stardust } from '@nebula.js/stardust';
 import { Cell, ExtendedSelectionAPI, Announce, Row } from '../../types';
 import { SelectionState, ActionPayload, SelectionActionTypes, SelectionDispatch } from '../types';
 import { SelectionActions, SelectionStates, KeyCodes } from '../constants';
-import { isArrowKey } from './handle-key-press';
+import { isShiftArrow } from './handle-key-press';
 
 interface AddSelectionListenersArgs {
   api: ExtendedSelectionAPI;
@@ -98,8 +98,6 @@ export const announceSelectionStatus = (
     announce({ keys: ['SNTable.SelectionLabel.ExitedSelectionMode'] });
   }
 };
-
-const isShiftArrow = (evt: React.KeyboardEvent) => evt.shiftKey && isArrowKey(evt.key);
 
 /**
  * Get the updated selected rows for when (de)selecting one row

--- a/src/table/utils/selections-utils.ts
+++ b/src/table/utils/selections-utils.ts
@@ -2,6 +2,7 @@ import { stardust } from '@nebula.js/stardust';
 import { Cell, ExtendedSelectionAPI, Announce, Row } from '../../types';
 import { SelectionState, ActionPayload, SelectionActionTypes, SelectionDispatch } from '../types';
 import { SelectionActions, SelectionStates, KeyCodes } from '../constants';
+import { isArrowKey } from './handle-key-press';
 
 interface AddSelectionListenersArgs {
   api: ExtendedSelectionAPI;
@@ -98,7 +99,7 @@ export const announceSelectionStatus = (
   }
 };
 
-const isShiftArrow = (evt: React.KeyboardEvent) => evt.shiftKey && evt.key.includes('Arrow');
+const isShiftArrow = (evt: React.KeyboardEvent) => evt.shiftKey && isArrowKey(evt.key);
 
 /**
  * Get the updated selected rows for when (de)selecting one row


### PR DESCRIPTION
To reduce risk of arrow key events being picked up at higher levels. This is sometimes used to navigate between charts on a "sheet". Without stopping the propagation, this could potentially make you lose focus when you intended to stay inside the table. pagination specifically since it has no listener for arrows