### PR TITLE
feat: disable sortItem when column sort direction is the same

### DIFF
--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -19,18 +19,25 @@ const MenuItem = ({
   children,
   itemTitle,
   sortOrder,
+  sortDirection,
   sortFromMenu,
   setOpen,
+  isCurrentColumnActive,
 }: {
   children: any;
   itemTitle: string;
   sortOrder: string;
+  sortDirection: string;
   sortFromMenu(evt: React.MouseEvent, sortOrder: string): void;
   setOpen: any;
+  isCurrentColumnActive: boolean;
 }) => {
+  const isDisabled = isCurrentColumnActive && sortOrder === (sortDirection === 'asc' ? 'A' : 'D');
   return (
     <ListItem disablePadding>
       <ListItemButton
+        disabled={isDisabled}
+        className="sn-table-head-menu-item-button"
         onClick={(evt) => {
           sortFromMenu(evt, sortOrder);
           setOpen(false);
@@ -46,11 +53,15 @@ const MenuItem = ({
 export default function HeadCellMenu({
   headerStyle,
   translator,
+  sortDirection,
   sortFromMenu,
+  isCurrentColumnActive,
 }: {
   headerStyle: GeneratedStyling;
   translator: ExtendedTranslator;
+  sortDirection: string;
   sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
+  isCurrentColumnActive: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
@@ -101,8 +112,10 @@ export default function HeadCellMenu({
                   <MenuItem
                     itemTitle={translator.get('SNTable.MenuItem.SortAscending')}
                     sortOrder="A"
+                    sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}
+                    isCurrentColumnActive={isCurrentColumnActive}
                   >
                     <ArrowUpwardIcon />
                   </MenuItem>
@@ -110,8 +123,10 @@ export default function HeadCellMenu({
                   <MenuItem
                     itemTitle={translator.get('SNTable.MenuItem.SortDescending')}
                     sortOrder="D"
+                    sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}
+                    isCurrentColumnActive={isCurrentColumnActive}
                   >
                     <ArrowDownwardIcon />
                   </MenuItem>

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -102,7 +102,13 @@ function TableHeadWrapper({
                   )}
                 </StyledSortLabel>
                 {areBasicFeaturesEnabled && (
-                  <HeadCellMenu headerStyle={headerStyle} translator={translator} sortFromMenu={sortFromMenu} />
+                  <HeadCellMenu
+                    headerStyle={headerStyle}
+                    translator={translator}
+                    sortDirection={column.sortDirection}
+                    sortFromMenu={sortFromMenu}
+                    isCurrentColumnActive={isCurrentColumnActive}
+                  />
                 )}
               </HeadCellContent>
             </StyledHeadCell>

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TableContextProvider } from '../../../context';
 import { ExtendedTranslator, ExtendedSelectionAPI } from '../../../../types';
 import { GeneratedStyling } from '../../../types';
@@ -10,11 +11,19 @@ describe('<HeadCellMenu />', () => {
   let selectionsAPI: ExtendedSelectionAPI;
   let headerStyle: GeneratedStyling;
   let sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
+  const sortDirection: string = 'asc';
+  let isCurrentColumnActive: boolean = false;
 
   const renderTableHeadCellMenu = (cellCoordMock?: [number, number]) =>
     render(
       <TableContextProvider selectionsAPI={selectionsAPI} cellCoordMock={cellCoordMock}>
-        <HeadCellMenu headerStyle={headerStyle} translator={translator} sortFromMenu={sortFromMenu} />
+        <HeadCellMenu
+          headerStyle={headerStyle}
+          translator={translator}
+          sortDirection={sortDirection}
+          sortFromMenu={sortFromMenu}
+          isCurrentColumnActive={isCurrentColumnActive}
+        />
       </TableContextProvider>
     );
 
@@ -45,6 +54,16 @@ describe('<HeadCellMenu />', () => {
     expect(getByRole('menu')).toBeVisible();
     expect(getByText('SNTable.MenuItem.SortAscending')).toBeVisible();
     expect(getByText('SNTable.MenuItem.SortDescending')).toBeVisible();
+  });
+
+  it('should disable sorting option when the column order is already set on that option', () => {
+    isCurrentColumnActive = true;
+    const { getByRole, getByText } = renderTableHeadCellMenu();
+    fireEvent.click(getByRole('button'));
+    const element = getByText('SNTable.MenuItem.SortAscending').closest('.sn-table-head-menu-item-button');
+    expect(element).toHaveAttribute('aria-disabled', 'true');
+    userEvent.click(element as HTMLElement);
+    expect(sortFromMenu).not.toHaveBeenCalled();
   });
 
   it('should close the menu when the menu item is clicked', () => {

--- a/src/table/utils/__tests__/handle-click.spec.ts
+++ b/src/table/utils/__tests__/handle-click.spec.ts
@@ -90,6 +90,7 @@ describe('handle-click', () => {
     it('should sort the column when the event target is not on the head cell menu button', () => {
       evt = {
         target: {
+          getElementsByClassName: () => [{ ariaDisabled: false }],
           closest: () => false,
         } as unknown as HTMLElement,
       } as unknown as MouseEvent;
@@ -100,7 +101,19 @@ describe('handle-click', () => {
     it('should not sort the column when the event target is on the head cell menu button', () => {
       evt = {
         target: {
+          getElementsByClassName: () => [{ ariaDisabled: false }],
           closest: () => true,
+        } as unknown as HTMLElement,
+      } as unknown as MouseEvent;
+      handleClickToSort(evt, column, changeSortOrder, isInteractionEnabled);
+      expect(changeSortOrder).not.toHaveBeenCalled();
+    });
+
+    it('should not sort the column when the event target on menu item button is disabled', () => {
+      evt = {
+        target: {
+          getElementsByClassName: () => [{ ariaDisabled: true }],
+          closest: () => false,
         } as unknown as HTMLElement,
       } as unknown as MouseEvent;
       handleClickToSort(evt, column, changeSortOrder, isInteractionEnabled);

--- a/src/table/utils/handle-click.ts
+++ b/src/table/utils/handle-click.ts
@@ -37,7 +37,10 @@ export const handleClickToSort = (
   changeSortOrder: ChangeSortOrder,
   isInteractionEnabled: boolean
 ) => {
-  !(evt.target as HTMLElement).closest('#sn-table-head-menu-button') && isInteractionEnabled && changeSortOrder(column);
+  !(evt.target as HTMLElement).getElementsByClassName('sn-table-head-menu-item-button')[0]?.ariaDisabled &&
+    !(evt.target as HTMLElement).closest('#sn-table-head-menu-button') &&
+    isInteractionEnabled &&
+    changeSortOrder(column);
 };
 
 /**


### PR DESCRIPTION
Menu sort option will be disabled if the current column is already ordered in the same sort direction.
In the case that the sorting priority is not on the current column, both sort options stays enable until one of them be chosen.