### PR TITLE
chore: lock nebula build version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,18 @@
 {
-  "extends": [
-    "qlik-oss"
-  ],
+  "extends": ["qlik-oss"],
   "circleci": {
     "ignoreDeps": ["circleci/node"]
   },
   "semanticCommits": true,
   "rangeStrategy": "bump",
-  "packageRules": [{
-    "depTypeList": [
-      "engines"
-    ],
-    "enabled": false
-  }]
+  "packageRules": [
+    {
+      "depTypeList": ["engines"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["@nebula.js/cli-build"],
+      "allowedVersions": "3.0.3"
+    }
+  ]
 }


### PR DESCRIPTION
Lock the version for `@nebula.js/cli-build` due to the issue described here #746 