### PR TITLE
fix: closing menu by clicking head cell causes sorting order

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "13.4.0",
     "@testing-library/react-hooks": "8.0.1",
+    "@testing-library/user-event": "^14.4.3",
     "@types/jest": "29.1.2",
     "@types/react-native": "0.70.4",
     "@types/react-window": "1.8.5",

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -20,15 +20,22 @@ const MenuItem = ({
   itemTitle,
   sortOrder,
   sortFromMenu,
+  setOpen,
 }: {
   children: any;
   itemTitle: string;
   sortOrder: string;
   sortFromMenu(evt: React.MouseEvent, sortOrder: string): void;
+  setOpen: any;
 }) => {
   return (
     <ListItem disablePadding>
-      <ListItemButton onClick={(evt) => sortFromMenu(evt, sortOrder)}>
+      <ListItemButton
+        onClick={(evt) => {
+          sortFromMenu(evt, sortOrder);
+          setOpen(false);
+        }}
+      >
         <ListItemIcon sx={{ minWidth: '25px' }}>{children}</ListItemIcon>
         <ListItemText primary={itemTitle} />
       </ListItemButton>
@@ -48,14 +55,6 @@ export default function HeadCellMenu({
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
 
-  const handleClickMenuOpen = () => {
-    setOpen(true);
-  };
-
-  const handleClickMenuClose = (event: Event | React.SyntheticEvent) => {
-    !anchorRef.current?.contains(event.target as HTMLElement) && setOpen(false);
-  };
-
   return (
     <StyledCellMenu headerStyle={headerStyle}>
       <StyledMenuIconButton
@@ -65,7 +64,7 @@ export default function HeadCellMenu({
         aria-controls={open ? 'sn-table-head-menu' : undefined}
         aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
-        onClick={handleClickMenuOpen}
+        onClick={() => setOpen(!open)}
       >
         <MoreHoriz />
       </StyledMenuIconButton>
@@ -93,7 +92,7 @@ export default function HeadCellMenu({
             }}
           >
             <Paper sx={{ boxShadow: 15 }}>
-              <ClickAwayListener onClickAway={handleClickMenuClose}>
+              <ClickAwayListener onClickAway={() => setOpen(false)}>
                 <MenuList
                   autoFocusItem={open}
                   className="sn-table-head-menu"
@@ -103,6 +102,7 @@ export default function HeadCellMenu({
                     itemTitle={translator.get('SNTable.MenuItem.SortAscending')}
                     sortOrder="A"
                     sortFromMenu={sortFromMenu}
+                    setOpen={setOpen}
                   >
                     <ArrowUpwardIcon />
                   </MenuItem>
@@ -111,6 +111,7 @@ export default function HeadCellMenu({
                     itemTitle={translator.get('SNTable.MenuItem.SortDescending')}
                     sortOrder="D"
                     sortFromMenu={sortFromMenu}
+                    setOpen={setOpen}
                   >
                     <ArrowDownwardIcon />
                   </MenuItem>

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -47,6 +47,24 @@ describe('<HeadCellMenu />', () => {
     expect(getByText('SNTable.MenuItem.SortDescending')).toBeVisible();
   });
 
+  it('should close the menu when the menu item is clicked', () => {
+    const { getByRole, getByText } = renderTableHeadCellMenu();
+
+    fireEvent.click(getByRole('button'));
+    expect(getByRole('menu')).toBeVisible();
+    fireEvent.click(getByText('SNTable.MenuItem.SortAscending'));
+    expect(getByRole('menu')).not.toBeVisible();
+  });
+
+  it('should close the menu by clicking the menu button when the context menu is open', () => {
+    const { getAllByRole, getByRole } = renderTableHeadCellMenu();
+
+    fireEvent.click(getAllByRole('button')[0]);
+    expect(getByRole('menu')).toBeVisible();
+    fireEvent.click(getAllByRole('button')[0]);
+    expect(getByRole('menu')).not.toBeVisible();
+  });
+
   it('should call changeSortOrder when the sort item is clicked', () => {
     const { getByRole, getByText } = renderTableHeadCellMenu();
     fireEvent.click(getByRole('button'));

--- a/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { stardust } from '@nebula.js/stardust';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import useEvent from '@testing-library/user-event';
 import TableHeadWrapper from '../TableHeadWrapper';
 import { TableContextProvider } from '../../../context';
 import * as handleKeyPress from '../../../utils/handle-key-press';
@@ -73,6 +74,7 @@ describe('<TableHeadWrapper />', () => {
       enabled: false,
     } as stardust.Keyboard;
     translator = { get: (s) => s } as ExtendedTranslator;
+    areBasicFeaturesEnabled = false;
   });
 
   it('should render table head', () => {
@@ -82,14 +84,32 @@ describe('<TableHeadWrapper />', () => {
     expect(queryByText(tableData.columns[1].label)).toBeVisible();
   });
 
-  it.skip('should show the menu button when the head cell is on focus', () => {
+  it('should show the menu button when the head cell is on focus', () => {
     areBasicFeaturesEnabled = true;
     const { getByText } = renderTableHead();
 
     const element = getByText(tableData.columns[0].label).closest('th') as HTMLTableCellElement;
     expect(element.querySelector('#sn-table-head-menu-button')).not.toBeVisible();
     element.focus();
-    expect(element.querySelector('#sn-table-head-menu-button')).toBeVisible();
+    waitFor(async () => {
+      expect(element.querySelector('#sn-table-head-menu-button')).toBeVisible();
+    });
+  });
+
+  it('should show the menu button when the head cell is hovered', () => {
+    areBasicFeaturesEnabled = true;
+    const { getByText } = renderTableHead();
+
+    const element = getByText(tableData.columns[0].label).closest('th') as HTMLTableCellElement;
+    expect(element.querySelector('#sn-table-head-menu-button')).not.toBeVisible();
+    useEvent.hover(element);
+    waitFor(async () => {
+      expect(element.querySelector('#sn-table-head-menu-button')).toBeVisible();
+    });
+    useEvent.unhover(element);
+    waitFor(async () => {
+      expect(element.querySelector('#sn-table-head-menu-button')).not.toBeVisible();
+    });
   });
 
   it('should call changeSortOrder when clicking the header cell', () => {

--- a/src/table/components/head/styles.ts
+++ b/src/table/components/head/styles.ts
@@ -28,6 +28,9 @@ export const StyledHeadCell = styled(TableCell, {
   lineHeight: '150%',
   pointer: 'cursor',
   borderWidth: '1px 1px 1px 0px',
+  '&&:hover, &&:focus': {
+    '& svg, & button': { opacity: 1 },
+  },
 }));
 
 export const StyledSortLabel = styled(TableSortLabel, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,6 +2937,11 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
Issues that are fixed:

- Clicking the button does not close the context menu if it is already open.
- Showing menu button when the head cell is hovered or focused
- Making selection on menu-item doesn't close the menu

After fix:

- Clicking the menu button should open the menu as well as closing it.
- Hovering, focusing, clicking the head cell appears the menu button
- Menu will be closed as soon as a menu item is clicked