### PR TITLE
refactor: align sort format and remove hyhpercube dependency

### DIFF
--- a/src/__test__/handle-data.spec.ts
+++ b/src/__test__/handle-data.spec.ts
@@ -22,11 +22,12 @@ describe('handle-data', () => {
       align: isDim ? 'left' : 'right',
       stylingIDs: [] as string[],
       totalInfo: totals,
-      sortDirection: 'asc',
+      sortDirection: 'A',
       colIdx,
       pageColIdx,
       isLocked,
       qApprMaxGlyphCount: 3,
+      qReverseSort: false,
     });
 
     it('should return column info for dimension', () => {

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -9,12 +9,6 @@ import {
   TableData,
 } from './types';
 
-enum DirectionMap {
-  A = 'asc',
-  D = 'desc',
-  N = 'asc',
-}
-
 const MAX_CELLS = 10000;
 
 /**
@@ -63,7 +57,8 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
   const info = (isDim ? qDimensionInfo[colIdx] : qMeasureInfo[colIdx - numDims]) as
     | ExtendedNxMeasureInfo
     | ExtendedNxDimensionInfo;
-  const isHidden = info.qError?.qErrorCode === 7005;
+  const { qError, qFallbackTitle, textAlign, qAttrExprInfo, qSortIndicator, qReverseSort, qApprMaxGlyphCount } = info;
+  const isHidden = qError?.qErrorCode === 7005;
   const isLocked = isDim && (info as ExtendedNxDimensionInfo).qLocked;
   const autoAlign = isDim ? 'left' : 'right';
 
@@ -73,13 +68,15 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
       isLocked,
       colIdx,
       pageColIdx,
+      qApprMaxGlyphCount,
+      qReverseSort,
       id: `col-${pageColIdx}`,
-      label: info.qFallbackTitle,
-      align: !info.textAlign || info.textAlign.auto ? autoAlign : info.textAlign.align,
-      stylingIDs: info.qAttrExprInfo.map((expr) => expr.id),
-      sortDirection: info.qSortIndicator ? DirectionMap[info.qSortIndicator] : DirectionMap.A,
+      label: qFallbackTitle,
+      align: !textAlign || textAlign.auto ? autoAlign : textAlign.align,
+      stylingIDs: qAttrExprInfo.map((expr) => expr.id),
+      // making sure that qSortIndicator is either A or D
+      sortDirection: qSortIndicator && qSortIndicator !== 'N' ? qSortIndicator : 'A',
       totalInfo: getTotalInfo(layout, colIdx, pageColIdx, numDims),
-      qApprMaxGlyphCount: info.qApprMaxGlyphCount,
     }
   );
 }

--- a/src/nebula-hooks/__tests__/use-sorting.spec.ts
+++ b/src/nebula-hooks/__tests__/use-sorting.spec.ts
@@ -1,6 +1,6 @@
 import { sortingFactory } from '../use-sorting';
 import { generateLayout } from '../../__test__/generate-test-data';
-import { Column, TableLayout, HyperCube } from '../../types';
+import { Column, TableLayout, HyperCube, SortDirection } from '../../types';
 
 describe('use-sorting', () => {
   describe('sortingFactory', () => {
@@ -17,7 +17,7 @@ describe('use-sorting', () => {
     let column: Column;
     let layout: TableLayout;
     let model: EngineAPI.IGenericObject;
-    let changeSortOrder: ((column: Column, sortOrder?: string) => Promise<void>) | undefined;
+    let changeSortOrder: ((column: Column, sortOrder?: SortDirection) => Promise<void>) | undefined;
     let expectedPatches: EngineAPI.INxPatch[];
 
     beforeEach(() => {
@@ -85,7 +85,7 @@ describe('use-sorting', () => {
     it('should not apply patches for qReverseSort for dimension when sortOrder and qSortIndicator are both ascending', async () => {
       column.colIdx = 0;
       if (changeSortOrder) {
-        await changeSortOrder(column, 'A');
+        await changeSortOrder(column, 'asc');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
@@ -95,7 +95,7 @@ describe('use-sorting', () => {
       layout.qHyperCube.qDimensionInfo[0].qSortIndicator = 'D';
 
       if (changeSortOrder) {
-        await changeSortOrder(column, 'D');
+        await changeSortOrder(column, 'desc');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
@@ -110,7 +110,7 @@ describe('use-sorting', () => {
       });
 
       if (changeSortOrder) {
-        await changeSortOrder(column, 'A');
+        await changeSortOrder(column, 'asc');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
@@ -124,7 +124,7 @@ describe('use-sorting', () => {
       });
 
       if (changeSortOrder) {
-        await changeSortOrder(column, 'D');
+        await changeSortOrder(column, 'desc');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });

--- a/src/nebula-hooks/__tests__/use-sorting.spec.ts
+++ b/src/nebula-hooks/__tests__/use-sorting.spec.ts
@@ -6,8 +6,7 @@ describe('use-sorting', () => {
   describe('sortingFactory', () => {
     it('should return undefined when model is undefined', async () => {
       const model = undefined;
-      const hyperCube = {} as HyperCube;
-      const changeSortOrder = sortingFactory(model, hyperCube);
+      const changeSortOrder = sortingFactory(model, 0);
       expect(changeSortOrder).toBeUndefined();
     });
   });
@@ -17,13 +16,13 @@ describe('use-sorting', () => {
     let column: Column;
     let layout: TableLayout;
     let model: EngineAPI.IGenericObject;
-    let changeSortOrder: ((column: Column, sortOrder?: SortDirection) => Promise<void>) | undefined;
+    let changeSortOrder: ((column: Column, sortDirection?: SortDirection) => Promise<void>) | undefined;
     let expectedPatches: EngineAPI.INxPatch[];
 
     beforeEach(() => {
       originalOrder = [0, 1, 2, 3];
       layout = generateLayout(2, 2, 2);
-      column = { isDim: true, colIdx: 1 } as Column;
+      column = { isDim: true, colIdx: 1, qReverseSort: false, sortDirection: 'A' } as Column;
       model = {
         applyPatches: jest.fn(),
         getEffectiveProperties: async () =>
@@ -33,7 +32,7 @@ describe('use-sorting', () => {
             } as unknown as HyperCube,
           }),
       } as unknown as EngineAPI.IGenericObject;
-      changeSortOrder = sortingFactory(model, layout.qHyperCube);
+      changeSortOrder = sortingFactory(model, layout.qHyperCube.qDimensionInfo.length);
       expectedPatches = [
         {
           qPath: '/qHyperCubeDef/qInterColumnSortOrder',
@@ -67,7 +66,7 @@ describe('use-sorting', () => {
     });
 
     it('should call apply patches with another patch for qReverseSort for measure', async () => {
-      column = { isDim: false, colIdx: 2 } as Column;
+      column = { isDim: false, colIdx: 2, qReverseSort: false } as Column;
       originalOrder = [2, 0, 1, 3];
       expectedPatches[0].qValue = '[2,0,1,3]';
       expectedPatches.push({
@@ -82,27 +81,27 @@ describe('use-sorting', () => {
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
 
-    it('should not apply patches for qReverseSort for dimension when sortOrder and qSortIndicator are both ascending', async () => {
+    it('should not apply patches for qReverseSort for dimension when newSortDirecion and qSortIndicator are both ascending', async () => {
       column.colIdx = 0;
       if (changeSortOrder) {
-        await changeSortOrder(column, 'asc');
+        await changeSortOrder(column, 'A');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
 
-    it('should not apply patches for qReverseSort for dimension when sortOrder and qSortIndicator are both descending', async () => {
+    it('should not apply patches for qReverseSort for dimension when newSortDirection and qSortIndicator are both descending', async () => {
       column.colIdx = 0;
-      layout.qHyperCube.qDimensionInfo[0].qSortIndicator = 'D';
+      column.sortDirection = 'D';
 
       if (changeSortOrder) {
-        await changeSortOrder(column, 'desc');
+        await changeSortOrder(column, 'D');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
 
-    it('should apply patches for qReverseSort for dimension when sortOrder is ascending and qSortIndicator is descending', async () => {
+    it('should apply patches for qReverseSort for dimension when newSortDirection is ascending and qSortIndicator is descending', async () => {
       column.colIdx = 0;
-      layout.qHyperCube.qDimensionInfo[0].qSortIndicator = 'D';
+      column.sortDirection = 'D';
       expectedPatches.push({
         qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
         qOp: 'Replace' as EngineAPI.NxPatchOpType,
@@ -110,12 +109,12 @@ describe('use-sorting', () => {
       });
 
       if (changeSortOrder) {
-        await changeSortOrder(column, 'asc');
+        await changeSortOrder(column, 'A');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
 
-    it('should apply patches for qReverseSort for dimension when sortOrder is descending and qSortIndicator is ascending', async () => {
+    it('should apply patches for qReverseSort for dimension when newSortDirection is descending and qSortIndicator is ascending', async () => {
       column.colIdx = 0;
       expectedPatches.push({
         qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
@@ -124,7 +123,7 @@ describe('use-sorting', () => {
       });
 
       if (changeSortOrder) {
-        await changeSortOrder(column, 'desc');
+        await changeSortOrder(column, 'D');
       }
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });

--- a/src/nebula-hooks/use-sorting.ts
+++ b/src/nebula-hooks/use-sorting.ts
@@ -1,10 +1,10 @@
 import { useMemo } from '@nebula.js/stardust';
-import { Column, HyperCube } from '../types';
+import { Column, HyperCube, SortDirection } from '../types';
 
 export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, hyperCube: HyperCube) => {
   if (!model) return undefined;
 
-  return async (column: Column, sortDirection?: string) => {
+  return async (column: Column, sortDirection?: SortDirection) => {
     const { isDim, colIdx } = column;
     const { qDimensionInfo, qMeasureInfo } = hyperCube;
     const idx = isDim ? colIdx : colIdx - qDimensionInfo.length;
@@ -29,7 +29,10 @@ export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, hype
     ];
 
     // Revers
-    if ((sortDirection && sortDirection !== qSortIndicator) || (!sortDirection && colIdx === topSortIdx)) {
+    if (
+      (sortDirection && sortDirection?.charAt(0).toUpperCase() !== qSortIndicator) ||
+      (!sortDirection && colIdx === topSortIdx)
+    ) {
       const qPath = `/qHyperCubeDef/${isDim ? 'qDimensions' : 'qMeasures'}/${idx}/qDef/qReverseSort`;
 
       patches.push({

--- a/src/nebula-hooks/use-sorting.ts
+++ b/src/nebula-hooks/use-sorting.ts
@@ -1,12 +1,12 @@
 import { useMemo } from '@nebula.js/stardust';
 import { Column, HyperCube, SortDirection } from '../types';
 
-export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, dimensionLength: number) => {
+export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, dimensionsLength: number) => {
   if (!model) return undefined;
 
   return async (column: Column, newSortDirection?: SortDirection) => {
     const { isDim, colIdx, sortDirection, qReverseSort } = column;
-    const idx = isDim ? colIdx : colIdx - dimensionLength;
+    const idx = isDim ? colIdx : colIdx - dimensionsLength;
 
     // The sort order from the properties is needed since it contains hidden columns
     const properties = await model.getEffectiveProperties();
@@ -41,5 +41,5 @@ export const sortingFactory = (model: EngineAPI.IGenericObject | undefined, dime
 };
 
 const useSorting = (model: EngineAPI.IGenericObject | undefined, hyperCube: HyperCube) =>
-  useMemo(() => sortingFactory(model, hyperCube.qDimensionInfo.length), [model, hyperCube]);
+  useMemo(() => sortingFactory(model, hyperCube.qDimensionInfo.length), [model, hyperCube.qDimensionInfo.length]);
 export default useSorting;

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -15,44 +15,6 @@ import { StyledMenuIconButton, StyledCellMenu } from './styles';
 import { GeneratedStyling } from '../../types';
 import { ExtendedTranslator, SortDirection } from '../../../types';
 
-const MenuItem = ({
-  children,
-  itemTitle,
-  sortOrder,
-  sortDirection,
-  sortFromMenu,
-  setOpen,
-  isInteractionEnabled,
-  isCurrentColumnActive,
-}: {
-  children: any;
-  itemTitle: string;
-  sortOrder: string;
-  sortDirection: string;
-  sortFromMenu(evt: React.MouseEvent, sortOrder: string): void;
-  setOpen: any;
-  isInteractionEnabled: boolean;
-  isCurrentColumnActive: boolean;
-}) => {
-  let isDisabled = false;
-  isDisabled = !isInteractionEnabled || (isCurrentColumnActive && sortOrder === sortDirection);
-  return (
-    <ListItem disablePadding>
-      <ListItemButton
-        disabled={isDisabled}
-        className="sn-table-head-menu-item-button"
-        onClick={(evt) => {
-          sortFromMenu(evt, sortOrder);
-          setOpen(false);
-        }}
-      >
-        <ListItemIcon sx={{ minWidth: '25px' }}>{children}</ListItemIcon>
-        <ListItemText primary={itemTitle} />
-      </ListItemButton>
-    </ListItem>
-  );
-};
-
 export default function HeadCellMenu({
   headerStyle,
   translator,
@@ -70,6 +32,33 @@ export default function HeadCellMenu({
 }) {
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
+
+  const MenuItem = ({
+    children,
+    itemTitle,
+    newSortDirection,
+  }: {
+    children: any;
+    itemTitle: string;
+    newSortDirection: SortDirection;
+  }) => {
+    const isDisabled = !isInteractionEnabled || (isCurrentColumnActive && newSortDirection === sortDirection);
+    return (
+      <ListItem disablePadding>
+        <ListItemButton
+          disabled={isDisabled}
+          className="sn-table-head-menu-item-button"
+          onClick={(evt) => {
+            sortFromMenu(evt, newSortDirection);
+            setOpen(false);
+          }}
+        >
+          <ListItemIcon sx={{ minWidth: '25px' }}>{children}</ListItemIcon>
+          <ListItemText primary={itemTitle} />
+        </ListItemButton>
+      </ListItem>
+    );
+  };
 
   return (
     <StyledCellMenu headerStyle={headerStyle}>
@@ -114,27 +103,11 @@ export default function HeadCellMenu({
                   className="sn-table-head-menu"
                   aria-labelledby="sn-table-head-menu-button"
                 >
-                  <MenuItem
-                    itemTitle={translator.get('SNTable.MenuItem.SortAscending')}
-                    sortOrder="asc"
-                    sortDirection={sortDirection}
-                    sortFromMenu={sortFromMenu}
-                    setOpen={setOpen}
-                    isInteractionEnabled={isInteractionEnabled}
-                    isCurrentColumnActive={isCurrentColumnActive}
-                  >
+                  <MenuItem itemTitle={translator.get('SNTable.MenuItem.SortAscending')} newSortDirection="A">
                     <ArrowUpwardIcon />
                   </MenuItem>
 
-                  <MenuItem
-                    itemTitle={translator.get('SNTable.MenuItem.SortDescending')}
-                    sortOrder="desc"
-                    sortDirection={sortDirection}
-                    sortFromMenu={sortFromMenu}
-                    setOpen={setOpen}
-                    isInteractionEnabled={isInteractionEnabled}
-                    isCurrentColumnActive={isCurrentColumnActive}
-                  >
+                  <MenuItem itemTitle={translator.get('SNTable.MenuItem.SortDescending')} newSortDirection="D">
                     <ArrowDownwardIcon />
                   </MenuItem>
                 </MenuList>

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -13,7 +13,7 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import MoreHoriz from '@mui/icons-material/MoreHoriz';
 import { StyledMenuIconButton, StyledCellMenu } from './styles';
 import { GeneratedStyling } from '../../types';
-import { ExtendedTranslator } from '../../../types';
+import { ExtendedTranslator, SortDirection } from '../../../types';
 
 const MenuItem = ({
   children,
@@ -35,14 +35,14 @@ const MenuItem = ({
   isCurrentColumnActive: boolean;
 }) => {
   let isDisabled = false;
-  isDisabled = !isInteractionEnabled || (isCurrentColumnActive && sortOrder === (sortDirection === 'asc' ? 'A' : 'D'));
+  isDisabled = !isInteractionEnabled || (isCurrentColumnActive && sortOrder === sortDirection);
   return (
     <ListItem disablePadding>
       <ListItemButton
         disabled={isDisabled}
         className="sn-table-head-menu-item-button"
         onClick={(evt) => {
-          sortFromMenu(evt, sortOrder);
+          sortFromMenu(evt, sortOrder.charAt(0).toUpperCase());
           setOpen(false);
         }}
       >
@@ -63,8 +63,8 @@ export default function HeadCellMenu({
 }: {
   headerStyle: GeneratedStyling;
   translator: ExtendedTranslator;
-  sortDirection: string;
-  sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
+  sortDirection: SortDirection;
+  sortFromMenu: (evt: React.MouseEvent, sortOrder: SortDirection) => void;
   isInteractionEnabled: boolean;
   isCurrentColumnActive: boolean;
 }) {
@@ -116,7 +116,7 @@ export default function HeadCellMenu({
                 >
                   <MenuItem
                     itemTitle={translator.get('SNTable.MenuItem.SortAscending')}
-                    sortOrder="A"
+                    sortOrder="asc"
                     sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}
@@ -128,7 +128,7 @@ export default function HeadCellMenu({
 
                   <MenuItem
                     itemTitle={translator.get('SNTable.MenuItem.SortDescending')}
-                    sortOrder="D"
+                    sortOrder="desc"
                     sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -22,6 +22,7 @@ const MenuItem = ({
   sortDirection,
   sortFromMenu,
   setOpen,
+  isInteractionEnabled,
   isCurrentColumnActive,
 }: {
   children: any;
@@ -30,13 +31,16 @@ const MenuItem = ({
   sortDirection: string;
   sortFromMenu(evt: React.MouseEvent, sortOrder: string): void;
   setOpen: any;
+  isInteractionEnabled: boolean;
   isCurrentColumnActive: boolean;
 }) => {
   const isDisabled = isCurrentColumnActive && sortOrder === (sortDirection === 'asc' ? 'A' : 'D');
+//  const isDisabled = false;
   return (
     <ListItem disablePadding>
       <ListItemButton
-        disabled={isDisabled}
+      	disabled={isDisabled}
+        //disabled={!isInteractionEnabled ? !isDisabled : isDisabled}
         className="sn-table-head-menu-item-button"
         onClick={(evt) => {
           sortFromMenu(evt, sortOrder);
@@ -55,14 +59,17 @@ export default function HeadCellMenu({
   translator,
   sortDirection,
   sortFromMenu,
+  isInteractionEnabled,
   isCurrentColumnActive,
 }: {
   headerStyle: GeneratedStyling;
   translator: ExtendedTranslator;
   sortDirection: string;
   sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
+  isInteractionEnabled: boolean;
   isCurrentColumnActive: boolean;
 }) {
+  console.log('HeadMenu isInteractionEnabled: ', isInteractionEnabled);
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
 
@@ -115,6 +122,7 @@ export default function HeadCellMenu({
                     sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}
+		    isInteractionEnabled={isInteractionEnabled}
                     isCurrentColumnActive={isCurrentColumnActive}
                   >
                     <ArrowUpwardIcon />
@@ -126,6 +134,7 @@ export default function HeadCellMenu({
                     sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}
+		    isInteractionEnabled={isInteractionEnabled}
                     isCurrentColumnActive={isCurrentColumnActive}
                   >
                     <ArrowDownwardIcon />

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -34,13 +34,14 @@ const MenuItem = ({
   isInteractionEnabled: boolean;
   isCurrentColumnActive: boolean;
 }) => {
-  const isDisabled = isCurrentColumnActive && sortOrder === (sortDirection === 'asc' ? 'A' : 'D');
-//  const isDisabled = false;
+  let isDisabled = false;
+  isDisabled =
+    (!isInteractionEnabled ? !isDisabled : isDisabled) ||
+    (isCurrentColumnActive && sortOrder === (sortDirection === 'asc' ? 'A' : 'D'));
   return (
     <ListItem disablePadding>
       <ListItemButton
-      	disabled={isDisabled}
-        //disabled={!isInteractionEnabled ? !isDisabled : isDisabled}
+        disabled={isDisabled}
         className="sn-table-head-menu-item-button"
         onClick={(evt) => {
           sortFromMenu(evt, sortOrder);
@@ -69,7 +70,6 @@ export default function HeadCellMenu({
   isInteractionEnabled: boolean;
   isCurrentColumnActive: boolean;
 }) {
-  console.log('HeadMenu isInteractionEnabled: ', isInteractionEnabled);
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
 
@@ -122,7 +122,7 @@ export default function HeadCellMenu({
                     sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}
-		    isInteractionEnabled={isInteractionEnabled}
+                    isInteractionEnabled={isInteractionEnabled}
                     isCurrentColumnActive={isCurrentColumnActive}
                   >
                     <ArrowUpwardIcon />
@@ -134,7 +134,7 @@ export default function HeadCellMenu({
                     sortDirection={sortDirection}
                     sortFromMenu={sortFromMenu}
                     setOpen={setOpen}
-		    isInteractionEnabled={isInteractionEnabled}
+                    isInteractionEnabled={isInteractionEnabled}
                     isCurrentColumnActive={isCurrentColumnActive}
                   >
                     <ArrowDownwardIcon />

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -35,9 +35,7 @@ const MenuItem = ({
   isCurrentColumnActive: boolean;
 }) => {
   let isDisabled = false;
-  isDisabled =
-    (!isInteractionEnabled ? !isDisabled : isDisabled) ||
-    (isCurrentColumnActive && sortOrder === (sortDirection === 'asc' ? 'A' : 'D'));
+  isDisabled = !isInteractionEnabled || (isCurrentColumnActive && sortOrder === (sortDirection === 'asc' ? 'A' : 'D'));
   return (
     <ListItem disablePadding>
       <ListItemButton

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -42,7 +42,7 @@ const MenuItem = ({
         disabled={isDisabled}
         className="sn-table-head-menu-item-button"
         onClick={(evt) => {
-          sortFromMenu(evt, sortOrder.charAt(0).toUpperCase());
+          sortFromMenu(evt, sortOrder);
           setOpen(false);
         }}
       >

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -59,7 +59,6 @@ function TableHeadWrapper({
           const tabIndex = columnIndex === 0 && !keyboard.enabled ? 0 : -1;
           const isCurrentColumnActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.colIdx;
           const ariaSort = isCurrentColumnActive ? FullSortDirection[column.sortDirection] : undefined;
-          const ariaPressed = isCurrentColumnActive ? column.qReverseSort : undefined;
 
           const handleKeyDown = (evt: React.KeyboardEvent) => {
             handleHeadKeyDown({
@@ -87,7 +86,7 @@ function TableHeadWrapper({
               className="sn-table-head-cell sn-table-cell"
               tabIndex={tabIndex}
               aria-sort={ariaSort}
-              aria-pressed={ariaPressed}
+              aria-pressed={isCurrentColumnActive}
               onKeyDown={handleKeyDown}
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
               onClick={(evt: React.MouseEvent) => handleClickToSort(evt, column, changeSortOrder, isInteractionEnabled)}
@@ -96,8 +95,8 @@ function TableHeadWrapper({
                 <StyledSortLabel
                   headerStyle={headerStyle}
                   active={isCurrentColumnActive}
-                  title={!constraints.passive ? ShortSortDirection[column.sortDirection] : undefined} // passive: turn off tooltips.
-                  direction={FullSortDirection[column.sortDirection]}
+                  title={!constraints.passive ? FullSortDirection[column.sortDirection] : undefined} // passive: turn off tooltips.
+                  direction={ShortSortDirection[column.sortDirection]}
                   tabIndex={-1}
                   onMouseDown={(evt: React.MouseEvent) =>
                     handleMouseDownLabelToFocusHeadCell(evt, rootElement, columnIndex)

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -102,7 +102,7 @@ function TableHeadWrapper({
                     </VisuallyHidden>
                   )}
                 </StyledSortLabel>
-                {areBasicFeaturesEnabled && (
+                {true && (
                   <HeadCellMenu
                     headerStyle={headerStyle}
                     translator={translator}

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -102,7 +102,7 @@ function TableHeadWrapper({
                     </VisuallyHidden>
                   )}
                 </StyledSortLabel>
-                {true && (
+                {areBasicFeaturesEnabled && (
                   <HeadCellMenu
                     headerStyle={headerStyle}
                     translator={translator}

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -79,7 +79,6 @@ function TableHeadWrapper({
               tabIndex={tabIndex}
               aria-sort={ariaSort}
               aria-pressed={isCurrentColumnActive}
-              isInteractionEnabled={isInteractionEnabled}
               onKeyDown={handleKeyDown}
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
               onClick={(evt: React.MouseEvent) => handleClickToSort(evt, column, changeSortOrder, isInteractionEnabled)}

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -14,6 +14,7 @@ import {
 import { TableHeadWrapperProps } from '../../types';
 import HeadCellMenu from './HeadCellMenu';
 import CellText from '../CellText';
+import { SortDirection } from '../../../types';
 
 function TableHeadWrapper({
   rootElement,
@@ -64,7 +65,7 @@ function TableHeadWrapper({
             });
           };
 
-          const sortFromMenu = (evt: React.MouseEvent, sortOrder: string) => {
+          const sortFromMenu = (evt: React.MouseEvent, sortOrder: SortDirection) => {
             evt.stopPropagation();
             changeSortOrder(column, sortOrder);
           };

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -11,10 +11,20 @@ import {
   handleClickToFocusHead,
   handleClickToSort,
 } from '../../utils/handle-click';
+import { SortDirection } from '../../../types';
 import { TableHeadWrapperProps } from '../../types';
 import HeadCellMenu from './HeadCellMenu';
 import CellText from '../CellText';
-import { SortDirection } from '../../../types';
+
+enum FullSortDirection {
+  A = 'ascending',
+  D = 'descending',
+}
+
+enum ShortSortDirection {
+  A = 'asc',
+  D = 'desc',
+}
 
 function TableHeadWrapper({
   rootElement,
@@ -48,9 +58,8 @@ function TableHeadWrapper({
           // when nebula does not handle keyboard navigation
           const tabIndex = columnIndex === 0 && !keyboard.enabled ? 0 : -1;
           const isCurrentColumnActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.colIdx;
-          const ariaSort = isCurrentColumnActive
-            ? (`${column.sortDirection}ending` as 'ascending' | 'descending')
-            : undefined;
+          const ariaSort = isCurrentColumnActive ? FullSortDirection[column.sortDirection] : undefined;
+          const ariaPressed = isCurrentColumnActive ? column.qReverseSort : undefined;
 
           const handleKeyDown = (evt: React.KeyboardEvent) => {
             handleHeadKeyDown({
@@ -65,9 +74,9 @@ function TableHeadWrapper({
             });
           };
 
-          const sortFromMenu = (evt: React.MouseEvent, sortOrder: SortDirection) => {
+          const sortFromMenu = (evt: React.MouseEvent, newSortDirection: SortDirection) => {
             evt.stopPropagation();
-            changeSortOrder(column, sortOrder);
+            changeSortOrder(column, newSortDirection);
           };
 
           return (
@@ -78,7 +87,7 @@ function TableHeadWrapper({
               className="sn-table-head-cell sn-table-cell"
               tabIndex={tabIndex}
               aria-sort={ariaSort}
-              aria-pressed={isCurrentColumnActive}
+              aria-pressed={ariaPressed}
               onKeyDown={handleKeyDown}
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
               onClick={(evt: React.MouseEvent) => handleClickToSort(evt, column, changeSortOrder, isInteractionEnabled)}
@@ -87,8 +96,8 @@ function TableHeadWrapper({
                 <StyledSortLabel
                   headerStyle={headerStyle}
                   active={isCurrentColumnActive}
-                  title={!constraints.passive ? column.sortDirection : undefined} // passive: turn off tooltips.
-                  direction={column.sortDirection}
+                  title={!constraints.passive ? ShortSortDirection[column.sortDirection] : undefined} // passive: turn off tooltips.
+                  direction={FullSortDirection[column.sortDirection]}
                   tabIndex={-1}
                   onMouseDown={(evt: React.MouseEvent) =>
                     handleMouseDownLabelToFocusHeadCell(evt, rootElement, columnIndex)

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -102,13 +102,13 @@ function TableHeadWrapper({
                     </VisuallyHidden>
                   )}
                 </StyledSortLabel>
-                {true && (
+                {areBasicFeaturesEnabled && (
                   <HeadCellMenu
                     headerStyle={headerStyle}
                     translator={translator}
                     sortDirection={column.sortDirection}
                     sortFromMenu={sortFromMenu}
-		    isInteractionEnabled={isInteractionEnabled}
+                    isInteractionEnabled={isInteractionEnabled}
                     isCurrentColumnActive={isCurrentColumnActive}
                   />
                 )}

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -78,6 +78,7 @@ function TableHeadWrapper({
               tabIndex={tabIndex}
               aria-sort={ariaSort}
               aria-pressed={isCurrentColumnActive}
+              isInteractionEnabled={isInteractionEnabled}
               onKeyDown={handleKeyDown}
               onMouseDown={() => handleClickToFocusHead(columnIndex, rootElement, setFocusedCellCoord, keyboard)}
               onClick={(evt: React.MouseEvent) => handleClickToSort(evt, column, changeSortOrder, isInteractionEnabled)}
@@ -101,12 +102,13 @@ function TableHeadWrapper({
                     </VisuallyHidden>
                   )}
                 </StyledSortLabel>
-                {areBasicFeaturesEnabled && (
+                {true && (
                   <HeadCellMenu
                     headerStyle={headerStyle}
                     translator={translator}
                     sortDirection={column.sortDirection}
                     sortFromMenu={sortFromMenu}
+		    isInteractionEnabled={isInteractionEnabled}
                     isCurrentColumnActive={isCurrentColumnActive}
                   />
                 )}

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -10,6 +10,7 @@ describe('<HeadCellMenu />', () => {
   let translator: ExtendedTranslator;
   let selectionsAPI: ExtendedSelectionAPI;
   let headerStyle: GeneratedStyling;
+  let isInteractionEnabled: boolean;
   let sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
   const sortDirection: string = 'asc';
   let isCurrentColumnActive: boolean = false;
@@ -22,6 +23,7 @@ describe('<HeadCellMenu />', () => {
           translator={translator}
           sortDirection={sortDirection}
           sortFromMenu={sortFromMenu}
+	  isInteractionEnabled={isInteractionEnabled}
           isCurrentColumnActive={isCurrentColumnActive}
         />
       </TableContextProvider>

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -11,7 +11,7 @@ describe('<HeadCellMenu />', () => {
   let selectionsAPI: ExtendedSelectionAPI;
   let headerStyle: GeneratedStyling;
   let sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
-  const sortDirection: SortDirection = 'asc';
+  const sortDirection: SortDirection = 'A';
   let isInteractionEnabled: boolean = true;
   let isCurrentColumnActive: boolean = false;
 

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -23,7 +23,7 @@ describe('<HeadCellMenu />', () => {
           translator={translator}
           sortDirection={sortDirection}
           sortFromMenu={sortFromMenu}
-	  isInteractionEnabled={isInteractionEnabled}
+          isInteractionEnabled={isInteractionEnabled}
           isCurrentColumnActive={isCurrentColumnActive}
         />
       </TableContextProvider>

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -10,9 +10,9 @@ describe('<HeadCellMenu />', () => {
   let translator: ExtendedTranslator;
   let selectionsAPI: ExtendedSelectionAPI;
   let headerStyle: GeneratedStyling;
-  let isInteractionEnabled: boolean;
   let sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
   const sortDirection: string = 'asc';
+  let isInteractionEnabled: boolean = true;
   let isCurrentColumnActive: boolean = false;
 
   const renderTableHeadCellMenu = (cellCoordMock?: [number, number]) =>
@@ -65,6 +65,20 @@ describe('<HeadCellMenu />', () => {
     const element = getByText('SNTable.MenuItem.SortAscending').closest('.sn-table-head-menu-item-button');
     expect(element).toHaveAttribute('aria-disabled', 'true');
     userEvent.click(element as HTMLElement);
+    expect(sortFromMenu).not.toHaveBeenCalled();
+  });
+
+  it('should disable sorting option when the column is in selection mode', () => {
+    isInteractionEnabled = false;
+    const { getByRole, getByText } = renderTableHeadCellMenu();
+    fireEvent.click(getByRole('button'));
+    const ascendingBtn = getByText('SNTable.MenuItem.SortAscending').closest('.sn-table-head-menu-item-button');
+    const descendingBtn = getByText('SNTable.MenuItem.SortDescending').closest('.sn-table-head-menu-item-button');
+    expect(ascendingBtn).toHaveAttribute('aria-disabled', 'true');
+    expect(descendingBtn).toHaveAttribute('aria-disabled', 'true');
+    userEvent.click(ascendingBtn as HTMLElement);
+    expect(sortFromMenu).not.toHaveBeenCalled();
+    userEvent.click(descendingBtn as HTMLElement);
     expect(sortFromMenu).not.toHaveBeenCalled();
   });
 

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TableContextProvider } from '../../../context';
-import { ExtendedTranslator, ExtendedSelectionAPI } from '../../../../types';
+import { ExtendedTranslator, ExtendedSelectionAPI, SortDirection } from '../../../../types';
 import { GeneratedStyling } from '../../../types';
 import HeadCellMenu from '../HeadCellMenu';
 
@@ -11,7 +11,7 @@ describe('<HeadCellMenu />', () => {
   let selectionsAPI: ExtendedSelectionAPI;
   let headerStyle: GeneratedStyling;
   let sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
-  const sortDirection: string = 'asc';
+  const sortDirection: SortDirection = 'asc';
   let isInteractionEnabled: boolean = true;
   let isCurrentColumnActive: boolean = false;
 

--- a/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
@@ -194,7 +194,7 @@ describe('<TableHeadWrapper />', () => {
     const secondColQuery = getByText(tableData.columns[1].label).closest('th') as HTMLTableCellElement;
 
     expect(firstColQuery.getAttribute('aria-sort')).toBeNull();
-    expect(firstColQuery.getAttribute('aria-pressed')).toBeNull();
+    expect(firstColQuery.getAttribute('aria-pressed')).toBe('false');
     expect(secondColQuery.getAttribute('aria-sort')).toBe('ascending');
     expect(secondColQuery.getAttribute('aria-pressed')).toBe('true');
   });

--- a/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
@@ -48,8 +48,17 @@ describe('<TableHeadWrapper />', () => {
   beforeEach(() => {
     tableData = {
       columns: [
-        { id: 1, align: 'left', label: 'someDim', sortDirection: 'asc', isDim: true, isLocked: false, colIdx: 0 },
-        { id: 2, align: 'right', label: 'someMsr', sortDirection: 'desc', isDim: false, colIdx: 1 },
+        {
+          id: 1,
+          align: 'left',
+          label: 'someDim',
+          sortDirection: 'A',
+          isDim: true,
+          isLocked: false,
+          colIdx: 0,
+          qReverseSort: false,
+        },
+        { id: 2, align: 'right', label: 'someMsr', sortDirection: 'D', isDim: false, colIdx: 1, qReverseSort: false },
       ],
     } as unknown as TableData;
     theme = {
@@ -170,8 +179,8 @@ describe('<TableHeadWrapper />', () => {
   it('should change `aria-pressed` and `aria-sort` when you sort by second column', () => {
     tableData = {
       columns: [
-        { ...tableData.columns[0], sortDirection: 'desc' },
-        { ...tableData.columns[1], sortDirection: 'asc' },
+        { ...tableData.columns[0], sortDirection: 'D' },
+        { ...tableData.columns[1], sortDirection: 'A' },
       ],
     } as unknown as TableData;
     layout = {
@@ -185,7 +194,7 @@ describe('<TableHeadWrapper />', () => {
     const secondColQuery = getByText(tableData.columns[1].label).closest('th') as HTMLTableCellElement;
 
     expect(firstColQuery.getAttribute('aria-sort')).toBeNull();
-    expect(firstColQuery.getAttribute('aria-pressed')).toBe('false');
+    expect(firstColQuery.getAttribute('aria-pressed')).toBeNull();
     expect(secondColQuery.getAttribute('aria-sort')).toBe('ascending');
     expect(secondColQuery.getAttribute('aria-pressed')).toBe('true');
   });

--- a/src/table/components/head/styles.ts
+++ b/src/table/components/head/styles.ts
@@ -21,15 +21,16 @@ export const StyledHeadRow = styled(TableRow, {
 }));
 
 export const StyledHeadCell = styled(TableCell, {
-  shouldForwardProp: (prop: string) => prop !== 'headerStyle',
-})(({ headerStyle }) => ({
+  shouldForwardProp: (prop: string) => prop !== 'headerStyle' && prop !== 'isInteractionEnabled',
+})(({ headerStyle, isInteractionEnabled }) => ({
   ...COMMON_CELL_STYLING,
   ...headerStyle,
   lineHeight: '150%',
   pointer: 'cursor',
   borderWidth: '1px 1px 1px 0px',
   '&&:hover, &&:focus': {
-    '& svg, & button': { opacity: 1 },
+    '& button': { opacity: 1 },
+    '& svg': { opacity: !isInteractionEnabled ? 0 : 1 },
   },
 }));
 

--- a/src/table/components/head/styles.ts
+++ b/src/table/components/head/styles.ts
@@ -30,7 +30,7 @@ export const StyledHeadCell = styled(TableCell, {
   borderWidth: '1px 1px 1px 0px',
   '&&:hover, &&:focus': {
     '& button': { opacity: 1 },
-    '& svg': { opacity: !isInteractionEnabled ? 0 : 1 },
+    '& svg': { opacity: isInteractionEnabled ? 1 : 0 },
   },
 }));
 

--- a/src/table/components/head/styles.ts
+++ b/src/table/components/head/styles.ts
@@ -21,16 +21,15 @@ export const StyledHeadRow = styled(TableRow, {
 }));
 
 export const StyledHeadCell = styled(TableCell, {
-  shouldForwardProp: (prop: string) => prop !== 'headerStyle' && prop !== 'isInteractionEnabled',
-})(({ headerStyle, isInteractionEnabled }) => ({
+  shouldForwardProp: (prop: string) => prop !== 'headerStyle',
+})(({ headerStyle }) => ({
   ...COMMON_CELL_STYLING,
   ...headerStyle,
   lineHeight: '150%',
   pointer: 'cursor',
   borderWidth: '1px 1px 1px 0px',
   '&&:hover, &&:focus': {
-    '& button': { opacity: 1 },
-    '& svg': { opacity: isInteractionEnabled ? 1 : 0 },
+    '& button, & svg': { opacity: 1 },
   },
 }));
 

--- a/src/table/utils/styling-utils.ts
+++ b/src/table/utils/styling-utils.ts
@@ -46,7 +46,7 @@ export const getAutoFontColor = (backgroundColor: string): string =>
   isDarkColor(backgroundColor) ? StylingDefaults.WHITE : StylingDefaults.FONT_COLOR;
 
 /**
- * get the border color based on the color of the background, returns bright color if background is darka dn vice versa
+ * get the border color based on the color of the background, returns bright color if background is dark and vice versa
  */
 export const getBorderColor = (isBackgroundDark: boolean): string => (isBackgroundDark ? '#F2F2F2' : '#D9D9D9');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,7 @@ export interface Row {
   // for the row key, string is needed
   [key: string]: Cell | string;
 }
+export type SortDirection = 'asc' | 'desc';
 
 export interface Column {
   id: string;
@@ -109,7 +110,7 @@ export interface Column {
   label: string;
   align: 'left' | 'center' | 'right';
   stylingIDs: string[];
-  sortDirection: string;
+  sortDirection: SortDirection;
   totalInfo?: string;
   qApprMaxGlyphCount: number;
 }
@@ -179,7 +180,7 @@ export interface AnnounceArgs {
 
 export type Announce = (arg0: AnnounceArgs) => void;
 
-export type ChangeSortOrder = (column: Column, sortOrder?: string) => Promise<void>;
+export type ChangeSortOrder = (column: Column, sortOrder?: SortDirection) => Promise<void>;
 
 export interface Galaxy {
   translator: ExtendedTranslator;

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,8 @@ export interface Row {
   // for the row key, string is needed
   [key: string]: Cell | string;
 }
-export type SortDirection = 'asc' | 'desc';
+
+export type SortDirection = 'A' | 'D';
 
 export interface Column {
   id: string;
@@ -111,6 +112,7 @@ export interface Column {
   align: 'left' | 'center' | 'right';
   stylingIDs: string[];
   sortDirection: SortDirection;
+  qReverseSort: boolean;
   totalInfo?: string;
   qApprMaxGlyphCount: number;
 }


### PR DESCRIPTION
- the current sort direction already exists on the column, might as well use that. Still need the number of dimension to get the right path to the field when we call engine
- Store sorting direction as  `A` or `D`. then use enums to get the asc/desc that mui needs + the full word for aria-sort