### PR TITLE
chore: add @types/react as dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.4.3",
     "@types/jest": "29.1.2",
+    "@types/react": "18.0.26",
     "@types/react-native": "0.70.4",
     "@types/react-window": "1.8.5",
     "@typescript-eslint/eslint-plugin": "5.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,6 +3293,15 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/react@18.0.26":
+  version "18.0.26"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.26.tgz#8ad59fc01fef8eaf5c74f4ea392621749f0b7917"
+  integrity sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"


### PR DESCRIPTION
Explicity set `@types/react` as a dep. Before it was added as a dependecy via `@types/react-native`.

Possible fix to allow us to merge #770. Should probably have it anyway as `@mui/material` have it as a peer dependency.