### PR TITLE
fix: totals bottom position in vt mode

### DIFF
--- a/src/table/components/virtualized-table/FullSizeContainer.tsx
+++ b/src/table/components/virtualized-table/FullSizeContainer.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
-import { PAGINATION_HEIGHT } from './constants';
 
 interface FullSizeContainerProps {
   width: number;
   height: number;
   children: (JSX.Element | null)[] | JSX.Element;
-  paginationNeeded: boolean;
 }
 
-const FullSizeContainer = ({ width, height, paginationNeeded, children }: FullSizeContainerProps): JSX.Element => {
+const FullSizeContainer = ({ width, height, children }: FullSizeContainerProps): JSX.Element => {
   return (
     <div
       data-key="full-size-container"
       style={{
         display: 'block',
         width,
-        height: height + (paginationNeeded ? PAGINATION_HEIGHT : 0),
+        height,
       }}
     >
       {children}

--- a/src/table/components/virtualized-table/TableContainer.tsx
+++ b/src/table/components/virtualized-table/TableContainer.tsx
@@ -12,6 +12,7 @@ import useScrollHandler from './hooks/use-scroll-handler';
 import Totals from './Totals';
 import useTotals from './hooks/use-totals';
 import useOnPropsChange from './hooks/use-on-props-change';
+import useTableCount from './hooks/use-table-count';
 
 const TableContainer = (props: TableContainerProps) => {
   const { layout, rect, pageInfo, paginationNeeded, model, theme, constraints, selectionsAPI } = props;
@@ -32,10 +33,9 @@ const TableContainer = (props: TableContainerProps) => {
   const totals = useTotals(layout);
   const columns = useMemo(() => getColumns(layout), [layout]);
   const { width } = useColumnSize(rect, columns, headerStyle, bodyStyle);
+  const { rowCount } = useTableCount(layout, pageInfo, rect, width);
   const containerWidth = columns.reduce((prev, curr, index) => prev + width[index], 0);
-  const [containerHeight, setContainerHeight] = useState(
-    pageInfo.rowsPerPage * DEFAULT_ROW_HEIGHT + totals.shrinkBodyHeightBy
-  );
+  const [containerHeight, setContainerHeight] = useState(rowCount * DEFAULT_ROW_HEIGHT + totals.shrinkBodyHeightBy);
   const scrollHandler = useScrollHandler(
     headerRef,
     totalsRef,
@@ -47,8 +47,8 @@ const TableContainer = (props: TableContainerProps) => {
   );
 
   useOnPropsChange(() => {
-    setContainerHeight(pageInfo.rowsPerPage * DEFAULT_ROW_HEIGHT + totals.shrinkBodyHeightBy);
-  }, [layout]);
+    setContainerHeight(rowCount * DEFAULT_ROW_HEIGHT + totals.shrinkBodyHeightBy);
+  }, [rowCount, totals.shrinkBodyHeightBy]);
 
   useLayoutEffect(() => {
     if (ref.current) {
@@ -82,7 +82,7 @@ const TableContainer = (props: TableContainerProps) => {
       }}
       onScroll={scrollHandler}
     >
-      <FullSizeContainer width={containerWidth} height={containerHeight} paginationNeeded={paginationNeeded}>
+      <FullSizeContainer width={containerWidth} height={containerHeight}>
         <Header
           headerStyle={headerStyle}
           layout={layout}


### PR DESCRIPTION
Fixes an issue where the totals row would be poorly position if a used change to a page with just a few rows

Before:
![Skärmavbild 2022-12-21 kl  10 05 52](https://user-images.githubusercontent.com/16608020/208865315-31b462f0-0bbb-4527-b67b-83e3d6f233a5.png)


After:
![Skärmavbild 2022-12-21 kl  10 04 47](https://user-images.githubusercontent.com/16608020/208865148-63f52101-0e6b-4bb9-8b6b-5b4d3027a0df.png)
