### PR TITLE
chore: lint files when committing

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "yarn lint",
+      "bash -c 'yarn lint'",
       "bash -c 'yarn types:check'"
     ],
     "*.{json,css,md}": [


### PR DESCRIPTION
similar to https://github.com/qlik-oss/sn-table/pull/704
eslint ignores configurations when eslint is called through git hooks, using a bash -c trick
