### PR TITLE
fix: avoid rerendering when deleting alternative columns

### DIFF
--- a/src/ext/data.js
+++ b/src/ext/data.js
@@ -64,7 +64,7 @@ export default function getData(env) {
         return dimension;
       },
       remove(dimension, data, hcHandler, idx) {
-        if (dimension && dimension.isAlternative) return;
+        if (dimension?.isAlternative) return;
         const { qColumnOrder, columnWidths } = hcHandler.hcProperties;
         indexRemoved(qColumnOrder, idx);
         columnWidths.splice(qColumnOrder[idx], 1);

--- a/src/ext/data.js
+++ b/src/ext/data.js
@@ -64,9 +64,11 @@ export default function getData(env) {
         return dimension;
       },
       remove(dimension, data, hcHandler, idx) {
-        const { qColumnOrder, columnWidths } = hcHandler.hcProperties;
-        indexRemoved(qColumnOrder, idx);
-        columnWidths.splice(qColumnOrder[idx], 1);
+        if (!dimension.isAlternative) {
+          const { qColumnOrder, columnWidths } = hcHandler.hcProperties;
+          indexRemoved(qColumnOrder, idx);
+          columnWidths.splice(qColumnOrder[idx], 1);
+        }
       },
     },
   };

--- a/src/ext/data.js
+++ b/src/ext/data.js
@@ -64,11 +64,10 @@ export default function getData(env) {
         return dimension;
       },
       remove(dimension, data, hcHandler, idx) {
-        if (!dimension.isAlternative) {
-          const { qColumnOrder, columnWidths } = hcHandler.hcProperties;
-          indexRemoved(qColumnOrder, idx);
-          columnWidths.splice(qColumnOrder[idx], 1);
-        }
+        if (dimension && dimension.isAlternative) return;
+        const { qColumnOrder, columnWidths } = hcHandler.hcProperties;
+        indexRemoved(qColumnOrder, idx);
+        columnWidths.splice(qColumnOrder[idx], 1);
       },
     },
   };


### PR DESCRIPTION
When deleting alternative columns functions remove in sn-table/ext/data.js is called for both columns and alternative columns. This trigger a re-rendering. For removing alternative columns re-rendering is not necessary.
