### PR TITLE
refactor: put rows in order it should be rendered

### DIFF
--- a/src/__test__/handle-data.spec.ts
+++ b/src/__test__/handle-data.spec.ts
@@ -1,4 +1,4 @@
-import manageData, { getColumnOrder, getColumnInfo, getTotalInfo, getTotalPosition } from '../handle-data';
+import manageData, { getColumns, getColumnInfo, getTotalInfo, getTotalPosition } from '../handle-data';
 import { generateDataPages, generateLayout } from './generate-test-data';
 import { TableLayout, PageInfo, SetPageInfo, TableData, Cell, ExtendedNxAttrExprInfo } from '../types';
 
@@ -73,18 +73,26 @@ describe('handle-data', () => {
     });
   });
 
-  describe('getColumnOrder', () => {
-    it('should return qColumnOrder when length of qColumnOrder equals the number of columns', () => {
-      const columnLayout = getColumnOrder(layout.qHyperCube);
-      expect(columnLayout).toBe(layout.qHyperCube.qColumnOrder);
-    });
-
-    it('should return [0, 1, ... , number of columns] when length of qColumnOrder does not equal number of columns', () => {
+  describe('getColumns', () => {
+    it('should return columns in default order when length of qColumnOrder does not equal number of columns', () => {
       layout.qHyperCube.qColumnOrder = [];
 
-      const columnLayout = getColumnOrder(layout.qHyperCube);
-      expect(columnLayout).toEqual([0, 1, 2, 3]);
+      const columns = getColumns(layout);
+      expect(columns[0].colIdx).toBe(0);
+      expect(columns[1].colIdx).toBe(1);
+      expect(columns[2].colIdx).toBe(2);
+      expect(columns[3].colIdx).toBe(3);
     });
+
+    it('should return columns in defined column order when qColumnOrder is set', () => {
+      const columns = getColumns(layout);
+      expect(columns[0].colIdx).toBe(1);
+      expect(columns[1].colIdx).toBe(2);
+      expect(columns[2].colIdx).toBe(0);
+      expect(columns[3].colIdx).toBe(3);
+    });
+
+    // it('should return [0, 1, ... , number of columns] when length of qColumnOrder does not equal number of columns', () => {});
   });
 
   describe('manageData', () => {

--- a/src/__test__/handle-data.spec.ts
+++ b/src/__test__/handle-data.spec.ts
@@ -96,7 +96,6 @@ describe('handle-data', () => {
       pageInfo = { page: 1, rowsPerPage: 100, rowsPerPageOptions: [10, 25, 100] };
       model = { getHyperCubeData: async () => generateDataPages(100, 4) } as unknown as EngineAPI.IGenericObject;
       setPageInfo = jest.fn();
-      // console.log(generateDataPages(100, 4)[0].qMatrix[0]);
     });
 
     it('should return size, rows and columns correctly formatted', async () => {
@@ -109,8 +108,6 @@ describe('handle-data', () => {
 
       const firstColCell = rows[0]['col-0'] as Cell;
       const secondColCell = rows[0]['col-1'] as Cell;
-
-      console.log(rows);
 
       expect(totalColumnCount).toBe(layout.qHyperCube.qSize.qcx);
       expect(totalRowCount).toBe(layout.qHyperCube.qSize.qcy);
@@ -186,8 +183,6 @@ describe('handle-data', () => {
 
     it('should not get any total measure value when qGrandTotalRow has no value', () => {
       layout.qHyperCube.qGrandTotalRow = [];
-      expect(getTotalInfo(layout, 0, 0, 2)).toBe('Totals');
-      expect(getTotalInfo(layout, 1, 1, 2)).toBe('');
       expect(getTotalInfo(layout, 2, 2, 2)).toBe(undefined);
       expect(getTotalInfo(layout, 3, 3, 2)).toBe(undefined);
     });

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -23,29 +23,31 @@ export function getHighestPossibleRpp(width: number, rowsPerPageOptions: number[
   return highestPossibleOption || Math.floor(MAX_CELLS / width); // covering corner case of lowest option being too high
 }
 
+/**
+ * Gets columns order, if it does not exist, create a new default one, [1, 2, ... nCols]
+ */
 export function getColumnOrder({ qColumnOrder, qDimensionInfo, qMeasureInfo }: HyperCube): number[] {
   const columnsLength = qDimensionInfo.length + qMeasureInfo.length;
   return qColumnOrder?.length === columnsLength ? qColumnOrder : Array.from(Array(columnsLength).keys());
 }
 
-// Get total cell info
-export function getTotalInfo(
-  isDim: boolean,
-  layout: TableLayout,
-  colIndex: number,
-  numDims: number,
-  columnOrder: number[]
-) {
-  if (!isDim) return layout.qHyperCube.qGrandTotalRow[colIndex - numDims]?.qText;
-  if (colIndex === 0 && columnOrder[0] === 0) return layout.totals.label;
+/**
+ * Gets the totals text for a column
+ */
+export function getTotalInfo(layout: TableLayout, colIdx: number, pageColIdx: number, numDims: number) {
+  if (colIdx >= numDims) return layout.qHyperCube.qGrandTotalRow[colIdx - numDims]?.qText;
+  if (colIdx === 0 && pageColIdx === 0) return layout.totals.label;
   return '';
 }
 
-export function getColumnInfo(layout: TableLayout, colIndex: number, columnOrder: number[]): false | Column {
+/**
+ * Gets all column info, returns false if hidden
+ */
+export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: number): false | Column {
   const { qDimensionInfo, qMeasureInfo } = layout.qHyperCube;
   const numDims = qDimensionInfo.length;
-  const isDim = colIndex < numDims;
-  const info = (isDim ? qDimensionInfo[colIndex] : qMeasureInfo[colIndex - numDims]) as
+  const isDim = colIdx < numDims;
+  const info = (isDim ? qDimensionInfo[colIdx] : qMeasureInfo[colIdx - numDims]) as
     | ExtendedNxMeasureInfo
     | ExtendedNxDimensionInfo;
   const isHidden = info.qError?.qErrorCode === 7005;
@@ -56,35 +58,41 @@ export function getColumnInfo(layout: TableLayout, colIndex: number, columnOrder
     !isHidden && {
       isDim,
       isLocked,
-      width: 200,
+      colIdx,
+      pageColIdx,
+      id: `col-${pageColIdx}`,
       label: info.qFallbackTitle,
-      id: `col-${colIndex}`,
       align: !info.textAlign || info.textAlign.auto ? autoAlign : info.textAlign.align,
       stylingIDs: info.qAttrExprInfo.map((expr) => expr.id),
       sortDirection: info.qSortIndicator ? DirectionMap[info.qSortIndicator] : DirectionMap.A,
-      dataColIdx: colIndex,
-      totalInfo: getTotalInfo(isDim, layout, colIndex, numDims, columnOrder),
+      totalInfo: getTotalInfo(layout, colIdx, pageColIdx, numDims),
     }
   );
 }
-
-// Get the position of the totals
+/**
+ * Get the position of the totals
+ */
 export function getTotalPosition(layout: TableLayout) {
-  const [hasOnlyMeasure, hasDimension, hasGrandTotal, hasMeasure, isTotalModeAuto] = [
-    layout.qHyperCube.qDimensionInfo.length === 0,
+  const [hasDimension, hasMeasure, hasGrandTotal, isTotalModeAuto, position] = [
     layout.qHyperCube.qDimensionInfo.length > 0,
-    layout.qHyperCube.qGrandTotalRow.length > 0,
     layout.qHyperCube.qMeasureInfo.length > 0,
+    layout.qHyperCube.qGrandTotalRow.length > 0,
     layout.totals?.show,
+    layout.totals.position,
   ];
 
-  if (hasGrandTotal && ((hasDimension && hasMeasure) || (!isTotalModeAuto && hasOnlyMeasure))) {
-    if (isTotalModeAuto || (!isTotalModeAuto && layout.totals.position === 'top')) return 'top';
-    if (!isTotalModeAuto && layout.totals.position === 'bottom') return 'bottom';
+  if (hasGrandTotal && ((hasDimension && hasMeasure) || (!isTotalModeAuto && !hasDimension))) {
+    if (isTotalModeAuto || position === 'top') return 'top';
+    if (!isTotalModeAuto && position === 'bottom') return 'bottom';
   }
   return 'noTotals';
 }
 
+/**
+ * Fetches the data for the given pageInfo. Returns rows and columns, sorted in the order they will be displayed,
+ * and meta data for size etc. The column/row indexes used in engine are stored as col/rowIdx, while the index within
+ * the displayed page is stored as pageRow/ColIdx
+ */
 export default async function manageData(
   model: EngineAPI.IGenericObject,
   layout: TableLayout,
@@ -101,12 +109,12 @@ export default async function manageData(
   const top = page * rowsPerPage;
   const height = Math.min(rowsPerPage, totalRowCount - top);
   // When the number of rows is reduced (e.g. confirming selections),
-  // you can end up still being on a page that doesn't exist anymore, then go back to the first page and return null
+  // you can end up still being on a page that doesn't exist anymore, then go back to the first page and rerender
   if (page > 0 && top >= totalRowCount && pageInfo) {
     setPageInfo({ ...pageInfo, page: 0 });
     return null;
   }
-  // If the number of cells exceeds 10k then we need to lower the rows per page to the maximum possible value
+  // If the number of cells exceeds 10k then we need to lower the rows per page to the maximum possible value and rerender
   if (height * totalColumnCount > MAX_CELLS && pageInfo) {
     setPageInfo({ ...pageInfo, rowsPerPage: getHighestPossibleRpp(totalColumnCount, rowsPerPageOptions), page: 0 });
     return null;
@@ -115,24 +123,23 @@ export default async function manageData(
   const columnOrder = getColumnOrder(qHyperCube);
   // using filter to remove hidden columns (represented with false)
   const columns = columnOrder
-    .map((colIndex) => getColumnInfo(layout, colIndex, columnOrder))
+    .map((colIdx, pageColIdx) => getColumnInfo(layout, colIdx, pageColIdx))
     .filter(Boolean) as Column[];
   const dataPages = await model.getHyperCubeData('/qHyperCubeDef', [
     { qTop: top, qLeft: 0, qHeight: height, qWidth: totalColumnCount },
   ]);
 
-  const rows = dataPages[0].qMatrix.map((r, rowIdx) => {
-    const row: Row = { key: `row-${rowIdx}` };
-    // the backend indexes are stored as col/rowIdx while the indexes for the loaded page is pageCol/RowIdx
-    columns.forEach((c, colIdx) => {
+  const rows = dataPages[0].qMatrix.map((r, pageRowIdx) => {
+    const row: Row = { id: `row-${pageRowIdx}` };
+    columns.forEach((c, pageColIdx) => {
       row[c.id] = {
-        ...r[colIdx],
-        rowIdx: rowIdx + top,
-        colIdx: columnOrder[colIdx],
-        pageRowIdx: rowIdx,
-        pageColIdx: colIdx,
+        ...r[pageColIdx],
+        rowIdx: pageRowIdx + top,
+        colIdx: columnOrder[pageColIdx],
+        pageRowIdx,
+        pageColIdx,
         isSelectable: c.isDim && !c.isLocked,
-        isLastRow: rowIdx === height - 1,
+        isLastRow: pageRowIdx === height - 1,
       };
     });
     return row;

--- a/src/nebula-hooks/__tests__/use-sorting.spec.ts
+++ b/src/nebula-hooks/__tests__/use-sorting.spec.ts
@@ -23,7 +23,7 @@ describe('use-sorting', () => {
     beforeEach(() => {
       originalOrder = [0, 1, 2, 3];
       layout = generateLayout(2, 2, 2);
-      column = { isDim: true, dataColIdx: 1 } as Column;
+      column = { isDim: true, colIdx: 1 } as Column;
       model = {
         applyPatches: jest.fn(),
         getEffectiveProperties: async () =>
@@ -53,7 +53,7 @@ describe('use-sorting', () => {
     });
 
     it('should call apply patches with another patch for qReverseSort for dimension', async () => {
-      column.dataColIdx = 0;
+      column.colIdx = 0;
       expectedPatches.push({
         qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
         qOp: 'Replace' as EngineAPI.NxPatchOpType,
@@ -67,7 +67,7 @@ describe('use-sorting', () => {
     });
 
     it('should call apply patches with another patch for qReverseSort for measure', async () => {
-      column = { isDim: false, dataColIdx: 2 } as Column;
+      column = { isDim: false, colIdx: 2 } as Column;
       originalOrder = [2, 0, 1, 3];
       expectedPatches[0].qValue = '[2,0,1,3]';
       expectedPatches.push({

--- a/src/nebula-hooks/use-sorting.ts
+++ b/src/nebula-hooks/use-sorting.ts
@@ -5,15 +5,15 @@ export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, hype
   if (!model) return undefined;
 
   return async (column: Column) => {
-    const { isDim, dataColIdx } = column;
+    const { isDim, colIdx } = column;
     // The sort order from the properties is needed since it contains hidden columns
     const properties = await model.getEffectiveProperties();
     const sortOrder = properties.qHyperCubeDef.qInterColumnSortOrder;
     const topSortIdx = sortOrder[0];
 
-    if (dataColIdx !== topSortIdx) {
-      sortOrder.splice(sortOrder.indexOf(dataColIdx), 1);
-      sortOrder.unshift(dataColIdx);
+    if (colIdx !== topSortIdx) {
+      sortOrder.splice(sortOrder.indexOf(colIdx), 1);
+      sortOrder.unshift(colIdx);
     }
 
     const patches = [
@@ -25,9 +25,9 @@ export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, hype
     ];
 
     // reverse
-    if (dataColIdx === topSortIdx) {
+    if (colIdx === topSortIdx) {
       const { qDimensionInfo, qMeasureInfo } = hyperCube;
-      const idx = isDim ? dataColIdx : dataColIdx - qDimensionInfo.length;
+      const idx = isDim ? colIdx : colIdx - qDimensionInfo.length;
       const { qReverseSort } = isDim ? qDimensionInfo[idx] : qMeasureInfo[idx];
       const qPath = `/qHyperCubeDef/${isDim ? 'qDimensions' : 'qMeasures'}/${idx}/qDef/qReverseSort`;
 

--- a/src/table/components/TableBodyWrapper.tsx
+++ b/src/table/components/TableBodyWrapper.tsx
@@ -73,7 +73,7 @@ function TableBodyWrapper({
           bodyCellStyle={bodyCellStyle}
           hover={hoverEffect}
           tabIndex={-1}
-          key={row.key}
+          key={row.id}
           className="sn-table-row"
         >
           {columns.map((column, columnIndex) => {

--- a/src/table/components/TableHeadWrapper.tsx
+++ b/src/table/components/TableHeadWrapper.tsx
@@ -41,7 +41,7 @@ function TableHeadWrapper({
           // The first cell in the head is focusable in sequential keyboard navigation,
           // when nebula does not handle keyboard navigation
           const tabIndex = columnIndex === 0 && !keyboard.enabled ? 0 : -1;
-          const isCurrentColumnActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.dataColIdx;
+          const isCurrentColumnActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.colIdx;
           const ariaSort = isCurrentColumnActive
             ? (`${column.sortDirection}ending` as 'ascending' | 'descending')
             : undefined;

--- a/src/table/components/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableHeadWrapper.spec.tsx
@@ -47,8 +47,8 @@ describe('<TableHeadWrapper />', () => {
   beforeEach(() => {
     tableData = {
       columns: [
-        { id: 1, align: 'left', label: 'someDim', sortDirection: 'asc', isDim: true, dataColIdx: 0 },
-        { id: 2, align: 'right', label: 'someMsr', sortDirection: 'desc', isDim: false, dataColIdx: 1 },
+        { id: 1, align: 'left', label: 'someDim', sortDirection: 'asc', isDim: true, colIdx: 0 },
+        { id: 2, align: 'right', label: 'someMsr', sortDirection: 'desc', isDim: false, colIdx: 1 },
       ],
     } as unknown as TableData;
     theme = {

--- a/src/table/components/__tests__/TableTotals.spec.tsx
+++ b/src/table/components/__tests__/TableTotals.spec.tsx
@@ -40,8 +40,8 @@ describe('<TableTotals />', () => {
   beforeEach(() => {
     tableData = {
       columns: [
-        { id: 1, isDim: true, dataColIdx: 0, totalInfo: 'Totals' },
-        { id: 2, isDim: false, dataColIdx: 1, totalInfo: '350' },
+        { id: 1, isDim: true, colIdx: 0, totalInfo: 'Totals' },
+        { id: 2, isDim: false, colIdx: 1, totalInfo: '350' },
       ],
       rows: ['rowOne', 'rowTwo'],
     } as unknown as TableData;

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,8 +103,8 @@ export interface Column {
   id: string;
   isDim: boolean;
   isLocked: boolean;
-  dataColIdx: number;
-  width: number;
+  colIdx: number;
+  pageColIdx: number;
   label: string;
   align: 'left' | 'center' | 'right';
   stylingIDs: string[];


### PR DESCRIPTION
The data structure for `rows` has been unchanged since the prototype. I've been confused with this a million times. Aligning things so hopefully it will be easier in the future. This enabled me to do some rewrites in handle-data

- the order of columns in `rows` is the order they will be shown in, now this aligns with `columns`
- store both types of indexes in columns and cells. `col/rowIdx` is index in the entire dataset, not necesarilly what is rendered. `pageRow/ColIdx` is the index in the displayed page
- simplify `getTotalInfo` and `getTotalPosition`
- add comments for all functions in handle-data
- remove `width` from `Column` type since it was never used. Will add other width stuff here for the column resize
- removed `getColumnOrder` and put the logic in `getColumns` together with creation of columns array, since we don't need `columnOrder` in `manageData` anymore