### PR TITLE
refactor: move non-background styling from extendedTheme to styling-utils

### DIFF
--- a/src/nebula-hooks/__tests__/use-extended-theme.spec.ts
+++ b/src/nebula-hooks/__tests__/use-extended-theme.spec.ts
@@ -1,40 +1,24 @@
 import { ExtendedTheme } from '../../types';
-import { tableThemeColors } from '../use-extended-theme';
+import { getBackgroundColors } from '../use-extended-theme';
 
-describe('tableThemeColors', () => {
+describe('getBackgroundColors', () => {
   let themeObjectBackgroundColor: string | undefined;
   let themeTableBackgroundColor: string | undefined;
   let rootElement: HTMLElement;
-  let backgroundColor: string | undefined;
+  let color: string | undefined;
   const theme = {
     getStyle: (base: string, path: string, attribute: string) =>
       attribute === 'backgroundColor' ? themeObjectBackgroundColor : themeTableBackgroundColor,
   } as ExtendedTheme;
   let valueWithLightBackgroundColor = {
-    tableBackgroundColorFromTheme: 'inherit',
-    backgroundColor,
-    isBackgroundDarkColor: false,
-    isBackgroundTransparentColor: false,
-    body: { borderColor: '#D9D9D9' },
-    borderColor: '#D9D9D9',
-    pagination: {
-      borderColor: '#D9D9D9',
-      color: '#404040',
-      iconColor: 'rgba(0, 0, 0, 0.54)',
-      disabledIconColor: 'rgba(0, 0, 0, 0.3)',
-    },
+    tableColorFromTheme: 'inherit',
+    color,
+    isDark: false,
+    isTransparent: false,
   };
   let valueWithDarkBackgroundColor = {
     ...valueWithLightBackgroundColor,
-    isBackgroundDarkColor: true,
-    body: { borderColor: ' #F2F2F2' },
-    borderColor: ' #F2F2F2',
-    pagination: {
-      borderColor: ' #F2F2F2',
-      color: 'rgba(255, 255, 255, 0.9)',
-      disabledIconColor: 'rgba(255, 255, 255, 0.3)',
-      iconColor: 'rgba(255, 255, 255, 0.9)',
-    },
+    isDark: true,
   };
 
   beforeEach(() => {
@@ -49,7 +33,7 @@ describe('tableThemeColors', () => {
 
     describe('when there is no background color in the theme file', () => {
       it('should return the valueWithLightBackgroundColor', () => {
-        const result = tableThemeColors(theme, rootElement);
+        const result = getBackgroundColors(theme, rootElement);
         expect(result).toEqual(valueWithLightBackgroundColor);
       });
     });
@@ -60,65 +44,65 @@ describe('tableThemeColors', () => {
           it('should return the valueWithLightBackgroundColor when the background color is light', () => {
             themeObjectBackgroundColor = '#fff';
 
-            const result = tableThemeColors(theme, rootElement);
-            expect(result).toEqual({ ...valueWithLightBackgroundColor, backgroundColor: themeObjectBackgroundColor });
+            const result = getBackgroundColors(theme, rootElement);
+            expect(result).toEqual({ ...valueWithLightBackgroundColor, color: themeObjectBackgroundColor });
           });
 
           it('should return the valueWithDarkBackgroundColor when the background color is dark', () => {
             themeObjectBackgroundColor = '#000';
 
-            const result = tableThemeColors(theme, rootElement);
-            expect(result).toEqual({ ...valueWithDarkBackgroundColor, backgroundColor: themeObjectBackgroundColor });
+            const result = getBackgroundColors(theme, rootElement);
+            expect(result).toEqual({ ...valueWithDarkBackgroundColor, color: themeObjectBackgroundColor });
           });
         });
 
         describe('when the background color is transparent', () => {
-          it('should return the valueWithLightBackgroundColor and isBackgroundTransparentColor to be true when the background color is light', () => {
+          it('should return the valueWithLightBackgroundColor and isTransparent to be true when the background color is light', () => {
             themeObjectBackgroundColor = 'rgba(255, 255, 255, 0)';
 
-            const result = tableThemeColors(theme, rootElement);
+            const result = getBackgroundColors(theme, rootElement);
             expect(result).toEqual({
               ...valueWithLightBackgroundColor,
-              backgroundColor: themeObjectBackgroundColor,
-              isBackgroundTransparentColor: true,
+              color: themeObjectBackgroundColor,
+              isTransparent: true,
             });
           });
 
           it('should return the valueWithLightBackgroundColor when the background color is dark', () => {
             themeObjectBackgroundColor = 'rgba(0, 0, 0, 0)';
 
-            const result = tableThemeColors(theme, rootElement);
+            const result = getBackgroundColors(theme, rootElement);
             expect(result).toEqual({
               ...valueWithLightBackgroundColor,
-              backgroundColor: themeObjectBackgroundColor,
-              isBackgroundTransparentColor: true,
+              color: themeObjectBackgroundColor,
+              isTransparent: true,
             });
           });
         });
       });
 
       describe('when this is only a table background color', () => {
-        it('should return the valueWithLightBackgroundColor, backgroundColor, and tableBackgroundColorFromTheme when the background color is light', () => {
+        it('should return the valueWithLightBackgroundColor, backgroundColor, and tableColorFromTheme when the background color is light', () => {
           themeObjectBackgroundColor = undefined;
           themeTableBackgroundColor = '#fff';
 
-          const result = tableThemeColors(theme, rootElement);
+          const result = getBackgroundColors(theme, rootElement);
           expect(result).toEqual({
             ...valueWithLightBackgroundColor,
-            backgroundColor: themeTableBackgroundColor,
-            tableBackgroundColorFromTheme: themeTableBackgroundColor,
+            color: themeTableBackgroundColor,
+            tableColorFromTheme: themeTableBackgroundColor,
           });
         });
 
-        it('should return the valueWithDarkBackgroundColor, backgroundColor, and tableBackgroundColorFromTheme when the background color is dark', () => {
+        it('should return the valueWithDarkBackgroundColor, backgroundColor, and tableColorFromTheme when the background color is dark', () => {
           themeObjectBackgroundColor = undefined;
           themeTableBackgroundColor = '#000';
 
-          const result = tableThemeColors(theme, rootElement);
+          const result = getBackgroundColors(theme, rootElement);
           expect(result).toEqual({
             ...valueWithDarkBackgroundColor,
-            backgroundColor: themeTableBackgroundColor,
-            tableBackgroundColorFromTheme: themeTableBackgroundColor,
+            color: themeTableBackgroundColor,
+            tableColorFromTheme: themeTableBackgroundColor,
           });
         });
       });
@@ -128,11 +112,11 @@ describe('tableThemeColors', () => {
           themeObjectBackgroundColor = '#000';
           themeTableBackgroundColor = '#fff';
 
-          const result = tableThemeColors(theme, rootElement);
+          const result = getBackgroundColors(theme, rootElement);
           expect(result).toEqual({
             ...valueWithLightBackgroundColor,
-            backgroundColor: themeTableBackgroundColor,
-            tableBackgroundColorFromTheme: themeTableBackgroundColor,
+            color: themeTableBackgroundColor,
+            tableColorFromTheme: themeTableBackgroundColor,
           });
         });
 
@@ -140,11 +124,11 @@ describe('tableThemeColors', () => {
           themeObjectBackgroundColor = '#fff';
           themeTableBackgroundColor = '#000';
 
-          const result = tableThemeColors(theme, rootElement);
+          const result = getBackgroundColors(theme, rootElement);
           expect(result).toEqual({
             ...valueWithDarkBackgroundColor,
-            backgroundColor: themeTableBackgroundColor,
-            tableBackgroundColorFromTheme: themeTableBackgroundColor,
+            color: themeTableBackgroundColor,
+            tableColorFromTheme: themeTableBackgroundColor,
           });
         });
       });
@@ -173,13 +157,13 @@ describe('tableThemeColors', () => {
     beforeEach(() => {
       valueWithLightBackgroundColor = {
         ...valueWithLightBackgroundColor,
-        backgroundColor: 'rgba(0, 0, 0, 0)',
-        isBackgroundTransparentColor: true,
+        color: 'rgba(0, 0, 0, 0)',
+        isTransparent: true,
       };
       valueWithDarkBackgroundColor = {
         ...valueWithDarkBackgroundColor,
-        backgroundColor: 'rgba(0, 0, 0, 0)',
-        isBackgroundTransparentColor: true,
+        color: 'rgba(0, 0, 0, 0)',
+        isTransparent: true,
       };
       qvPanelSheetBackgroundColor = '#fff';
       qvInnerObjectBackgroundColor = 'rgba(0, 0, 0, 0)';
@@ -187,7 +171,7 @@ describe('tableThemeColors', () => {
 
     describe('when there is no background color from theme or css file', () => {
       it('should return the valueWithLightBackgroundColor', () => {
-        const result = tableThemeColors(theme, rootElement);
+        const result = getBackgroundColors(theme, rootElement);
         expect(result).toEqual(valueWithLightBackgroundColor);
       });
     });
@@ -197,7 +181,7 @@ describe('tableThemeColors', () => {
         it('should return the valueWithDarkBackgroundColor', () => {
           qvPanelSheetBackgroundColor = '#000';
 
-          const result = tableThemeColors(theme, rootElement);
+          const result = getBackgroundColors(theme, rootElement);
           expect(result).toEqual(valueWithDarkBackgroundColor);
         });
       });
@@ -206,28 +190,28 @@ describe('tableThemeColors', () => {
     describe('when there is a background color from theme file on object', () => {
       describe('when the background color is opaque', () => {
         describe('when the background color is light', () => {
-          it('should return the valueWithLightBackgroundColor, backgroundColor, and isBackgroundTransparentColor to be false', () => {
+          it('should return the valueWithLightBackgroundColor, backgroundColor, and isTransparent to be false', () => {
             qvPanelSheetBackgroundColor = '#000';
             qvInnerObjectBackgroundColor = '#fff';
 
-            const result = tableThemeColors(theme, rootElement);
+            const result = getBackgroundColors(theme, rootElement);
             expect(result).toEqual({
               ...valueWithLightBackgroundColor,
-              backgroundColor: qvInnerObjectBackgroundColor,
-              isBackgroundTransparentColor: false,
+              color: qvInnerObjectBackgroundColor,
+              isTransparent: false,
             });
           });
         });
 
         describe('when the background color is dark', () => {
-          it('should return the valueWithDarkBackgroundColor, backgroundColor, and isBackgroundTransparentColor to be false', () => {
+          it('should return the valueWithDarkBackgroundColor, backgroundColor, and isTransparent to be false', () => {
             qvInnerObjectBackgroundColor = '#000';
 
-            const result = tableThemeColors(theme, rootElement);
+            const result = getBackgroundColors(theme, rootElement);
             expect(result).toEqual({
               ...valueWithDarkBackgroundColor,
-              backgroundColor: qvInnerObjectBackgroundColor,
-              isBackgroundTransparentColor: false,
+              color: qvInnerObjectBackgroundColor,
+              isTransparent: false,
             });
           });
         });
@@ -238,10 +222,10 @@ describe('tableThemeColors', () => {
           qvPanelSheetBackgroundColor = '#fff';
           qvInnerObjectBackgroundColor = 'rgba(255, 255, 255, 0)';
 
-          const result = tableThemeColors(theme, rootElement);
+          const result = getBackgroundColors(theme, rootElement);
           expect(result).toEqual({
             ...valueWithLightBackgroundColor,
-            backgroundColor: qvInnerObjectBackgroundColor,
+            color: qvInnerObjectBackgroundColor,
           });
         });
       });
@@ -253,40 +237,40 @@ describe('tableThemeColors', () => {
           it('should return the valueWithLightBackgroundColor and backgroundColor', () => {
             themeTableBackgroundColor = '#fff';
 
-            const result = tableThemeColors(theme, rootElement);
+            const result = getBackgroundColors(theme, rootElement);
             expect(result).toEqual({
               ...valueWithLightBackgroundColor,
-              backgroundColor: themeTableBackgroundColor,
-              tableBackgroundColorFromTheme: themeTableBackgroundColor,
-              isBackgroundTransparentColor: false,
+              color: themeTableBackgroundColor,
+              tableColorFromTheme: themeTableBackgroundColor,
+              isTransparent: false,
             });
           });
         });
 
         describe('when the background color is dark', () => {
-          it('should return the valueWithLightBackgroundColor, backgroundColor, tableBackgroundColorFromTheme and isBackgroundTransparentColor to false', () => {
+          it('should return the valueWithLightBackgroundColor, backgroundColor, tableColorFromTheme and isTransparent to false', () => {
             themeTableBackgroundColor = '#000';
 
-            const result = tableThemeColors(theme, rootElement);
+            const result = getBackgroundColors(theme, rootElement);
             expect(result).toEqual({
               ...valueWithDarkBackgroundColor,
-              backgroundColor: themeTableBackgroundColor,
-              tableBackgroundColorFromTheme: themeTableBackgroundColor,
-              isBackgroundTransparentColor: false,
+              color: themeTableBackgroundColor,
+              tableColorFromTheme: themeTableBackgroundColor,
+              isTransparent: false,
             });
           });
         });
       });
 
       describe('when the background color is transparent', () => {
-        it('should return the valueWithLightBackgroundColor, backgroundColor, tableBackgroundColorFromTheme', () => {
+        it('should return the valueWithLightBackgroundColor, backgroundColor, tableColorFromTheme', () => {
           themeTableBackgroundColor = 'rgba(255, 255, 255, 0)';
 
-          const result = tableThemeColors(theme, rootElement);
+          const result = getBackgroundColors(theme, rootElement);
           expect(result).toEqual({
             ...valueWithLightBackgroundColor,
-            backgroundColor: themeTableBackgroundColor,
-            tableBackgroundColorFromTheme: themeTableBackgroundColor,
+            color: themeTableBackgroundColor,
+            tableColorFromTheme: themeTableBackgroundColor,
           });
         });
       });

--- a/src/nebula-hooks/use-extended-theme.ts
+++ b/src/nebula-hooks/use-extended-theme.ts
@@ -5,9 +5,9 @@ import { ExtendedTheme, BackgroundColors } from '../types';
 
 /**
  * The colors in the table can depend on background colors set on table, object and sheet level.
- * Even though not officially supported, it is expected that css settings on object and sheet are respected
- * The priority order is: table theme > object css > object theme > sheet css
- * If the result of those is transparent, we use the sheet css color
+ * Even though not officially supported, it is expected that css settings on object and sheet are respected.
+ * The priority order is: table theme > object css > object theme
+ * If the result for object/table background is transparent, the sheet css color is used
  */
 export const getBackgroundColors = (theme: ExtendedTheme, rootElement: HTMLElement): BackgroundColors => {
   const qvInnerObject = rootElement?.closest('.qv-object .qv-inner-object');
@@ -18,7 +18,8 @@ export const getBackgroundColors = (theme: ExtendedTheme, rootElement: HTMLEleme
 
   // tableColorFromTheme is undefined if nothing is set specifically for object.straightTable.backgroundColor
   const tableColorFromTheme = theme.getStyle('', '', 'object.straightTable.backgroundColor');
-  // colorFromTheme traverses the theme tree until it finds a value for backgroundColor, is undefined if there is no value
+  // colorFromTheme traverses the theme tree until it finds a value for backgroundColor
+  // it is undefined if there is no value
   const colorFromTheme = theme.getStyle('object', 'straightTable', 'backgroundColor');
 
   const color = tableColorFromTheme || objectColorFromCSS || colorFromTheme;

--- a/src/table/components/TableWrapper.tsx
+++ b/src/table/components/TableWrapper.tsx
@@ -102,7 +102,7 @@ export default function TableWrapper(props: TableWrapperProps) {
   return (
     <StyledTableWrapper
       ref={tableWrapperRef}
-      tableTheme={theme.table}
+      background={theme.background}
       paginationNeeded={paginationNeeded}
       dir={direction}
       onKeyDown={handleKeyDown}

--- a/src/table/components/__tests__/TableWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableWrapper.spec.tsx
@@ -93,14 +93,7 @@ describe('<TableWrapper />', () => {
     } as unknown as stardust.Rect;
     theme = {
       getStyle: () => undefined,
-      table: {
-        body: {
-          borderColor: '',
-        },
-        pagination: {
-          borderColor: '',
-        },
-      },
+      background: { isDark: false },
     } as unknown as ExtendedTheme;
   });
 

--- a/src/table/components/body/TableBodyWrapper.tsx
+++ b/src/table/components/body/TableBodyWrapper.tsx
@@ -42,7 +42,7 @@ function TableBodyWrapper({
   );
   const bodyCellStyle = useMemo(() => getBodyCellStyle(layout, theme), [layout, theme]);
   const hoverEffect = layout.components?.[0]?.content?.hoverEffect;
-  const cellStyle = { color: bodyCellStyle.color, backgroundColor: theme.table.backgroundColor };
+  const cellStyle = { color: bodyCellStyle.color, backgroundColor: theme.background.color };
   useEffect(() => {
     addSelectionListeners({
       api: selectionsAPI,

--- a/src/table/components/body/__tests__/TableBodyWrapper.spec.tsx
+++ b/src/table/components/body/__tests__/TableBodyWrapper.spec.tsx
@@ -64,7 +64,7 @@ describe('<TableBodyWrapper />', () => {
       getColorPickerColor: () => undefined,
       name: () => undefined,
       getStyle: () => undefined,
-      table: { body: { borderColor: '' } },
+      background: { isDark: false },
     } as unknown as ExtendedTheme;
     layout = {} as TableLayout;
     tableFirstRow = tableData.rows[0]['col-0'] as Cell;

--- a/src/table/components/body/__tests__/TableTotals.spec.tsx
+++ b/src/table/components/body/__tests__/TableTotals.spec.tsx
@@ -49,7 +49,7 @@ describe('<TableTotals />', () => {
       getColorPickerColor: () => undefined,
       name: () => undefined,
       getStyle: () => undefined,
-      table: { body: { borderColor: '' } },
+      background: { isDark: false },
     } as unknown as ExtendedTheme;
     layout = generateLayout(2, 2, 10, [], [{ qText: '350' }, { qText: '-' }]);
     keyboard = {

--- a/src/table/components/footer/FooterWrapper.tsx
+++ b/src/table/components/footer/FooterWrapper.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { StyledFooterWrapper } from './styles';
 import { FooterWrapperProps } from '../../types';
+import { getPaginationStyle } from '../../utils/styling-utils';
 
 export default function FooterWrapper({ children, theme, footerContainer }: FooterWrapperProps) {
+  const paginationStyle = useMemo(() => getPaginationStyle(theme.background), [theme]);
+
   return footerContainer ? (
     ReactDOM.createPortal(children, footerContainer)
   ) : (
-    <StyledFooterWrapper tableTheme={theme.table}>{children}</StyledFooterWrapper>
+    <StyledFooterWrapper paginationStyle={paginationStyle}>{children}</StyledFooterWrapper>
   );
 }

--- a/src/table/components/footer/FooterWrapper.tsx
+++ b/src/table/components/footer/FooterWrapper.tsx
@@ -2,14 +2,14 @@ import React, { useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { StyledFooterWrapper } from './styles';
 import { FooterWrapperProps } from '../../types';
-import { getPaginationStyle } from '../../utils/styling-utils';
+import { getFooterStyle } from '../../utils/styling-utils';
 
 export default function FooterWrapper({ children, theme, footerContainer }: FooterWrapperProps) {
-  const paginationStyle = useMemo(() => getPaginationStyle(theme.background), [theme]);
+  const footerStyle = useMemo(() => getFooterStyle(theme.background), [theme]);
 
   return footerContainer ? (
     ReactDOM.createPortal(children, footerContainer)
   ) : (
-    <StyledFooterWrapper paginationStyle={paginationStyle}>{children}</StyledFooterWrapper>
+    <StyledFooterWrapper footerStyle={footerStyle}>{children}</StyledFooterWrapper>
   );
 }

--- a/src/table/components/footer/PaginationContent.tsx
+++ b/src/table/components/footer/PaginationContent.tsx
@@ -8,7 +8,7 @@ import LastPageIcon from '@mui/icons-material/LastPage';
 import { StyledSelect, StyledIconButton, StyledInputLabel, StyledFormControl } from './styles';
 import { handleLastTab } from '../../utils/handle-key-press';
 import { PaginationContentProps } from '../../types';
-import { getPaginationStyle } from '../../utils/styling-utils';
+import { getFooterStyle } from '../../utils/styling-utils';
 
 const icons: Record<string, typeof FirstPageIcon> = {
   FirstPage: FirstPageIcon,
@@ -53,7 +53,7 @@ function PaginationContent({
 }: PaginationContentProps) {
   const { totalRowCount, totalColumnCount, totalPages, paginationNeeded } = tableData;
   const { page, rowsPerPage, rowsPerPageOptions } = pageInfo;
-  const paginationStyle = useMemo(() => getPaginationStyle(theme.background), [theme]);
+  const footerStyle = useMemo(() => getFooterStyle(theme.background), [theme]);
 
   if (!paginationNeeded) return null;
 
@@ -99,7 +99,7 @@ function PaginationContent({
     return (
       <StyledIconButton
         disabledCondition={disabledCondition}
-        paginationStyle={paginationStyle}
+        footerStyle={footerStyle}
         data-testid="pagination-action-icon-button"
         onClick={!disabledCondition ? () => handleChangePage(pageNumber) : null}
         aria-disabled={disabledCondition}
@@ -125,21 +125,15 @@ function PaginationContent({
       tabIndex,
       id,
       'data-testid': id,
-      style: { color: paginationStyle.color },
+      style: { color: footerStyle.color },
     };
 
     return (
       <StyledFormControl size="small">
-        <StyledInputLabel color={paginationStyle.color} htmlFor={id} shrink={false}>
+        <StyledInputLabel color={footerStyle.color} htmlFor={id} shrink={false}>
           {`${translator.get(translationName)}:`}
         </StyledInputLabel>
-        <StyledSelect
-          paginationStyle={paginationStyle}
-          native
-          value={value}
-          onChange={handleChange}
-          inputProps={inputProps}
-        >
+        <StyledSelect footerStyle={footerStyle} native value={value} onChange={handleChange} inputProps={inputProps}>
           {options}
         </StyledSelect>
       </StyledFormControl>

--- a/src/table/components/footer/PaginationContent.tsx
+++ b/src/table/components/footer/PaginationContent.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import Box from '@mui/material/Box';
 import FirstPageIcon from '@mui/icons-material/FirstPage';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
@@ -8,6 +8,7 @@ import LastPageIcon from '@mui/icons-material/LastPage';
 import { StyledSelect, StyledIconButton, StyledInputLabel, StyledFormControl } from './styles';
 import { handleLastTab } from '../../utils/handle-key-press';
 import { PaginationContentProps } from '../../types';
+import { getPaginationStyle } from '../../utils/styling-utils';
 
 const icons: Record<string, typeof FirstPageIcon> = {
   FirstPage: FirstPageIcon,
@@ -52,10 +53,10 @@ function PaginationContent({
 }: PaginationContentProps) {
   const { totalRowCount, totalColumnCount, totalPages, paginationNeeded } = tableData;
   const { page, rowsPerPage, rowsPerPageOptions } = pageInfo;
+  const paginationStyle = useMemo(() => getPaginationStyle(theme.background), [theme]);
 
   if (!paginationNeeded) return null;
 
-  const paginationTheme = theme.table.pagination;
   const onFirstPage = page === 0;
   const onLastPage = page >= totalPages - 1;
   // The elements can be focused in sequential keyboard navigation:
@@ -98,7 +99,7 @@ function PaginationContent({
     return (
       <StyledIconButton
         disabledCondition={disabledCondition}
-        paginationTheme={paginationTheme}
+        paginationStyle={paginationStyle}
         data-testid="pagination-action-icon-button"
         onClick={!disabledCondition ? () => handleChangePage(pageNumber) : null}
         aria-disabled={disabledCondition}
@@ -124,16 +125,16 @@ function PaginationContent({
       tabIndex,
       id,
       'data-testid': id,
-      style: { color: paginationTheme.color },
+      style: { color: paginationStyle.color },
     };
 
     return (
       <StyledFormControl size="small">
-        <StyledInputLabel color={paginationTheme.color} htmlFor={id} shrink={false}>
+        <StyledInputLabel color={paginationStyle.color} htmlFor={id} shrink={false}>
           {`${translator.get(translationName)}:`}
         </StyledInputLabel>
         <StyledSelect
-          paginationTheme={paginationTheme}
+          paginationStyle={paginationStyle}
           native
           value={value}
           onChange={handleChange}

--- a/src/table/components/footer/__tests__/PaginationContent.spec.tsx
+++ b/src/table/components/footer/__tests__/PaginationContent.spec.tsx
@@ -43,7 +43,7 @@ describe('<PaginationContent />', () => {
 
   beforeEach(() => {
     theme = {
-      table: { pagination: { color: '', iconColor: '' } },
+      background: { isDark: false },
     } as unknown as ExtendedTheme;
     direction = 'ltr';
     titles = [

--- a/src/table/components/footer/styles.ts
+++ b/src/table/components/footer/styles.ts
@@ -8,35 +8,37 @@ import FormControl from '@mui/material/FormControl';
 // ---------- FooterWrapper ----------
 
 export const StyledFooterWrapper = styled(Paper, {
-  shouldForwardProp: (prop: string) => prop !== 'paginationStyle',
-})(({ paginationStyle, theme }) => ({
-  height: 48,
-  display: 'flex',
-  justifyContent: 'flex-end',
-  alignItems: 'center',
-  paddingRight: theme.spacing(1),
-  boxShadow: 'none',
-  borderStyle: 'solid',
-  borderWidth: '0px 0px 1px 0px',
-  borderRadius: 0,
-  borderColor: paginationStyle.borderColor,
-  color: paginationStyle.color,
-  backgroundColor: paginationStyle.backgroundColor,
-}));
+  shouldForwardProp: (prop: string) => prop !== 'footerStyle',
+})(({ footerStyle, theme }) => {
+  return {
+    height: 48,
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    paddingRight: theme.spacing(1),
+    boxShadow: 'none',
+    borderStyle: 'solid',
+    borderWidth: '0px 0px 1px 0px',
+    borderRadius: 0,
+    borderColor: footerStyle.borderColor,
+    color: footerStyle.color,
+    backgroundColor: footerStyle.backgroundColor,
+  };
+});
 
 // ---------- PaginationContent ----------
 
 export const StyledSelect = styled(Select, {
-  shouldForwardProp: (prop: string) => prop !== 'paginationStyle',
-})(({ paginationStyle }) => ({
+  shouldForwardProp: (prop: string) => prop !== 'footerStyle',
+})(({ footerStyle }) => ({
   backgroundColor: 'inherit',
-  '& .MuiNativeSelect-icon': { color: paginationStyle.iconColor },
+  '& .MuiNativeSelect-icon': { color: footerStyle.iconColor },
 }));
 
 export const StyledIconButton = styled(IconButton, {
-  shouldForwardProp: (prop: string) => prop !== 'disabledCondition' && prop !== 'paginationStyle',
-})(({ disabledCondition, paginationStyle }) => ({
-  color: disabledCondition ? paginationStyle.disabledIconColor : paginationStyle.iconColor,
+  shouldForwardProp: (prop: string) => prop !== 'disabledCondition' && prop !== 'footerStyle',
+})(({ disabledCondition, footerStyle }) => ({
+  color: disabledCondition ? footerStyle.disabledIconColor : footerStyle.iconColor,
   cursor: disabledCondition ? 'default' : 'pointer',
   height: '32px',
   padding: '0px 7px',

--- a/src/table/components/footer/styles.ts
+++ b/src/table/components/footer/styles.ts
@@ -8,8 +8,8 @@ import FormControl from '@mui/material/FormControl';
 // ---------- FooterWrapper ----------
 
 export const StyledFooterWrapper = styled(Paper, {
-  shouldForwardProp: (prop: string) => prop !== 'tableTheme',
-})(({ tableTheme, theme }) => ({
+  shouldForwardProp: (prop: string) => prop !== 'paginationStyle',
+})(({ paginationStyle, theme }) => ({
   height: 48,
   display: 'flex',
   justifyContent: 'flex-end',
@@ -19,24 +19,24 @@ export const StyledFooterWrapper = styled(Paper, {
   borderStyle: 'solid',
   borderWidth: '0px 0px 1px 0px',
   borderRadius: 0,
-  borderColor: tableTheme.pagination.borderColor,
-  color: tableTheme.pagination.color,
-  backgroundColor: tableTheme.backgroundColor,
+  borderColor: paginationStyle.borderColor,
+  color: paginationStyle.color,
+  backgroundColor: paginationStyle.backgroundColor,
 }));
 
 // ---------- PaginationContent ----------
 
 export const StyledSelect = styled(Select, {
-  shouldForwardProp: (prop: string) => prop !== 'paginationTheme',
-})(({ paginationTheme }) => ({
+  shouldForwardProp: (prop: string) => prop !== 'paginationStyle',
+})(({ paginationStyle }) => ({
   backgroundColor: 'inherit',
-  '& .MuiNativeSelect-icon': { color: paginationTheme.iconColor },
+  '& .MuiNativeSelect-icon': { color: paginationStyle.iconColor },
 }));
 
 export const StyledIconButton = styled(IconButton, {
-  shouldForwardProp: (prop: string) => prop !== 'disabledCondition' && prop !== 'paginationTheme',
-})(({ disabledCondition, paginationTheme }) => ({
-  color: disabledCondition ? paginationTheme.disabledIconColor : paginationTheme.iconColor,
+  shouldForwardProp: (prop: string) => prop !== 'disabledCondition' && prop !== 'paginationStyle',
+})(({ disabledCondition, paginationStyle }) => ({
+  color: disabledCondition ? paginationStyle.disabledIconColor : paginationStyle.iconColor,
   cursor: disabledCondition ? 'default' : 'pointer',
   height: '32px',
   padding: '0px 7px',

--- a/src/table/components/footer/styles.ts
+++ b/src/table/components/footer/styles.ts
@@ -9,22 +9,20 @@ import FormControl from '@mui/material/FormControl';
 
 export const StyledFooterWrapper = styled(Paper, {
   shouldForwardProp: (prop: string) => prop !== 'footerStyle',
-})(({ footerStyle, theme }) => {
-  return {
-    height: 48,
-    display: 'flex',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    paddingRight: theme.spacing(1),
-    boxShadow: 'none',
-    borderStyle: 'solid',
-    borderWidth: '0px 0px 1px 0px',
-    borderRadius: 0,
-    borderColor: footerStyle.borderColor,
-    color: footerStyle.color,
-    backgroundColor: footerStyle.backgroundColor,
-  };
-});
+})(({ footerStyle, theme }) => ({
+  height: 48,
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+  paddingRight: theme.spacing(1),
+  boxShadow: 'none',
+  borderStyle: 'solid',
+  borderWidth: '0px 0px 1px 0px',
+  borderRadius: 0,
+  borderColor: footerStyle.borderColor,
+  color: footerStyle.color,
+  backgroundColor: footerStyle.backgroundColor,
+}));
 
 // ---------- PaginationContent ----------
 

--- a/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
@@ -55,7 +55,7 @@ describe('<TableHeadWrapper />', () => {
       getColorPickerColor: () => undefined,
       name: () => undefined,
       getStyle: () => undefined,
-      table: { body: { borderColor: '' } },
+      background: { isDark: false },
     } as unknown as ExtendedTheme;
     layout = {
       qHyperCube: {

--- a/src/table/components/styles.ts
+++ b/src/table/components/styles.ts
@@ -18,13 +18,14 @@ export const TableAnnouncer = styled('div')({
 // ---------- TableWrapper ----------
 
 export const StyledTableWrapper = styled(Paper, {
-  shouldForwardProp: (prop: string) => prop !== 'tableTheme' && prop !== 'paginationNeeded',
-})(({ tableTheme, paginationNeeded }) => ({
+  shouldForwardProp: (prop: string) => prop !== 'background' && prop !== 'paginationNeeded',
+})(({ background, paginationNeeded }) => ({
   borderWidth: paginationNeeded ? '0px 1px 0px' : '0px',
   borderStyle: 'solid',
-  borderColor: tableTheme.borderColor,
+  borderColor: background.isDark ? '#F2F2F2' : '#D9D9D9',
   height: '100%',
-  backgroundColor: tableTheme.tableBackgroundColorFromTheme,
+  // TODO: see if we really need this or if we can use background.color
+  backgroundColor: background.tableColorFromTheme,
   boxShadow: 'none',
   borderRadius: 'unset',
 }));

--- a/src/table/components/virtualized-table/Wrapper.tsx
+++ b/src/table/components/virtualized-table/Wrapper.tsx
@@ -35,7 +35,7 @@ export default function Wrapper(props: WrapperProps) {
   return (
     <StyledTableWrapper
       data-key="wrapper"
-      tableTheme={theme.table}
+      background={theme.background}
       paginationNeeded={paginationNeeded}
       dir="ltr"
       style={{ borderWidth: paginationNeeded ? '0px 1px 0px' : '0px 1px 1px' }}

--- a/src/table/components/virtualized-table/__tests__/TableContainer.spec.tsx
+++ b/src/table/components/virtualized-table/__tests__/TableContainer.spec.tsx
@@ -57,10 +57,7 @@ describe('<TableContainer />', () => {
 
     theme = {
       getStyle: () => undefined,
-      table: {
-        body: { borderColor: '' },
-        pagination: { borderColor: '' },
-      },
+      background: { isDark: false },
     } as unknown as ExtendedTheme;
   });
 

--- a/src/table/components/virtualized-table/__tests__/Wrapper.spec.tsx
+++ b/src/table/components/virtualized-table/__tests__/Wrapper.spec.tsx
@@ -53,10 +53,7 @@ describe('<Wrapper />', () => {
     } as unknown as stardust.Rect;
     theme = {
       getStyle: () => undefined,
-      table: {
-        body: { borderColor: '' },
-        pagination: { borderColor: '' },
-      },
+      background: { isDark: false },
     } as unknown as ExtendedTheme;
 
     constraints = { active: false };

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -91,6 +91,14 @@ export interface GeneratedStyling {
   hoverFontColor?: string;
 }
 
+export interface FooterStyle {
+  borderColor: string;
+  color: string;
+  iconColor: string;
+  disabledIconColor: string;
+  backgroundColor?: string;
+}
+
 export interface CellStyle {
   backgroundColor: string | undefined; // This is always set but could be undefined in the theme
   color: string;

--- a/src/table/utils/__tests__/styling-utils.spec.ts
+++ b/src/table/utils/__tests__/styling-utils.spec.ts
@@ -30,10 +30,7 @@ describe('styling-utils', () => {
       }
     },
     getStyle: () => undefined,
-    table: {
-      body: { borderColor: '#D9D9D9' },
-      backgroundColor: '#323232',
-    },
+    background: { isDark: false, color: '#323232' },
   } as unknown as ExtendedTheme;
 
   describe('getColor', () => {

--- a/src/table/utils/color-utils.ts
+++ b/src/table/utils/color-utils.ts
@@ -13,6 +13,9 @@ const hexToRGBAorRGB = (hex: string): string => {
   return typeof a !== 'undefined' ? `rgba(${r},${g},${b},${a / 255})` : `rgb(${r},${g},${b})`;
 };
 
+/**
+ * Converts rgb, argb, rgba, hex and css colors to rgba(a)
+ */
 export function resolveToRGBAorRGB(input: string): string {
   // rgb
   let matches = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i.exec(input);
@@ -46,6 +49,9 @@ export function resolveToRGBAorRGB(input: string): string {
   return 'none';
 }
 
+/**
+ * Determines if color is dark or bright by estimating the perceived brightness
+ */
 export function isDarkColor(color: string | undefined | null): boolean {
   if (color == null) return false;
 
@@ -58,11 +64,14 @@ export function isDarkColor(color: string | undefined | null): boolean {
   const b = matches?.[3];
   const validRGB = r !== undefined && g !== undefined && b !== undefined;
 
-  // Using the HSP (Highly Sensitive Poo) value, determine whether the color is light or dark
+  // Using the HSP (Highly Sensitive Perceived brightness) value, determine whether the color is light or dark
   // HSP < 125, the color is dark, otherwise, the color is light
   return validRGB ? 0.299 * +r + 0.587 * +g + 0.114 * +b < 125 : false;
 }
 
+/**
+ * Checks if color is completely transparent. Returns false if color is undefined
+ */
 export function isTransparentColor(color: string | undefined): boolean {
   if (color === undefined) return false;
 
@@ -72,6 +81,9 @@ export function isTransparentColor(color: string | undefined): boolean {
   return a !== undefined ? +a === 0 : false;
 }
 
+/**
+ * Removes the opacity from color, making it opaque. Returns undefined if color is undefined
+ */
 export function removeOpacity(color: string | undefined): string | undefined {
   if (color !== undefined) {
     const rgba = resolveToRGBAorRGB(color);

--- a/src/table/utils/styling-utils.ts
+++ b/src/table/utils/styling-utils.ts
@@ -2,7 +2,7 @@ import { stardust } from '@nebula.js/stardust';
 
 import { resolveToRGBAorRGB, isDarkColor, removeOpacity } from './color-utils';
 import { TableLayout, ExtendedTheme, HeaderStyling, ContentStyling, PaletteColor, BackgroundColors } from '../../types';
-import { GeneratedStyling, CellStyle } from '../types';
+import { GeneratedStyling, CellStyle, FooterStyle } from '../types';
 import { SelectionStates, StylingDefaults, SELECTION_STYLING } from '../constants';
 
 // the order of style
@@ -171,7 +171,7 @@ export function getBodyCellStyle(layout: TableLayout, theme: ExtendedTheme): Gen
   };
 }
 
-export const getFooterStyle = (background: BackgroundColors) =>
+export const getFooterStyle = (background: BackgroundColors): FooterStyle =>
   background.isDark
     ? {
         backgroundColor: background.color,

--- a/src/table/utils/styling-utils.ts
+++ b/src/table/utils/styling-utils.ts
@@ -34,7 +34,6 @@ export function getPadding(styleObj: ContentStyling | undefined): string | undef
  * Gets color from color picker. Defaults to default color if resolved color is invalid
  */
 export function getColor(defaultColor: string, theme: stardust.Theme, color = {}): string {
-  console.log(color);
   const resolvedColor = theme.getColorPickerColor(color);
 
   return !resolvedColor || resolvedColor === 'none' ? defaultColor : resolvedColor;
@@ -172,17 +171,17 @@ export function getBodyCellStyle(layout: TableLayout, theme: ExtendedTheme): Gen
   };
 }
 
-export const getPaginationStyle = (background: BackgroundColors) =>
+export const getFooterStyle = (background: BackgroundColors) =>
   background.isDark
     ? {
-        background: background.color,
+        backgroundColor: background.color,
         borderColor: '#F2F2F2',
         color: 'rgba(255, 255, 255, 0.9)',
         iconColor: 'rgba(255, 255, 255, 0.9)',
         disabledIconColor: 'rgba(255, 255, 255, 0.3)',
       }
     : {
-        background: background.color,
+        backgroundColor: background.color,
         borderColor: '#D9D9D9',
         color: '#404040',
         iconColor: 'rgba(0, 0, 0, 0.54)',

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,14 +145,11 @@ export interface PaginationColors {
   disabledIconColor: string;
 }
 
-export interface TableThemeColors {
-  tableBackgroundColorFromTheme: string;
-  backgroundColor?: string;
-  isBackgroundTransparentColor: boolean;
-  isBackgroundDarkColor: boolean;
-  borderColor: string;
-  body: BodyColors;
-  pagination: PaginationColors;
+export interface BackgroundColors {
+  tableColorFromTheme: string;
+  color?: string;
+  isDark: boolean;
+  isTransparent: boolean;
 }
 
 export interface ExtendedSelectionAPI extends stardust.ObjectSelections {
@@ -166,7 +163,7 @@ export interface ExtendedTranslator extends stardust.Translator {
 
 export interface ExtendedTheme extends stardust.Theme {
   name(): string;
-  table: TableThemeColors;
+  background: BackgroundColors;
 }
 
 export interface UseOptions {


### PR DESCRIPTION
The extended theme hook calculated things that we normally do in the styling-utils. I moved everything that is not related to calculating the background out of use-extended-theme. Still keeping the background stuff there since we want it centralized on the theme
- rename `tableThemeColors` to `getBackgroundColors` and store the result under `background` on the extended theme
  - remove `background` from the varialbe names inside that funciton, since it is implied that we are talking about background
- create `getFooterStyle` to align with body and header
- added some descriptions for the color utils