### PR TITLE
fix: correct index usage for select multiple

### DIFF
--- a/src/__test__/generate-test-data.ts
+++ b/src/__test__/generate-test-data.ts
@@ -68,7 +68,7 @@ export const createCell = (rowIdx: number, colIdx = 0) =>
 /**
  * creates a simplified Rows[] with one column. Used to create the pageRows that is in the selection state
  */
-export const createAllRows = (rows: number, colIdx = 0) => {
+export const createPageRows = (rows: number, colIdx = 0) => {
   const pageRows: Row[] = [];
   for (let idx = 0; idx <= rows; idx++) {
     pageRows.push({ [`col-${colIdx}`]: createCell(idx, colIdx) });

--- a/src/__test__/generate-test-data.ts
+++ b/src/__test__/generate-test-data.ts
@@ -61,17 +61,17 @@ export const createCell = (rowIdx: number, colIdx = 0) =>
     qElemNumber: rowIdx,
     rowIdx,
     colIdx,
-    rawRowIdx: rowIdx,
-    rawColIdx: colIdx,
+    pageRowIdx: rowIdx,
+    pageColIdx: colIdx,
   } as Cell);
 
 /**
- * creates a simplified Rows[] with one column. Used to create the allRows that is in the selection state
+ * creates a simplified Rows[] with one column. Used to create the pageRows that is in the selection state
  */
 export const createAllRows = (rows: number, colIdx = 0) => {
-  const allRows: Row[] = [];
+  const pageRows: Row[] = [];
   for (let idx = 0; idx <= rows; idx++) {
-    allRows.push({ [`col-${colIdx}`]: createCell(idx, colIdx) });
+    pageRows.push({ [`col-${colIdx}`]: createCell(idx, colIdx) });
   }
-  return allRows;
+  return pageRows;
 };

--- a/src/__test__/handle-data.spec.ts
+++ b/src/__test__/handle-data.spec.ts
@@ -113,13 +113,13 @@ describe('handle-data', () => {
       expect(firstColCell.qText).toBe('2');
       expect(firstColCell.rowIdx).toBe(100);
       expect(firstColCell.colIdx).toBe(0);
-      expect(firstColCell.rawRowIdx).toBe(0);
-      expect(firstColCell.rawColIdx).toBe(2);
+      expect(firstColCell.pageRowIdx).toBe(0);
+      expect(firstColCell.pageColIdx).toBe(2);
       expect(secondColCell.qText).toBe('0');
       expect(secondColCell.rowIdx).toBe(100);
       expect(secondColCell.colIdx).toBe(1);
-      expect(secondColCell.rawRowIdx).toBe(0);
-      expect(secondColCell.rawColIdx).toBe(0);
+      expect(secondColCell.pageRowIdx).toBe(0);
+      expect(secondColCell.pageColIdx).toBe(0);
       expect(columns).toHaveLength(4);
       columns.forEach((c, i) => {
         expect(c.id).toBe(Object.keys(rows[0])[i + 1]); // skip the first key

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -123,19 +123,23 @@ export default async function manageData(
 
   const rows = dataPages[0].qMatrix.map((r, rowIdx) => {
     const row: Row = { key: `row-${rowIdx}` };
+    // the backend indexes are stored as col/rowIdx while the indexes shown on a page is pageCol/RowIdx
     columns.forEach((c, colIdx) => {
       row[c.id] = {
         ...r[colIdx],
         rowIdx: rowIdx + top,
         colIdx: columnOrder[colIdx],
+        pageRowIdx: rowIdx,
+        pageColIdx: colIdx,
         isSelectable: c.isDim && !c.isLocked,
-        rawRowIdx: rowIdx,
-        rawColIdx: colIdx,
         isLastRow: rowIdx === height - 1,
       };
     });
     return row;
   });
+
   const totalsPosition = getTotalPosition(layout);
+
+  console.log('data rows', rows);
   return { totalColumnCount, totalRowCount, totalPages, paginationNeeded, rows, columns, totalsPosition };
 }

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -140,6 +140,5 @@ export default async function manageData(
 
   const totalsPosition = getTotalPosition(layout);
 
-  console.log('data rows', rows);
   return { totalColumnCount, totalRowCount, totalPages, paginationNeeded, rows, columns, totalsPosition };
 }

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -123,7 +123,7 @@ export default async function manageData(
 
   const rows = dataPages[0].qMatrix.map((r, rowIdx) => {
     const row: Row = { key: `row-${rowIdx}` };
-    // the backend indexes are stored as col/rowIdx while the indexes shown on a page is pageCol/RowIdx
+    // the backend indexes are stored as col/rowIdx while the indexes for the loaded page is pageCol/RowIdx
     columns.forEach((c, colIdx) => {
       row[c.id] = {
         ...r[colIdx],

--- a/src/table/Root.tsx
+++ b/src/table/Root.tsx
@@ -16,7 +16,7 @@ export function render(props: RenderProps, reactRoot?: ReactDom.Root) {
   reactRoot?.render(
     <StyleSheetManager stylisPlugins={direction === 'rtl' ? [rtlPluginSc] : undefined}>
       <ThemeProvider theme={muiTheme}>
-        <TableContextProvider selectionsAPI={selectionsAPI} tableRows={tableData?.rows}>
+        <TableContextProvider selectionsAPI={selectionsAPI} pageRows={tableData?.rows}>
           <TableWrapper {...(props as TableWrapperProps)} />
         </TableContextProvider>
       </ThemeProvider>

--- a/src/table/components/TableBodyWrapper.tsx
+++ b/src/table/components/TableBodyWrapper.tsx
@@ -62,7 +62,7 @@ function TableBodyWrapper({
       areBasicFeaturesEnabled={areBasicFeaturesEnabled}
     />
   );
-
+  console.log('body rows', rows);
   return (
     <StyledTableBody paginationNeeded={paginationNeeded} bodyCellStyle={bodyCellStyle}>
       {totalsPosition === 'top' ? totals : undefined}

--- a/src/table/components/TableBodyWrapper.tsx
+++ b/src/table/components/TableBodyWrapper.tsx
@@ -62,7 +62,7 @@ function TableBodyWrapper({
       areBasicFeaturesEnabled={areBasicFeaturesEnabled}
     />
   );
-  console.log('body rows', rows);
+
   return (
     <StyledTableBody paginationNeeded={paginationNeeded} bodyCellStyle={bodyCellStyle}>
       {totalsPosition === 'top' ? totals : undefined}
@@ -76,6 +76,8 @@ function TableBodyWrapper({
         >
           {columns.map((column, columnIndex) => {
             const { id, align } = column;
+            // Note that rows are not necessarily ordered in qColumnOrder.
+            // So for each row, the cells are mapped according to column.id
             const cell = row[id] as Cell;
             const CellRenderer = columnRenderers[columnIndex];
             const handleKeyDown = (evt: React.KeyboardEvent) => {

--- a/src/table/components/__tests__/TableBodyWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableBodyWrapper.spec.tsx
@@ -30,7 +30,7 @@ describe('<TableBodyWrapper />', () => {
 
   const renderTableBody = () =>
     render(
-      // Need to mock selectionDispatch since UPDATE_ALL_ROWS action can create infinite loop
+      // Need to mock selectionDispatch since UPDATE_PAGE_ROWS action can create infinite loop
       <TableContextProvider selectionsAPI={selectionsAPI} selectionDispatchMock={jest.fn()}>
         <TableBodyWrapper
           tableData={tableData}

--- a/src/table/constants.ts
+++ b/src/table/constants.ts
@@ -13,7 +13,7 @@ export enum SelectionActions {
   SELECT_MULTI_END = 'selectMultiEnd',
   RESET = 'reset',
   CLEAR = 'clear',
-  UPDATE_ALL_ROWS = 'updateAllRows',
+  UPDATE_PAGE_ROWS = 'updatePageRows',
 }
 
 export enum KeyCodes {

--- a/src/table/context/TableContext.tsx
+++ b/src/table/context/TableContext.tsx
@@ -33,7 +33,7 @@ export const TableContextProvider = ({
   });
 
   useDidUpdateEffect(() => {
-    selectionDispatch({ type: SelectionActions.UPDATE_ALL_ROWS, payload: { pageRows } });
+    selectionDispatch({ type: SelectionActions.UPDATE_PAGE_ROWS, payload: { pageRows } });
   }, [pageRows]);
 
   return (

--- a/src/table/context/TableContext.tsx
+++ b/src/table/context/TableContext.tsx
@@ -18,14 +18,14 @@ const ProviderWithSelector = createSelectorProvider(TableContext);
 export const TableContextProvider = ({
   children,
   selectionsAPI,
-  tableRows = [],
+  pageRows = [],
   cellCoordMock,
   selectionDispatchMock,
 }: ContextProviderProps) => {
   const [headRowHeight, setHeadRowHeight] = useState(0);
   const [focusedCellCoord, setFocusedCellCoord] = useState((cellCoordMock || [0, 0]) as [number, number]);
   const [selectionState, selectionDispatch] = useReducer(reducer, {
-    allRows: tableRows,
+    pageRows,
     rows: {},
     colIdx: -1,
     api: selectionsAPI as ExtendedSelectionAPI, // TODO: update nebula api with correct selection api type
@@ -33,8 +33,8 @@ export const TableContextProvider = ({
   });
 
   useDidUpdateEffect(() => {
-    selectionDispatch({ type: SelectionActions.UPDATE_ALL_ROWS, payload: { allRows: tableRows } });
-  }, [tableRows]);
+    selectionDispatch({ type: SelectionActions.UPDATE_ALL_ROWS, payload: { pageRows } });
+  }, [pageRows]);
 
   return (
     <ProviderWithSelector

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -43,7 +43,7 @@ export interface SelectMultiEndAction extends Action<SelectionActions.SELECT_MUL
 export interface ResetAction extends Action<SelectionActions.RESET> {}
 export interface ClearAction extends Action<SelectionActions.CLEAR> {}
 export interface UpdateAllRowsAction extends Action<SelectionActions.UPDATE_ALL_ROWS> {
-  payload: { allRows: Row[] };
+  payload: { pageRows: Row[] };
 }
 
 export type SelectionActionTypes =
@@ -59,7 +59,7 @@ export type SelectionActionTypes =
 export type SelectionDispatch = React.Dispatch<SelectionActionTypes>;
 
 export interface SelectionState {
-  allRows: Row[];
+  pageRows: Row[];
   rows: Record<string, number>;
   colIdx: number;
   api: ExtendedSelectionAPI;
@@ -156,7 +156,7 @@ export interface HandleResetFocusProps {
 export interface ContextProviderProps {
   children: JSX.Element;
   selectionsAPI: ExtendedSelectionAPI;
-  tableRows?: Row[];
+  pageRows?: Row[];
   cellCoordMock?: [number, number];
   selectionDispatchMock?: jest.Mock<any, any>;
 }

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -42,7 +42,7 @@ export interface SelectMultiAddAction extends Action<SelectionActions.SELECT_MUL
 export interface SelectMultiEndAction extends Action<SelectionActions.SELECT_MULTI_END> {}
 export interface ResetAction extends Action<SelectionActions.RESET> {}
 export interface ClearAction extends Action<SelectionActions.CLEAR> {}
-export interface UpdateAllRowsAction extends Action<SelectionActions.UPDATE_ALL_ROWS> {
+export interface UpdatePageRowsAction extends Action<SelectionActions.UPDATE_PAGE_ROWS> {
   payload: { pageRows: Row[] };
 }
 
@@ -54,7 +54,7 @@ export type SelectionActionTypes =
   | SelectMultiEndAction
   | ResetAction
   | ClearAction
-  | UpdateAllRowsAction;
+  | UpdatePageRowsAction;
 
 export type SelectionDispatch = React.Dispatch<SelectionActionTypes>;
 

--- a/src/table/utils/__tests__/handle-click.spec.ts
+++ b/src/table/utils/__tests__/handle-click.spec.ts
@@ -31,8 +31,8 @@ describe('handle-click', () => {
   describe('handleClickToFocusBody', () => {
     let totalsPosition: TotalsPosition;
     const cell = {
-      rawRowIdx: 0,
-      rawColIdx: 0,
+      pageRowIdx: 0,
+      pageColIdx: 0,
     } as Cell;
 
     beforeEach(() => {

--- a/src/table/utils/__tests__/handle-key-press.spec.ts
+++ b/src/table/utils/__tests__/handle-key-press.spec.ts
@@ -510,7 +510,7 @@ describe('handle-key-press', () => {
         cancel: jest.fn(),
         isModal: () => isModal,
       } as unknown as ExtendedSelectionAPI;
-      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1, isSelectable: true, isLastRow: false, rawRowIdx: 1 } as Cell;
+      cell = { qElemNumber: 1, colIdx: 1, rowIdx: 1, isSelectable: true, isLastRow: false, pageRowIdx: 1 } as Cell;
       keyboard = { enabled: true } as unknown as stardust.Keyboard;
       selectionDispatch = jest.fn();
       isSelectionsEnabled = true;
@@ -600,7 +600,7 @@ describe('handle-key-press', () => {
     });
 
     it('when press shift + arrow up key on the second row cell, should prevent default behavior, remove current focus and set focus and attribute to the next cell, but not select values for dimension', () => {
-      cell.rawRowIdx = 0;
+      cell.pageRowIdx = 0;
       evt.shiftKey = true;
       evt.key = KeyCodes.UP;
 

--- a/src/table/utils/__tests__/selections-utils.spec.ts
+++ b/src/table/utils/__tests__/selections-utils.spec.ts
@@ -14,13 +14,13 @@ import {
   SelectAction,
   ResetAction,
   ClearAction,
-  UpdateAllRowsAction,
+  UpdatePageRowsAction,
   SelectMouseDownAction,
   SelectMultiAddAction,
   SelectMouseUpAction,
 } from '../../types';
 import { SelectionStates, SelectionActions, KeyCodes } from '../../constants';
-import { createCell, createAllRows } from '../../../__test__/generate-test-data';
+import { createCell, createPageRows } from '../../../__test__/generate-test-data';
 
 describe('selections-utils', () => {
   describe('addSelectionListeners', () => {
@@ -195,7 +195,7 @@ describe('selections-utils', () => {
       let announce: jest.Mock<any, any>;
 
       beforeEach(() => {
-        state.pageRows = createAllRows(4, 1);
+        state.pageRows = createPageRows(4, 1);
         state.firstCell = undefined;
         evt = { shiftKey: false, key: KeyCodes.DOWN } as React.KeyboardEvent;
         announce = jest.fn();
@@ -349,9 +349,9 @@ describe('selections-utils', () => {
         expect(newState).toBe(state);
       });
 
-      it('should return state updated with pageRows when action.type is updateAllRows', () => {
+      it('should return state updated with pageRows when action.type is updatePageRows', () => {
         const pageRows = [{} as unknown as Row];
-        const action = { type: SelectionActions.UPDATE_ALL_ROWS, payload: { pageRows } } as UpdateAllRowsAction;
+        const action = { type: SelectionActions.UPDATE_PAGE_ROWS, payload: { pageRows } } as UpdatePageRowsAction;
         const newState = reducer(state, action);
         expect(newState).toEqual({ ...state, pageRows });
       });
@@ -464,7 +464,7 @@ describe('selections-utils', () => {
     let firstCell: Cell | undefined;
 
     beforeEach(() => {
-      pageRows = createAllRows(3);
+      pageRows = createPageRows(3);
       selectedRows = { '2': 2 };
       cell = createCell(1);
       evt = {} as React.KeyboardEvent;
@@ -520,7 +520,7 @@ describe('selections-utils', () => {
       } as Cell;
 
       selectionState = {
-        pageRows: createAllRows(4),
+        pageRows: createPageRows(4),
         colIdx: 1,
         rows: { 1: 1 },
         api: {

--- a/src/table/utils/__tests__/selections-utils.spec.ts
+++ b/src/table/utils/__tests__/selections-utils.spec.ts
@@ -118,7 +118,7 @@ describe('selections-utils', () => {
 
     beforeEach(() => {
       state = {
-        allRows: [] as Row[],
+        pageRows: [] as Row[],
         rows: { 1: 1 },
         colIdx: 1,
         api: {
@@ -195,7 +195,7 @@ describe('selections-utils', () => {
       let announce: jest.Mock<any, any>;
 
       beforeEach(() => {
-        state.allRows = createAllRows(4, 1);
+        state.pageRows = createAllRows(4, 1);
         state.firstCell = undefined;
         evt = { shiftKey: false, key: KeyCodes.DOWN } as React.KeyboardEvent;
         announce = jest.fn();
@@ -349,11 +349,11 @@ describe('selections-utils', () => {
         expect(newState).toBe(state);
       });
 
-      it('should return state updated with allRows when action.type is updateAllRows', () => {
-        const allRows = [{} as unknown as Row];
-        const action = { type: SelectionActions.UPDATE_ALL_ROWS, payload: { allRows } } as UpdateAllRowsAction;
+      it('should return state updated with pageRows when action.type is updateAllRows', () => {
+        const pageRows = [{} as unknown as Row];
+        const action = { type: SelectionActions.UPDATE_ALL_ROWS, payload: { pageRows } } as UpdateAllRowsAction;
         const newState = reducer(state, action);
-        expect(newState).toEqual({ ...state, allRows });
+        expect(newState).toEqual({ ...state, pageRows });
       });
     });
   });
@@ -457,14 +457,14 @@ describe('selections-utils', () => {
   });
 
   describe('getMultiSelectedRows', () => {
-    let allRows: Row[];
+    let pageRows: Row[];
     let selectedRows: Record<string, number>;
     let cell: Cell;
     let evt: React.KeyboardEvent;
     let firstCell: Cell | undefined;
 
     beforeEach(() => {
-      allRows = createAllRows(3);
+      pageRows = createAllRows(3);
       selectedRows = { '2': 2 };
       cell = createCell(1);
       evt = {} as React.KeyboardEvent;
@@ -475,7 +475,7 @@ describe('selections-utils', () => {
       evt.shiftKey = true;
       evt.key = KeyCodes.DOWN;
 
-      const updatedSelectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
+      const updatedSelectedRows = getMultiSelectedRows(pageRows, selectedRows, cell, evt, firstCell);
       expect(updatedSelectedRows).toEqual({
         ...selectedRows,
         [cell.qElemNumber]: cell.rowIdx,
@@ -487,7 +487,7 @@ describe('selections-utils', () => {
       evt.shiftKey = true;
       evt.key = KeyCodes.UP;
 
-      const updatedSelectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
+      const updatedSelectedRows = getMultiSelectedRows(pageRows, selectedRows, cell, evt, firstCell);
       expect(updatedSelectedRows).toEqual({
         ...selectedRows,
         [cell.qElemNumber]: cell.rowIdx,
@@ -496,13 +496,13 @@ describe('selections-utils', () => {
     });
 
     it('should return selectedRows unchanged when not shift+arrow but firstCell is undefined', () => {
-      const updatedSelectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
+      const updatedSelectedRows = getMultiSelectedRows(pageRows, selectedRows, cell, evt, firstCell);
       expect(updatedSelectedRows).toBe(selectedRows);
     });
 
     it('should return rows updated with all rows between firstCell and cell', () => {
       firstCell = createCell(3);
-      const updatedSelectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
+      const updatedSelectedRows = getMultiSelectedRows(pageRows, selectedRows, cell, evt, firstCell);
       expect(updatedSelectedRows).toEqual({ '1': 1, '2': 2, '3': 3 });
     });
   });
@@ -520,7 +520,7 @@ describe('selections-utils', () => {
       } as Cell;
 
       selectionState = {
-        allRows: createAllRows(4),
+        pageRows: createAllRows(4),
         colIdx: 1,
         rows: { 1: 1 },
         api: {

--- a/src/table/utils/handle-click.ts
+++ b/src/table/utils/handle-click.ts
@@ -12,9 +12,9 @@ export const handleClickToFocusBody = (
   keyboard: stardust.Keyboard,
   totalsPosition: TotalsPosition
 ) => {
-  const { rawRowIdx, rawColIdx } = cell;
-  const adjustedRowIdx = totalsPosition === 'top' ? rawRowIdx + 2 : rawRowIdx + 1;
-  removeTabAndFocusCell([adjustedRowIdx, rawColIdx], rootElement, setFocusedCellCoord, keyboard);
+  const { pageRowIdx, pageColIdx } = cell;
+  const adjustedRowIdx = totalsPosition === 'top' ? pageRowIdx + 2 : pageRowIdx + 1;
+  removeTabAndFocusCell([adjustedRowIdx, pageColIdx], rootElement, setFocusedCellCoord, keyboard);
 };
 
 export const handleClickToFocusHead = (

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -48,7 +48,7 @@ const shouldSelectMultiValues = (
   cell: Cell
 ) =>
   evt.shiftKey &&
-  ((evt.key === KeyCodes.UP && cell.rawRowIdx !== 0) || (evt.key === KeyCodes.DOWN && !cell.isLastRow)) &&
+  ((evt.key === KeyCodes.UP && cell.pageRowIdx !== 0) || (evt.key === KeyCodes.DOWN && !cell.isLastRow)) &&
   areBasicFeaturesEnabled &&
   isSelectionsEnabled &&
   cell.isSelectable;
@@ -201,7 +201,7 @@ export const handleBodyKeyDown = ({
 
   // Adjust the cellCoord depending on the totals position
   const firstBodyRowIdx = totalsPosition === 'top' ? 2 : 1;
-  const cellCoord: [number, number] = [cell.rawRowIdx + firstBodyRowIdx, cell.rawColIdx];
+  const cellCoord: [number, number] = [cell.pageRowIdx + firstBodyRowIdx, cell.pageColIdx];
   // Make sure you can't navigate to header (and totals) in selection mode
   const allowedRows = {
     top: isSelectionMode ? firstBodyRowIdx : 0,
@@ -211,7 +211,7 @@ export const handleBodyKeyDown = ({
   switch (evt.key) {
     case KeyCodes.UP:
     case KeyCodes.DOWN: {
-      evt.key === KeyCodes.UP && handleNavigateTop([cell.rawRowIdx, cell.rawColIdx], rootElement);
+      evt.key === KeyCodes.UP && handleNavigateTop([cell.pageRowIdx, cell.pageColIdx], rootElement);
       const nextCell = moveFocus(evt, rootElement, cellCoord, setFocusedCellCoord, allowedRows);
       // Shift + up/down arrow keys: select multiple values
       if (shouldSelectMultiValues(areBasicFeaturesEnabled, isSelectionsEnabled, evt, cell)) {

--- a/src/table/utils/selections-utils.ts
+++ b/src/table/utils/selections-utils.ts
@@ -172,7 +172,7 @@ export const getMultiSelectedRows = (
     newSelectedRows[cell.qElemNumber] = cell.rowIdx;
     // also add the next or previous cell to selectedRows, based on which arrow is pressed
     const idxShift = evt.key === KeyCodes.DOWN ? 1 : -1;
-    const nextCell = pageRows[cell.pageRowIdx + idxShift][`col-${cell.pageColIdx}`] as Cell;
+    const nextCell = pageRows[cell.pageRowIdx + idxShift][`col-${cell.colIdx}`] as Cell;
     newSelectedRows[nextCell.qElemNumber] = cell.rowIdx + idxShift;
     return newSelectedRows;
   }

--- a/src/table/utils/selections-utils.ts
+++ b/src/table/utils/selections-utils.ts
@@ -160,7 +160,7 @@ const selectCell = (state: SelectionState, payload: SelectPayload): SelectionSta
  * Get the updated selected rows for when selecting multiple rows
  */
 export const getMultiSelectedRows = (
-  allRows: Row[],
+  pageRows: Row[],
   selectedRows: Record<string, number>,
   cell: Cell,
   evt: React.KeyboardEvent | React.MouseEvent,
@@ -172,17 +172,17 @@ export const getMultiSelectedRows = (
     newSelectedRows[cell.qElemNumber] = cell.rowIdx;
     // also add the next or previous cell to selectedRows, based on which arrow is pressed
     const idxShift = evt.key === KeyCodes.DOWN ? 1 : -1;
-    const nextCell = allRows[cell.rawRowIdx + idxShift][`col-${cell.rawColIdx}`] as Cell;
+    const nextCell = pageRows[cell.pageRowIdx + idxShift][`col-${cell.pageColIdx}`] as Cell;
     newSelectedRows[nextCell.qElemNumber] = cell.rowIdx + idxShift;
     return newSelectedRows;
   }
 
   if (!firstCell) return selectedRows;
-  const lowestCellIdx = Math.min(firstCell.rawRowIdx, cell.rawRowIdx);
-  const highestCellIdx = Math.max(firstCell.rawRowIdx, cell.rawRowIdx);
+  const lowestRowIdx = Math.min(firstCell.pageRowIdx, cell.pageRowIdx);
+  const highestRowIdx = Math.max(firstCell.pageRowIdx, cell.pageRowIdx);
 
-  for (let idx = lowestCellIdx; idx <= highestCellIdx; idx++) {
-    const selectedCell = allRows[idx][`col-${firstCell.rawColIdx}`] as Cell;
+  for (let idx = lowestRowIdx; idx <= highestRowIdx; idx++) {
+    const selectedCell = pageRows[idx][`col-${firstCell.colIdx}`] as Cell;
     newSelectedRows[selectedCell.qElemNumber] = selectedCell.rowIdx;
   }
 
@@ -193,7 +193,7 @@ export const getMultiSelectedRows = (
  * Updates the selection state but bot the backend when selecting multiple rows
  */
 const selectMultipleCells = (state: SelectionState, payload: SelectPayload): SelectionState => {
-  const { api, rows, colIdx, allRows, firstCell } = state;
+  const { api, rows, colIdx, pageRows, firstCell } = state;
   const { cell, announce, evt } = payload;
   let selectedRows: Record<string, number> = {};
 
@@ -202,7 +202,7 @@ const selectMultipleCells = (state: SelectionState, payload: SelectPayload): Sel
   if (colIdx === -1) api.begin(['/qHyperCubeDef']);
   else selectedRows = { ...rows };
 
-  selectedRows = getMultiSelectedRows(allRows, selectedRows, cell, evt, firstCell);
+  selectedRows = getMultiSelectedRows(pageRows, selectedRows, cell, evt, firstCell);
   announceSelectionStatus(announce, rows, selectedRows);
 
   return { ...state, rows: selectedRows, colIdx: firstCell?.colIdx ?? cell.colIdx, isSelectMultiValues: true };
@@ -267,7 +267,7 @@ export const reducer = (state: SelectionState, action: SelectionActionTypes): Se
     case SelectionActions.CLEAR:
       return Object.keys(state.rows).length ? { ...state, rows: {} } : state;
     case SelectionActions.UPDATE_ALL_ROWS:
-      return { ...state, allRows: action.payload.allRows };
+      return { ...state, pageRows: action.payload.pageRows };
     default:
       throw new Error('reducer called with invalid action type');
   }

--- a/src/table/utils/selections-utils.ts
+++ b/src/table/utils/selections-utils.ts
@@ -266,7 +266,7 @@ export const reducer = (state: SelectionState, action: SelectionActionTypes): Se
       return state.api.isModal() ? state : { ...state, rows: {}, colIdx: -1 };
     case SelectionActions.CLEAR:
       return Object.keys(state.rows).length ? { ...state, rows: {} } : state;
-    case SelectionActions.UPDATE_ALL_ROWS:
+    case SelectionActions.UPDATE_PAGE_ROWS:
       return { ...state, pageRows: action.payload.pageRows };
     default:
       throw new Error('reducer called with invalid action type');

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,9 +88,9 @@ export interface Cell {
   qElemNumber: number;
   rowIdx: number;
   colIdx: number;
+  pageRowIdx: number;
+  pageColIdx: number;
   isSelectable: boolean;
-  rawRowIdx: number;
-  rawColIdx: number;
   isLastRow: boolean;
 }
 


### PR DESCRIPTION
Was using the wrong column index. Was really confused by the which one is which, so I renamed them
- rawCol/RowIdx -> pageCol/RowIdx. raw never made sense to me since raw could refer to the raw data, meaning the entire data set. page refers dataPage, so row 0 is the first row that we are actually showing atm
- allRows -> pageRows. Same terminology, it is all rows on the dataPage