### PR TITLE
refactor: align hooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export default function supernova(env: Galaxy) {
       const rect = useRect();
       const theme = useExtendedTheme(rootElement);
       const announce = useAnnounceAndTranslations(rootElement, translator);
-      const changeSortOrder = useSorting(model);
+      const changeSortOrder = useSorting(model, layout.qHyperCube);
 
       const [pageInfo, setPageInfo] = useState(initialPageInfo);
       const [tableData] = usePromise(

--- a/src/nebula-hooks/__tests__/use-sorting.spec.ts
+++ b/src/nebula-hooks/__tests__/use-sorting.spec.ts
@@ -6,7 +6,8 @@ describe('use-sorting', () => {
   describe('sortingFactory', () => {
     it('should return undefined when model is undefined', async () => {
       const model = undefined;
-      const changeSortOrder = sortingFactory(model);
+      const hyperCube = {} as HyperCube;
+      const changeSortOrder = sortingFactory(model, hyperCube);
       expect(changeSortOrder).toBeUndefined();
     });
   });
@@ -16,7 +17,7 @@ describe('use-sorting', () => {
     let column: Column;
     let layout: TableLayout;
     let model: EngineAPI.IGenericObject;
-    let changeSortOrder: ((layout: TableLayout, column: Column) => Promise<void>) | undefined;
+    let changeSortOrder: ((column: Column) => Promise<void>) | undefined;
     let expectedPatches: EngineAPI.INxPatch[];
 
     beforeEach(() => {
@@ -32,7 +33,7 @@ describe('use-sorting', () => {
             } as unknown as HyperCube,
           }),
       } as unknown as EngineAPI.IGenericObject;
-      changeSortOrder = sortingFactory(model);
+      changeSortOrder = sortingFactory(model, layout.qHyperCube);
       expectedPatches = [
         {
           qPath: '/qHyperCubeDef/qInterColumnSortOrder',
@@ -46,7 +47,7 @@ describe('use-sorting', () => {
       expectedPatches[0].qValue = '[1,0,2,3]';
 
       if (changeSortOrder) {
-        await changeSortOrder(layout, column);
+        await changeSortOrder(column);
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
@@ -60,7 +61,7 @@ describe('use-sorting', () => {
       });
 
       if (changeSortOrder) {
-        await changeSortOrder(layout, column);
+        await changeSortOrder(column);
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
@@ -76,7 +77,7 @@ describe('use-sorting', () => {
       });
 
       if (changeSortOrder) {
-        await changeSortOrder(layout, column);
+        await changeSortOrder(column);
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });

--- a/src/nebula-hooks/use-sorting.ts
+++ b/src/nebula-hooks/use-sorting.ts
@@ -1,10 +1,10 @@
 import { useMemo } from '@nebula.js/stardust';
-import { TableLayout, Column } from '../types';
+import { Column, HyperCube } from '../types';
 
-export const sortingFactory = (model: EngineAPI.IGenericObject | undefined) => {
+export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, hyperCube: HyperCube) => {
   if (!model) return undefined;
 
-  return async (layout: TableLayout, column: Column) => {
+  return async (column: Column) => {
     const { isDim, dataColIdx } = column;
     // The sort order from the properties is needed since it contains hidden columns
     const properties = await model.getEffectiveProperties();
@@ -26,7 +26,7 @@ export const sortingFactory = (model: EngineAPI.IGenericObject | undefined) => {
 
     // reverse
     if (dataColIdx === topSortIdx) {
-      const { qDimensionInfo, qMeasureInfo } = layout.qHyperCube;
+      const { qDimensionInfo, qMeasureInfo } = hyperCube;
       const idx = isDim ? dataColIdx : dataColIdx - qDimensionInfo.length;
       const { qReverseSort } = isDim ? qDimensionInfo[idx] : qMeasureInfo[idx];
       const qPath = `/qHyperCubeDef/${isDim ? 'qDimensions' : 'qMeasures'}/${idx}/qDef/qReverseSort`;
@@ -42,5 +42,6 @@ export const sortingFactory = (model: EngineAPI.IGenericObject | undefined) => {
   };
 };
 
-const useSorting = (model: EngineAPI.IGenericObject | undefined) => useMemo(() => sortingFactory(model), [model]);
+const useSorting = (model: EngineAPI.IGenericObject | undefined, hyperCube: HyperCube) =>
+  useMemo(() => sortingFactory(model, hyperCube), [model, hyperCube]);
 export default useSorting;

--- a/src/table/components/TableHeadWrapper.tsx
+++ b/src/table/components/TableHeadWrapper.tsx
@@ -53,7 +53,6 @@ function TableHeadWrapper({
               cellCoord: [0, columnIndex],
               column,
               changeSortOrder,
-              layout,
               isInteractionEnabled,
               setFocusedCellCoord,
               areBasicFeaturesEnabled,
@@ -71,7 +70,7 @@ function TableHeadWrapper({
               aria-pressed={isCurrentColumnActive}
               onKeyDown={handleKeyDown}
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
-              onClick={() => isInteractionEnabled && changeSortOrder(layout, column)}
+              onClick={() => isInteractionEnabled && changeSortOrder(column)}
             >
               <StyledSortLabel
                 headerStyle={headerStyle}

--- a/src/table/components/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.tsx
@@ -86,7 +86,7 @@ describe('<TableHeadWrapper />', () => {
     const { getByText } = renderTableHead();
     fireEvent.click(getByText(tableData.columns[0].label));
 
-    expect(changeSortOrder).toHaveBeenCalledWith(layout, tableData.columns[0]);
+    expect(changeSortOrder).toHaveBeenCalledWith(tableData.columns[0]);
   });
 
   it('should not call changeSortOrder when clicking a header cell in edit mode', () => {

--- a/src/table/context/TableContext.tsx
+++ b/src/table/context/TableContext.tsx
@@ -1,11 +1,8 @@
-import React, { useState, useReducer, createContext } from 'react';
+import React, { useState, createContext } from 'react';
 
 import { createSelectorProvider } from './createSelectorProvider';
-import { reducer } from '../utils/selections-utils';
-import { ExtendedSelectionAPI } from '../../types';
 import { ContextValue, ContextProviderProps } from '../types';
-import useDidUpdateEffect from '../hooks/use-did-update-effect';
-import { SelectionActions } from '../constants';
+import useSelectionReducer from '../hooks/use-selection-reducer';
 
 // In order to not have typing issues when using properties on the context,
 // the initial value for the context is casted to ContextValue.
@@ -24,17 +21,7 @@ export const TableContextProvider = ({
 }: ContextProviderProps) => {
   const [headRowHeight, setHeadRowHeight] = useState(0);
   const [focusedCellCoord, setFocusedCellCoord] = useState((cellCoordMock || [0, 0]) as [number, number]);
-  const [selectionState, selectionDispatch] = useReducer(reducer, {
-    pageRows,
-    rows: {},
-    colIdx: -1,
-    api: selectionsAPI as ExtendedSelectionAPI, // TODO: update nebula api with correct selection api type
-    isSelectMultiValues: false,
-  });
-
-  useDidUpdateEffect(() => {
-    selectionDispatch({ type: SelectionActions.UPDATE_PAGE_ROWS, payload: { pageRows } });
-  }, [pageRows]);
+  const [selectionState, selectionDispatch] = useSelectionReducer(pageRows, selectionsAPI);
 
   return (
     <ProviderWithSelector

--- a/src/table/hooks/use-selection-reducer.ts
+++ b/src/table/hooks/use-selection-reducer.ts
@@ -1,0 +1,28 @@
+import { useReducer } from 'react';
+
+import { ExtendedSelectionAPI, Row } from '../../types';
+import { SelectionDispatch, SelectionState } from '../types';
+import { reducer } from '../utils/selections-utils';
+import { SelectionActions } from '../constants';
+import useDidUpdateEffect from './use-did-update-effect';
+
+const useSelectionReducer = (
+  pageRows: Row[],
+  selectionsAPI: ExtendedSelectionAPI
+): [SelectionState, SelectionDispatch] => {
+  const [selectionState, selectionDispatch] = useReducer(reducer, {
+    pageRows,
+    rows: {},
+    colIdx: -1,
+    api: selectionsAPI as ExtendedSelectionAPI, // TODO: update nebula api with correct selection api type
+    isSelectMultiValues: false,
+  });
+
+  useDidUpdateEffect(() => {
+    selectionDispatch({ type: SelectionActions.UPDATE_PAGE_ROWS, payload: { pageRows } });
+  }, [pageRows]);
+
+  return [selectionState, selectionDispatch];
+};
+
+export default useSelectionReducer;

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -116,7 +116,6 @@ export interface HandleHeadKeyDownProps {
   cellCoord: [number, number];
   column: Column;
   changeSortOrder: ChangeSortOrder;
-  layout: TableLayout;
   isInteractionEnabled: boolean;
   setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
   areBasicFeaturesEnabled: boolean;

--- a/src/table/utils/__tests__/handle-key-press.spec.ts
+++ b/src/table/utils/__tests__/handle-key-press.spec.ts
@@ -13,7 +13,7 @@ import {
 import * as handleAccessibility from '../accessibility-utils';
 import * as handleScroll from '../handle-scroll';
 import * as handleCopy from '../copy-utils';
-import { Announce, Column, ExtendedSelectionAPI, Cell, TableLayout, TotalsPosition } from '../../../types';
+import { Announce, Column, ExtendedSelectionAPI, Cell, TotalsPosition } from '../../../types';
 import { SelectionDispatch } from '../../types';
 import { KeyCodes } from '../../constants';
 
@@ -275,8 +275,7 @@ describe('handle-key-press', () => {
     let column: Column;
     let evt: React.KeyboardEvent;
     let rootElement: HTMLElement;
-    let changeSortOrder: (layout: TableLayout, column: Column) => Promise<void>;
-    let layout: TableLayout;
+    let changeSortOrder: (column: Column) => Promise<void>;
     let isInteractionEnabled: boolean;
     let setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
 
@@ -287,7 +286,6 @@ describe('handle-key-press', () => {
         cellCoord: [rowIndex, colIndex],
         column,
         changeSortOrder,
-        layout,
         isInteractionEnabled,
         setFocusedCellCoord,
         areBasicFeaturesEnabled,

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -115,7 +115,6 @@ export const handleHeadKeyDown = ({
   cellCoord,
   column,
   changeSortOrder,
-  layout,
   isInteractionEnabled,
   setFocusedCellCoord,
   areBasicFeaturesEnabled,
@@ -136,7 +135,7 @@ export const handleHeadKeyDown = ({
     case KeyCodes.SPACE:
     case KeyCodes.ENTER:
       // Space bar / Enter: update the sorting
-      changeSortOrder(layout, column);
+      changeSortOrder(column);
       break;
     case KeyCodes.C: {
       areBasicFeaturesEnabled && (evt.ctrlKey || evt.metaKey) && copyCellValue(evt);

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,7 @@ export interface AnnounceArgs {
 
 export type Announce = (arg0: AnnounceArgs) => void;
 
-export type ChangeSortOrder = (layout: TableLayout, column: Column) => Promise<void>;
+export type ChangeSortOrder = (column: Column) => Promise<void>;
 
 export interface Galaxy {
   translator: ExtendedTranslator;


### PR DESCRIPTION
Noticed some things we could clean up.
- wrap the selection reducer in a hook. Will ad more stuff to TableContext so want to keep it clean
- not passing layout to sorting. When it changes we rerender from root, so we can add the hypercube in the factory