### PR TITLE
fix: resize colum width on rect change in vt mode

### DIFF
--- a/src/table/components/virtualized-table/Body.tsx
+++ b/src/table/components/virtualized-table/Body.tsx
@@ -59,7 +59,7 @@ const Body = (props: BodyProps) => {
 
     forwardRef.current.resetAfterIndices({ columnIndex: 0, rowIndex: 0, shouldForceUpdate: true });
     forwardRef.current.scrollTo({ scrollLeft: 0, scrollTop: 0 });
-  }, [layout, pageInfo, forwardRef]);
+  }, [layout, pageInfo, forwardRef, columnWidth]);
 
   const handleItemsRendered = useCallback(
     ({

--- a/src/table/components/virtualized-table/Header.tsx
+++ b/src/table/components/virtualized-table/Header.tsx
@@ -10,7 +10,7 @@ const Header = (props: HeaderProps) => {
   useLayoutEffect(() => {
     forwardRef?.current?.resetAfterIndex(0, true);
     forwardRef?.current?.scrollTo(0);
-  }, [layout, pageInfo, forwardRef]);
+  }, [layout, pageInfo, forwardRef, columnWidth]);
 
   return (
     <VariableSizeList


### PR DESCRIPTION
Fixes an issue where the table in vt mode would not resize the columns if the rect from nebula changed. Ex. if a user changed the size of the browser window so that it became larger, the columns would not become larger before this fix.