### PR TITLE
fix: virtual table header rendering artifact

### DIFF
--- a/src/table/components/virtualized-table/Header.tsx
+++ b/src/table/components/virtualized-table/Header.tsx
@@ -25,6 +25,7 @@ const Header = (props: HeaderProps) => {
         borderColor: headerStyle.borderColor,
         borderStyle: 'solid',
         borderWidth: '1px 0px',
+        boxSizing: 'border-box',
       }}
       itemCount={layout.qHyperCube.qSize.qcx}
       itemSize={(index) => columnWidth[index]}


### PR DESCRIPTION
Before:
<img width="755" alt="Screenshot 2022-12-13 at 10 59 41" src="https://user-images.githubusercontent.com/16608020/207287335-e1544b9f-5c9a-48fd-85b4-83f44575deef.png">

After:
<img width="766" alt="Screenshot 2022-12-13 at 10 58 35" src="https://user-images.githubusercontent.com/16608020/207287372-fcdd6b48-becc-42e3-a01a-fa35b330be9f.png">
