### PR TITLE
fix: column width calc

### DIFF
--- a/src/table/components/virtualized-table/TableContainer.tsx
+++ b/src/table/components/virtualized-table/TableContainer.tsx
@@ -55,7 +55,7 @@ export default function TableContainer(props: TableContainerProps) {
       ref={ref}
       style={{
         overflow: 'auto',
-        width: '100%',
+        width: rect.width,
         height: rect.height - (paginationNeeded ? PAGINATION_HEIGHT : 0),
       }}
       onScroll={onScrollHandler}

--- a/src/table/components/virtualized-table/hooks/__tests__/use-columns-size.test.ts
+++ b/src/table/components/virtualized-table/hooks/__tests__/use-columns-size.test.ts
@@ -23,7 +23,7 @@ describe('useColumnSize', () => {
       estimateWidth: jest.fn() as jest.MockedFunction<(length: number) => number>,
     };
     mockedUseMeasureText.mockReturnValue(mockedMeasureText);
-    columns = [{} as Column];
+    columns = [{}, {}, {}] as Column[];
     headerStyle = {} as GeneratedStyling;
     bodyStyle = {} as GeneratedStyling;
   });
@@ -32,8 +32,9 @@ describe('useColumnSize', () => {
     jest.restoreAllMocks();
   });
 
-  test('should use fill width when there is space available', () => {
-    rect.width = 200; // fillWidth => 200;
+  test('should fill up available space given a single column', () => {
+    columns = [{}] as Column[];
+    rect.width = 200;
     (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
     (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(25);
     const { result } = renderHook(() => useColumnSize(rect, columns, headerStyle, bodyStyle));
@@ -41,19 +42,32 @@ describe('useColumnSize', () => {
     expect(result.current.width).toEqual([200]);
   });
 
-  test('should use estimated width given it produces the largest value', () => {
-    (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(500);
+  test('should fill up available space given multiple columns', () => {
+    rect.width = 300;
+    (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
     (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(25);
     const { result } = renderHook(() => useColumnSize(rect, columns, headerStyle, bodyStyle));
 
-    expect(result.current.width).toEqual([500]);
+    expect(result.current.width).toEqual([100, 100, 100]);
+  });
+
+  test('should use estimated width given it produces the largest value', () => {
+    (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(500);
+    (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(400);
+    (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(300);
+    (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(25);
+    const { result } = renderHook(() => useColumnSize(rect, columns, headerStyle, bodyStyle));
+
+    expect(result.current.width).toEqual([500, 400, 300]);
   });
 
   test('should use measured text width given it produces the largest value', () => {
     (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
-    (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(250);
+    (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValueOnce(500);
+    (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValueOnce(400);
+    (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValueOnce(300);
     const { result } = renderHook(() => useColumnSize(rect, columns, headerStyle, bodyStyle));
 
-    expect(result.current.width).toEqual([250]);
+    expect(result.current.width).toEqual([500, 400, 300]);
   });
 });

--- a/src/table/components/virtualized-table/hooks/__tests__/use-columns-size.test.ts
+++ b/src/table/components/virtualized-table/hooks/__tests__/use-columns-size.test.ts
@@ -51,6 +51,16 @@ describe('useColumnSize', () => {
     expect(result.current.width).toEqual([100, 100, 100]);
   });
 
+  test('fill width should not be included when space available is filled', () => {
+    rect.width = 1000;
+    (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(1000);
+    (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
+    (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(50);
+    const { result } = renderHook(() => useColumnSize(rect, columns, headerStyle, bodyStyle));
+
+    expect(result.current.width).toEqual([1000, 50, 50]);
+  });
+
   test('should use estimated width given it produces the largest value', () => {
     (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(500);
     (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(400);

--- a/src/table/components/virtualized-table/hooks/__tests__/use-measure-text.test.ts
+++ b/src/table/components/virtualized-table/hooks/__tests__/use-measure-text.test.ts
@@ -21,7 +21,7 @@ describe('useMeasureText', () => {
       measureTextMock.mockReturnValue({ width: 150 });
       const { result } = renderHook(() => useMeasureText('13px', 'font'));
 
-      expect(result.current.estimateWidth(2)).toBe(325);
+      expect(result.current.estimateWidth(2)).toBe(332);
     });
   });
 
@@ -30,7 +30,7 @@ describe('useMeasureText', () => {
       measureTextMock.mockReturnValue({ width: 150 });
       const { result } = renderHook(() => useMeasureText('13px', 'font'));
 
-      expect(result.current.measureText('some string')).toBe(175);
+      expect(result.current.measureText('some string')).toBe(182);
     });
   });
 });

--- a/src/table/components/virtualized-table/hooks/use-column-size.ts
+++ b/src/table/components/virtualized-table/hooks/use-column-size.ts
@@ -13,16 +13,24 @@ const useColumnSize = (
   const { measureText } = useMeasureText(headerStyle.fontSize, headerStyle.fontFamily);
   const { estimateWidth } = useMeasureText(bodyStyle.fontSize, bodyStyle.fontFamily);
 
-  const width = useMemo(
-    () =>
-      columns.map((c) => {
-        const fillWidth = rect.width / columns.length;
-        const maxWidth = Math.max(fillWidth, measureText(c.label), estimateWidth(c.qApprMaxGlyphCount));
+  const width = useMemo(() => {
+    let measuredWidths: number[] = [];
+    let totalWidth = 0;
+    columns.forEach((col) => {
+      const colWidth = Math.max(measureText(col.label), estimateWidth(col.qApprMaxGlyphCount));
+      measuredWidths.push(colWidth);
+      totalWidth += colWidth;
+    });
 
-        return maxWidth;
-      }),
-    [rect, columns, measureText, estimateWidth]
-  );
+    if (totalWidth < rect.width) {
+      // If the width of all columns is less then the available width, spread it evenly among all columns
+      const diff = rect.width - totalWidth;
+      const spread = diff / columns.length;
+      measuredWidths = measuredWidths.map((w) => spread + w);
+    }
+
+    return measuredWidths;
+  }, [rect, columns, measureText, estimateWidth]);
 
   return { width };
 };

--- a/src/table/components/virtualized-table/hooks/use-column-size.ts
+++ b/src/table/components/virtualized-table/hooks/use-column-size.ts
@@ -14,7 +14,7 @@ const useColumnSize = (
   const { estimateWidth } = useMeasureText(bodyStyle.fontSize, bodyStyle.fontFamily);
 
   const width = useMemo(() => {
-    let measuredWidths: number[] = [];
+    const measuredWidths: number[] = [];
     let totalWidth = 0;
     columns.forEach((col) => {
       const colWidth = Math.max(measureText(col.label), estimateWidth(col.qApprMaxGlyphCount));
@@ -26,7 +26,7 @@ const useColumnSize = (
       // If the width of all columns is less then the available width, spread it evenly among all columns
       const diff = rect.width - totalWidth;
       const spread = diff / columns.length;
-      measuredWidths = measuredWidths.map((w) => spread + w);
+      return measuredWidths.map((w) => spread + w);
     }
 
     return measuredWidths;

--- a/src/table/components/virtualized-table/hooks/use-column-size.ts
+++ b/src/table/components/virtualized-table/hooks/use-column-size.ts
@@ -14,13 +14,10 @@ const useColumnSize = (
   const { estimateWidth } = useMeasureText(bodyStyle.fontSize, bodyStyle.fontFamily);
 
   const width = useMemo(() => {
-    const measuredWidths: number[] = [];
-    let totalWidth = 0;
-    columns.forEach((col) => {
-      const colWidth = Math.max(measureText(col.label), estimateWidth(col.qApprMaxGlyphCount));
-      measuredWidths.push(colWidth);
-      totalWidth += colWidth;
-    });
+    const measuredWidths = columns.map((col) =>
+      Math.max(measureText(col.label), estimateWidth(col.qApprMaxGlyphCount))
+    );
+    const totalWidth = measuredWidths.reduce((sum, w) => sum + w, 0);
 
     if (totalWidth < rect.width) {
       // If the width of all columns is less then the available width, spread it evenly among all columns
@@ -30,7 +27,7 @@ const useColumnSize = (
     }
 
     return measuredWidths;
-  }, [rect, columns, measureText, estimateWidth]);
+  }, [rect.width, columns, measureText, estimateWidth]);
 
   return { width };
 };

--- a/src/table/components/virtualized-table/hooks/use-measure-text.ts
+++ b/src/table/components/virtualized-table/hooks/use-measure-text.ts
@@ -8,7 +8,7 @@ export interface MeasureTextHook {
 
 const MAGIC_DEFAULT_CHAR = 'M';
 
-const LEEWAY_WIDTH = 25; // Used to make sure there is some leeway in the measurement of a text
+const ACCOUNT_FOR_PADDING = 32; // Default left and right padding is 2 * 14px, make some extra room for that
 
 export default function useMeasureText(fontSize: string | undefined, fontFamily: string | undefined): MeasureTextHook {
   const { estimateWidth, measureText } = useMemo((): MeasureTextHook => {
@@ -18,8 +18,8 @@ export default function useMeasureText(fontSize: string | undefined, fontFamily:
     const memoizedMeasureText = memoize(context.measureText.bind(context)) as (text: string) => TextMetrics;
 
     return {
-      measureText: (text) => memoizedMeasureText(text).width + LEEWAY_WIDTH,
-      estimateWidth: (length: number) => memoizedMeasureText(MAGIC_DEFAULT_CHAR).width * length + LEEWAY_WIDTH,
+      measureText: (text) => memoizedMeasureText(text).width + ACCOUNT_FOR_PADDING,
+      estimateWidth: (length: number) => memoizedMeasureText(MAGIC_DEFAULT_CHAR).width * length + ACCOUNT_FOR_PADDING,
     };
   }, [fontSize, fontFamily]);
 


### PR DESCRIPTION
There was an issue with how the column width was calculated. It could give the wrong size when all the available space was filled, but the `fillWidth` value was largar then the measure width.

Also the the hard-coded value of 25 that was added to the measured width, was not enough to account for cell padding of 28px.