### PR TITLE
refactor: use baseProps on context for pagination implementation

### DIFF
--- a/src/__test__/test-with-providers.tsx
+++ b/src/__test__/test-with-providers.tsx
@@ -20,6 +20,8 @@ interface ProviderProps {
   theme?: ExtendedTheme;
   keyboard?: stardust.Keyboard;
   direction?: 'ltr' | 'rtl';
+  rootElement?: HTMLElement;
+  embed?: stardust.Embed;
 }
 
 const TestWithProviders = ({
@@ -42,6 +44,8 @@ const TestWithProviders = ({
   cellCoordMock = undefined,
   selectionDispatchMock = undefined, // Can be used to avoid selectionDispatch infinite loop
   direction = 'ltr',
+  rootElement = {} as HTMLElement,
+  embed = {} as stardust.Embed,
 }: ProviderProps) => {
   return (
     <ThemeProvider theme={muiSetup(direction)}>
@@ -56,6 +60,8 @@ const TestWithProviders = ({
         pageRows={pageRows}
         cellCoordMock={cellCoordMock}
         selectionDispatchMock={selectionDispatchMock}
+        rootElement={rootElement}
+        embed={embed}
       >
         {children as JSX.Element}
       </TableContextProvider>

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,8 @@ export default function supernova(env: Galaxy) {
             translator,
             constraints,
             selectionsAPI,
+            rootElement,
+            embed,
           },
           reactRoot
         );

--- a/src/table/Root.tsx
+++ b/src/table/Root.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDom from 'react-dom/client';
 import { StyleSheetManager } from 'styled-components';
 import { ThemeProvider } from '@mui/material/styles';
+import { stardust } from '@nebula.js/stardust';
 import rtlPluginSc from 'stylis-plugin-rtl-sc';
 
 import TableWrapper from './components/TableWrapper';
@@ -12,7 +13,18 @@ import VirualizedTable from './components/virtualized-table/Wrapper';
 import { VirtualTableRenderProps } from './components/virtualized-table/types';
 
 export function render(props: RenderProps, reactRoot?: ReactDom.Root) {
-  const { direction, selectionsAPI, tableData, layout, translator, constraints, theme, keyboard } = props;
+  const {
+    direction,
+    selectionsAPI,
+    layout,
+    translator,
+    constraints,
+    theme,
+    keyboard,
+    rootElement,
+    embed,
+    ...wrapperProps
+  } = props;
   const muiTheme = muiSetup(direction);
 
   reactRoot?.render(
@@ -20,14 +32,16 @@ export function render(props: RenderProps, reactRoot?: ReactDom.Root) {
       <ThemeProvider theme={muiTheme}>
         <TableContextProvider
           selectionsAPI={selectionsAPI}
-          pageRows={tableData?.rows}
+          pageRows={props.tableData?.rows}
           layout={layout}
           translator={translator}
           constraints={constraints}
           theme={theme}
           keyboard={keyboard}
+          rootElement={rootElement as HTMLElement}
+          embed={embed as stardust.Embed}
         >
-          <TableWrapper {...(props as TableWrapperProps)} />
+          <TableWrapper {...(wrapperProps as TableWrapperProps)} />
         </TableContextProvider>
       </ThemeProvider>
     </StyleSheetManager>
@@ -35,7 +49,7 @@ export function render(props: RenderProps, reactRoot?: ReactDom.Root) {
 }
 
 export function renderVirtualizedTable(props: VirtualTableRenderProps, reactRoot?: ReactDom.Root) {
-  const { selectionsAPI, layout, model, translator, constraints, theme, keyboard, rect } = props;
+  const { selectionsAPI, layout, model, translator, constraints, theme, keyboard, rect, rootElement, embed } = props;
   const muiTheme = muiSetup('ltr');
 
   reactRoot?.render(
@@ -49,6 +63,8 @@ export function renderVirtualizedTable(props: VirtualTableRenderProps, reactRoot
           constraints={constraints}
           theme={theme}
           keyboard={keyboard}
+          rootElement={rootElement}
+          embed={embed}
         >
           <VirualizedTable rect={rect} />
         </TableContextProvider>

--- a/src/table/components/TableWrapper.tsx
+++ b/src/table/components/TableWrapper.tsx
@@ -16,28 +16,19 @@ import { updateFocus, resetFocus, getCellElement } from '../utils/accessibility-
 import { TableWrapperProps } from '../types';
 
 export default function TableWrapper(props: TableWrapperProps) {
-  const {
-    rootElement,
-    tableData,
-    pageInfo,
-    setPageInfo,
-    constraints,
-    translator,
-    selectionsAPI,
-    theme,
-    keyboard,
-    direction,
-    footerContainer,
-    announce,
-  } = props;
+  const { tableData, pageInfo, setPageInfo, direction, footerContainer, announce } = props;
   const { totalColumnCount, totalRowCount, totalPages, paginationNeeded, rows, columns, totalsPosition } = tableData;
   const { page, rowsPerPage } = pageInfo;
-  const isSelectionMode = selectionsAPI.isModal();
+  const { selectionsAPI, rootElement, keyboard, translator, theme, constraints } = useContextSelector(
+    TableContext,
+    (value) => value.baseProps
+  );
   const focusedCellCoord = useContextSelector(TableContext, (value) => value.focusedCellCoord);
   const setFocusedCellCoord = useContextSelector(TableContext, (value) => value.setFocusedCellCoord);
   const shouldRefocus = useRef(false);
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const tableWrapperRef = useRef<HTMLDivElement>(null);
+  const isSelectionMode = selectionsAPI.isModal();
 
   const setShouldRefocus = useCallback(() => {
     shouldRefocus.current = rootElement.getElementsByTagName('table')[0].contains(document.activeElement);
@@ -116,7 +107,7 @@ export default function TableWrapper(props: TableWrapperProps) {
         </Table>
       </StyledTableContainer>
       {!constraints.active && (
-        <FooterWrapper theme={theme} footerContainer={footerContainer} paginationNeeded={paginationNeeded}>
+        <FooterWrapper footerContainer={footerContainer} paginationNeeded={paginationNeeded}>
           <PaginationContent {...props} handleChangePage={handleChangePage} isSelectionMode={isSelectionMode} />
         </FooterWrapper>
       )}

--- a/src/table/components/__tests__/TableWrapper.spec.tsx
+++ b/src/table/components/__tests__/TableWrapper.spec.tsx
@@ -6,18 +6,7 @@ import TableBodyWrapper from '../body/TableBodyWrapper';
 import TableHeadWrapper from '../head/TableHeadWrapper';
 import * as handleKeyPress from '../../utils/handle-key-press';
 import * as handleScroll from '../../utils/handle-scroll';
-import {
-  TableLayout,
-  TableData,
-  PageInfo,
-  SetPageInfo,
-  ExtendedTranslator,
-  ExtendedTheme,
-  Announce,
-  Column,
-  ChangeSortOrder,
-  ExtendedSelectionAPI,
-} from '../../../types';
+import { TableLayout, TableData, PageInfo, SetPageInfo, Announce, Column, ChangeSortOrder } from '../../../types';
 import TestWithProviders from '../../../__test__/test-with-providers';
 
 describe('<TableWrapper />', () => {
@@ -25,46 +14,26 @@ describe('<TableWrapper />', () => {
   let pageInfo: PageInfo;
   let setPageInfo: SetPageInfo;
   let constraints: stardust.Constraints;
-  let selectionsAPI: ExtendedSelectionAPI;
-  let modal: boolean;
   let rootElement: HTMLElement;
-  let keyboard: stardust.Keyboard;
-  let translator: ExtendedTranslator;
   let rect: stardust.Rect;
-  let theme: ExtendedTheme;
   let direction: 'ltr' | 'rtl';
   let announce: Announce;
   let changeSortOrder: ChangeSortOrder;
   let layout: TableLayout;
   let areBasicFeaturesEnabled: boolean;
-  let embed: stardust.Embed;
 
   const renderTableWrapper = () =>
     render(
-      <TestWithProviders
-        selectionsAPI={selectionsAPI}
-        layout={layout}
-        translator={translator}
-        constraints={constraints}
-        keyboard={keyboard}
-      >
+      <TestWithProviders layout={layout} constraints={constraints} rootElement={rootElement}>
         <TableWrapper
           tableData={tableData}
           pageInfo={pageInfo}
           setPageInfo={setPageInfo}
-          constraints={constraints}
-          selectionsAPI={selectionsAPI}
-          rootElement={rootElement}
-          keyboard={keyboard}
-          translator={translator}
           rect={rect}
-          theme={theme}
           direction={direction}
           announce={announce}
           changeSortOrder={changeSortOrder}
-          layout={layout}
           areBasicFeaturesEnabled={areBasicFeaturesEnabled}
-          embed={embed}
         />
       </TestWithProviders>
     );
@@ -84,24 +53,14 @@ describe('<TableWrapper />', () => {
     pageInfo = { page: 0, rowsPerPage: 100, rowsPerPageOptions: [10, 25, 100] };
     setPageInfo = jest.fn();
     constraints = {};
-    selectionsAPI = {
-      isModal: () => modal,
-    } as unknown as ExtendedSelectionAPI;
-    modal = false;
     rootElement = {
       getElementsByClassName: () => [],
       getElementsByTagName: () => [{ clientHeight: {}, contains: jest.fn() }],
       querySelector: () => undefined,
     } as unknown as HTMLElement;
-    keyboard = { enabled: false, active: false };
-    translator = { get: (s: string) => s } as unknown as ExtendedTranslator;
     rect = {
       width: 750,
     } as unknown as stardust.Rect;
-    theme = {
-      getStyle: () => undefined,
-      background: { isDark: false },
-    } as unknown as ExtendedTheme;
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/src/table/components/body/TableBodyWrapper.tsx
+++ b/src/table/components/body/TableBodyWrapper.tsx
@@ -13,26 +13,24 @@ import TableTotals from './TableTotals';
 import CellText from '../CellText';
 
 function TableBodyWrapper({
-  rootElement,
   tableData,
-  constraints,
-  selectionsAPI,
-  layout,
-  theme,
   setShouldRefocus,
-  keyboard,
   tableWrapperRef,
   announce,
   areBasicFeaturesEnabled,
 }: TableBodyWrapperProps) {
   const { rows, columns, paginationNeeded, totalsPosition } = tableData;
-  const columnsStylingIDsJSON = JSON.stringify(columns.map((column) => column.stylingIDs));
+  const { selectionsAPI, rootElement, keyboard, layout, theme, constraints } = useContextSelector(
+    TableContext,
+    (value) => value.baseProps
+  );
   const setFocusedCellCoord = useContextSelector(TableContext, (value) => value.setFocusedCellCoord);
   const selectionDispatch = useContextSelector(TableContext, (value) => value.selectionDispatch);
   // constraints.active: true - turn off interactions that affect the state of the visual
   // representation including selection, zoom, scroll, etc.
   // constraints.select: true - turn off selections.
   const isSelectionsEnabled = !constraints.active && !constraints.select;
+  const columnsStylingIDsJSON = JSON.stringify(columns.map((column) => column.stylingIDs));
   const columnRenderers = useMemo(
     () =>
       JSON.parse(columnsStylingIDsJSON).map((stylingIDs: string[]) =>
@@ -56,17 +54,7 @@ function TableBodyWrapper({
     });
   }, []);
 
-  const totals = (
-    <TableTotals
-      rootElement={rootElement}
-      tableData={tableData}
-      theme={theme}
-      layout={layout}
-      keyboard={keyboard}
-      selectionsAPI={selectionsAPI}
-      areBasicFeaturesEnabled={areBasicFeaturesEnabled}
-    />
-  );
+  const totals = <TableTotals tableData={tableData} areBasicFeaturesEnabled={areBasicFeaturesEnabled} />;
 
   return (
     <StyledBody lastRowBottomBorder={lastRowBottomBorder}>

--- a/src/table/components/body/TableTotals.tsx
+++ b/src/table/components/body/TableTotals.tsx
@@ -9,20 +9,16 @@ import { StyledTotalsCell } from './styles';
 import { TableTotalsProps } from '../../types';
 import CellText from '../CellText';
 
-function TableTotals({
-  rootElement,
-  tableData,
-  theme,
-  layout,
-  keyboard,
-  selectionsAPI,
-  areBasicFeaturesEnabled,
-}: TableTotalsProps) {
+function TableTotals({ tableData, areBasicFeaturesEnabled }: TableTotalsProps) {
   const {
     columns,
     totalsPosition: { atTop },
     rows,
   } = tableData;
+  const { layout, theme, rootElement, selectionsAPI, keyboard } = useContextSelector(
+    TableContext,
+    (value) => value.baseProps
+  );
   const headRowHeight = useContextSelector(TableContext, (value) => value.headRowHeight);
   const setFocusedCellCoord = useContextSelector(TableContext, (value) => value.setFocusedCellCoord);
   const totalsStyle = useMemo(() => getTotalsCellStyle(layout, theme, atTop), [layout, theme.name(), atTop]);

--- a/src/table/components/body/__tests__/TableBodyWrapper.spec.tsx
+++ b/src/table/components/body/__tests__/TableBodyWrapper.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { stardust } from '@nebula.js/stardust';
 import { render, fireEvent } from '@testing-library/react';
 import { generateDataPages, generateLayout } from '../../../../__test__/generate-test-data';
 import manageData from '../../../../handle-data';
@@ -8,22 +7,17 @@ import * as selectionsUtils from '../../../utils/selections-utils';
 import * as getCellRenderer from '../../../utils/get-cell-renderer';
 import * as handleKeyPress from '../../../utils/handle-key-press';
 import * as handleClick from '../../../utils/handle-click';
-import { TableData, ExtendedSelectionAPI, TableLayout, ExtendedTheme, PageInfo, Cell } from '../../../../types';
+import { TableData, ExtendedSelectionAPI, PageInfo, Cell } from '../../../../types';
 import TestWithProviders from '../../../../__test__/test-with-providers';
 
 describe('<TableBodyWrapper />', () => {
-  const rootElement = {} as HTMLElement;
   const setShouldRefocus = () => undefined;
-  const keyboard = {} as stardust.Keyboard;
   const tableWrapperRef = {} as React.MutableRefObject<HTMLDivElement | null>;
   const announce = () => undefined;
   const model = { getHyperCubeData: async () => generateDataPages(2, 2) } as unknown as EngineAPI.IGenericObject;
 
   let tableData: TableData;
-  let constraints: stardust.Constraints;
   let selectionsAPI: ExtendedSelectionAPI;
-  let layout: TableLayout;
-  let theme: ExtendedTheme;
   let tableFirstRow: Cell;
   let tableSecondRow: Cell;
   let areBasicFeaturesEnabled: boolean;
@@ -33,13 +27,7 @@ describe('<TableBodyWrapper />', () => {
       <TestWithProviders selectionsAPI={selectionsAPI}>
         <TableBodyWrapper
           tableData={tableData}
-          constraints={constraints}
-          selectionsAPI={selectionsAPI}
-          layout={layout}
-          theme={theme}
-          rootElement={rootElement}
           setShouldRefocus={setShouldRefocus}
-          keyboard={keyboard}
           tableWrapperRef={tableWrapperRef}
           announce={announce}
           areBasicFeaturesEnabled={areBasicFeaturesEnabled}
@@ -55,17 +43,6 @@ describe('<TableBodyWrapper />', () => {
       { top: 0, height: 100 } as unknown as PageInfo,
       () => undefined
     )) as TableData;
-    constraints = {};
-    selectionsAPI = {
-      isModal: () => true,
-    } as ExtendedSelectionAPI;
-    theme = {
-      getColorPickerColor: () => undefined,
-      name: () => undefined,
-      getStyle: () => undefined,
-      background: { isDark: false },
-    } as unknown as ExtendedTheme;
-    layout = {} as TableLayout;
     tableFirstRow = tableData.rows[0]['col-0'] as Cell;
     tableSecondRow = tableData.rows[0]['col-1'] as Cell;
     areBasicFeaturesEnabled = true;

--- a/src/table/components/body/__tests__/TableTotals.spec.tsx
+++ b/src/table/components/body/__tests__/TableTotals.spec.tsx
@@ -1,36 +1,24 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { stardust } from '@nebula.js/stardust';
 import TableTotals from '../TableTotals';
 import manageData from '../../../../handle-data';
 import * as handleKeyPress from '../../../utils/handle-key-press';
 import * as handleAccessibility from '../../../utils/accessibility-utils';
 import { generateDataPages, generateLayout } from '../../../../__test__/generate-test-data';
-import { TableData, ExtendedTheme, ExtendedSelectionAPI, PageInfo } from '../../../../types';
+import { TableData, ExtendedSelectionAPI, PageInfo } from '../../../../types';
 import TestWithProviders from '../../../../__test__/test-with-providers';
 
 describe('<TableTotals />', () => {
-  const rootElement = {} as HTMLElement;
   const model = { getHyperCubeData: async () => generateDataPages(2, 2) } as unknown as EngineAPI.IGenericObject;
   const layout = generateLayout(1, 1, 2, [], [{ qText: '350' }]);
   let tableData: TableData;
-  let theme: ExtendedTheme;
   let selectionsAPI: ExtendedSelectionAPI;
-  let keyboard: stardust.Keyboard;
   let areBasicFeaturesEnabled: boolean;
 
   const renderTableTotals = (cellCoordMock?: [number, number]) =>
     render(
       <TestWithProviders selectionsAPI={selectionsAPI} cellCoordMock={cellCoordMock}>
-        <TableTotals
-          rootElement={rootElement}
-          tableData={tableData}
-          theme={theme}
-          layout={layout}
-          keyboard={keyboard}
-          selectionsAPI={selectionsAPI}
-          areBasicFeaturesEnabled={areBasicFeaturesEnabled}
-        />
+        <TableTotals tableData={tableData} areBasicFeaturesEnabled={areBasicFeaturesEnabled} />
       </TestWithProviders>
     );
 
@@ -41,18 +29,6 @@ describe('<TableTotals />', () => {
       { top: 0, height: 100 } as unknown as PageInfo,
       () => undefined
     )) as TableData;
-    theme = {
-      getColorPickerColor: () => undefined,
-      name: () => undefined,
-      getStyle: () => undefined,
-      background: { isDark: false },
-    } as unknown as ExtendedTheme;
-    keyboard = {
-      enabled: false,
-    } as stardust.Keyboard;
-    selectionsAPI = {
-      isModal: () => false,
-    } as ExtendedSelectionAPI;
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/src/table/components/footer/FooterWrapper.tsx
+++ b/src/table/components/footer/FooterWrapper.tsx
@@ -3,13 +3,10 @@ import ReactDOM from 'react-dom';
 import { StyledFooterWrapper } from './styles';
 import { FooterWrapperProps } from '../../types';
 import { getFooterStyle } from '../../utils/styling-utils';
+import { useContextSelector, TableContext } from '../../context';
 
-export default function FooterWrapper({
-  children,
-  theme,
-  footerContainer,
-  paginationNeeded = true,
-}: FooterWrapperProps) {
+export default function FooterWrapper({ children, footerContainer, paginationNeeded = true }: FooterWrapperProps) {
+  const { theme } = useContextSelector(TableContext, (value) => value.baseProps);
   const footerStyle = useMemo(() => getFooterStyle(theme.background), [theme]);
 
   const pagination = paginationNeeded ? (

--- a/src/table/components/footer/PaginationContent.tsx
+++ b/src/table/components/footer/PaginationContent.tsx
@@ -9,6 +9,7 @@ import { StyledSelect, StyledButton, StyledTypography } from './styles';
 import { handleLastTab } from '../../utils/handle-key-press';
 import { PaginationContentProps } from '../../types';
 import { getFooterStyle } from '../../utils/styling-utils';
+import { useContextSelector, TableContext } from '../../context';
 
 const icons: Record<string, typeof ArrowLeft> = {
   FirstPage: ArrowLeftStop,
@@ -37,14 +38,10 @@ export const shouldShow = (component: string, width: number) => {
 };
 
 function PaginationContent({
-  theme,
   direction,
   tableData,
   pageInfo,
   setPageInfo,
-  keyboard,
-  translator,
-  constraints,
   footerContainer,
   isSelectionMode,
   rect,
@@ -53,6 +50,7 @@ function PaginationContent({
 }: PaginationContentProps) {
   const { totalRowCount, totalColumnCount, totalPages } = tableData;
   const { page, rowsPerPage, rowsPerPageOptions } = pageInfo;
+  const { keyboard, translator, theme, constraints } = useContextSelector(TableContext, (value) => value.baseProps);
   const footerStyle = useMemo(() => getFooterStyle(theme.background), [theme]);
   const onFirstPage = page === 0;
   const onLastPage = page >= totalPages - 1;

--- a/src/table/components/footer/__tests__/PaginationContent.spec.tsx
+++ b/src/table/components/footer/__tests__/PaginationContent.spec.tsx
@@ -4,10 +4,11 @@ import { stardust } from '@nebula.js/stardust';
 
 import PaginationContent from '../PaginationContent';
 import * as handleAccessibility from '../../../utils/accessibility-utils';
-import { Announce, ExtendedTheme, ExtendedTranslator, PageInfo, SetPageInfo, TableData } from '../../../../types';
+import { Announce, PageInfo, SetPageInfo, TableData } from '../../../../types';
+import TestWithProviders from '../../../../__test__/test-with-providers';
 
 describe('<PaginationContent />', () => {
-  let theme: ExtendedTheme;
+  const keyboard = { enabled: true, active: false };
   let direction: 'ltr' | 'rtl' | undefined;
   let tableData: TableData;
   let pageInfo: PageInfo;
@@ -15,36 +16,28 @@ describe('<PaginationContent />', () => {
   let titles: string[];
   let handleChangePage: () => void;
   let rect: stardust.Rect;
-  let translator: ExtendedTranslator;
   let isSelectionMode: boolean;
-  let keyboard: stardust.Keyboard;
-  let constraints: stardust.Constraints;
   let footerContainer: HTMLElement;
   let announce: Announce;
 
   const renderPagination = () =>
     render(
-      <PaginationContent
-        theme={theme}
-        direction={direction}
-        tableData={tableData}
-        pageInfo={pageInfo}
-        setPageInfo={setPageInfo}
-        keyboard={keyboard}
-        translator={translator}
-        constraints={constraints}
-        footerContainer={footerContainer}
-        isSelectionMode={isSelectionMode}
-        rect={rect}
-        handleChangePage={handleChangePage}
-        announce={announce}
-      />
+      <TestWithProviders keyboard={keyboard}>
+        <PaginationContent
+          direction={direction}
+          tableData={tableData}
+          pageInfo={pageInfo}
+          setPageInfo={setPageInfo}
+          footerContainer={footerContainer}
+          isSelectionMode={isSelectionMode}
+          rect={rect}
+          handleChangePage={handleChangePage}
+          announce={announce}
+        />
+      </TestWithProviders>
     );
 
   beforeEach(() => {
-    theme = {
-      background: { isDark: false },
-    } as unknown as ExtendedTheme;
     direction = 'ltr';
     titles = [
       'SNTable.Pagination.FirstPage',
@@ -65,10 +58,7 @@ describe('<PaginationContent />', () => {
     setPageInfo = jest.fn();
     handleChangePage = jest.fn();
     rect = { width: 750 } as unknown as stardust.Rect;
-    translator = { get: (s: string) => s } as unknown as ExtendedTranslator;
     isSelectionMode = false;
-    keyboard = { enabled: true } as unknown as stardust.Keyboard;
-    constraints = {};
     announce = jest.fn();
     jest.spyOn(handleAccessibility, 'focusSelectionToolbar').mockImplementation(() => jest.fn());
   });

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -5,22 +5,21 @@ import Search from '@qlik-trial/sprout/icons/Search';
 import Descending from '@qlik-trial/sprout/icons/Descending';
 import Ascending from '@qlik-trial/sprout/icons/Ascending';
 
+import { useContextSelector, TableContext } from '../../context';
 import { HeadCellMenuProps, MenuItemGroup } from '../../types';
 import { StyledMenuIconButton, NebulaListBox } from './styles';
 import { ListBoxWrapper, ListBoxWrapperRenderProps } from './ListBoxWrapper';
 import MenuItems from './MenuItems';
 
 export default function HeadCellMenu({
-  translator,
   sortDirection,
   sortFromMenu,
-  embed,
-  layout,
   columnIndex,
   isInteractionEnabled,
   isCurrentColumnActive,
   isDimension,
 }: HeadCellMenuProps) {
+  const { translator } = useContextSelector(TableContext, (value) => value.baseProps);
   const [openMenuDropdown, setOpenMenuDropdown] = useState(false);
   const [openListboxDropdown, setOpenListboxDropdown] = useState(false);
   const anchorRef = useRef<HTMLButtonElement>(null);
@@ -98,7 +97,7 @@ export default function HeadCellMenu({
       </Menu>
 
       <Menu open={openListboxDropdown} anchorEl={anchorRef.current} onClose={() => setOpenListboxDropdown(false)}>
-        <ListBoxWrapper layout={layout} embed={embed} columnIndex={columnIndex}>
+        <ListBoxWrapper columnIndex={columnIndex}>
           {({ ref }: ListBoxWrapperRenderProps) => <NebulaListBox ref={ref} />}
         </ListBoxWrapper>
       </Menu>

--- a/src/table/components/head/ListBoxWrapper.tsx
+++ b/src/table/components/head/ListBoxWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { stardust } from '@nebula.js/stardust';
+import { useContextSelector, TableContext } from '../../context';
 import { TableLayout } from '../../../types';
 
 export interface ListBoxWrapperRenderProps {
@@ -8,8 +9,6 @@ export interface ListBoxWrapperRenderProps {
 
 interface ListBoxWrapperProps {
   children: (props: ListBoxWrapperRenderProps) => JSX.Element;
-  layout: TableLayout;
-  embed: stardust.Embed;
   columnIndex: number;
 }
 
@@ -21,7 +20,8 @@ const getFieldId = (layout: TableLayout, columnIndex: number): string | stardust
       }
     : layout.qHyperCube.qDimensionInfo[columnIndex]?.qFallbackTitle;
 
-export const ListBoxWrapper = ({ children, embed, layout, columnIndex }: ListBoxWrapperProps) => {
+export const ListBoxWrapper = ({ children, columnIndex }: ListBoxWrapperProps) => {
+  const { embed, layout } = useContextSelector(TableContext, (value) => value.baseProps);
   const [listboxInstance, setListboxInstance] = useState<stardust.FieldInstance>();
   const ref = useRef<HTMLElement>(null);
 

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -27,20 +27,12 @@ enum ShortSortDirection {
   D = 'desc',
 }
 
-function TableHeadWrapper({
-  rootElement,
-  tableData,
-  theme,
-  layout,
-  changeSortOrder,
-  constraints,
-  translator,
-  selectionsAPI,
-  keyboard,
-  embed,
-  areBasicFeaturesEnabled,
-}: TableHeadWrapperProps) {
+function TableHeadWrapper({ tableData, changeSortOrder, areBasicFeaturesEnabled }: TableHeadWrapperProps) {
   const { columns, totalsPosition } = tableData;
+  const { layout, theme, constraints, selectionsAPI, rootElement, keyboard, translator } = useContextSelector(
+    TableContext,
+    (value) => value.baseProps
+  );
   const setHeadRowHeight = useContextSelector(TableContext, (value) => value.setHeadRowHeight);
   const isFocusInHead = useContextSelector(TableContext, (value) => value.focusedCellCoord[0] === 0);
   const setFocusedCellCoord = useContextSelector(TableContext, (value) => value.setFocusedCellCoord);
@@ -119,10 +111,7 @@ function TableHeadWrapper({
                 {areBasicFeaturesEnabled && (
                   <HeadCellMenu
                     headerStyle={headerStyle}
-                    translator={translator}
                     sortFromMenu={sortFromMenu}
-                    embed={embed}
-                    layout={layout}
                     columnIndex={columnIndex}
                     sortDirection={column.sortDirection}
                     isInteractionEnabled={isInteractionEnabled}

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -2,14 +2,12 @@ import React from 'react';
 import { stardust } from '@nebula.js/stardust';
 import { render, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ExtendedTranslator, ExtendedSelectionAPI, SortDirection, TableLayout } from '../../../../types';
+import { SortDirection, TableLayout } from '../../../../types';
 import { GeneratedStyling } from '../../../types';
 import HeadCellMenu from '../HeadCellMenu';
 import TestWithProviders from '../../../../__test__/test-with-providers';
 
 describe('<HeadCellMenu />', () => {
-  let translator: ExtendedTranslator;
-  let selectionsAPI: ExtendedSelectionAPI;
   let headerStyle: GeneratedStyling;
   let sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
   const sortDirection: SortDirection = 'A';
@@ -22,27 +20,20 @@ describe('<HeadCellMenu />', () => {
 
   const renderTableHeadCellMenu = (cellCoordMock?: [number, number]) =>
     render(
-      <TestWithProviders selectionsAPI={selectionsAPI} cellCoordMock={cellCoordMock} direction={direction}>
+      <TestWithProviders cellCoordMock={cellCoordMock} layout={layout} direction={direction} embed={embed}>
         <HeadCellMenu
           isDimension
           headerStyle={headerStyle}
-          translator={translator}
           sortDirection={sortDirection}
           sortFromMenu={sortFromMenu}
           isInteractionEnabled={isInteractionEnabled}
           isCurrentColumnActive={isCurrentColumnActive}
-          embed={embed}
-          layout={layout}
           columnIndex={columnIndex}
         />
       </TestWithProviders>
     );
 
   beforeEach(() => {
-    selectionsAPI = {
-      isModal: () => false,
-    } as ExtendedSelectionAPI;
-    translator = { get: (s) => s } as ExtendedTranslator;
     headerStyle = {
       borderBottomColor: '#4287f5',
       borderRightColor: '#4287f5',

--- a/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
+++ b/src/table/components/head/__tests__/TableHeadWrapper.spec.tsx
@@ -5,44 +5,29 @@ import useEvent from '@testing-library/user-event';
 import TableHeadWrapper from '../TableHeadWrapper';
 import * as handleKeyPress from '../../../utils/handle-key-press';
 import * as handleClick from '../../../utils/handle-click';
-import {
-  TableData,
-  TableLayout,
-  ExtendedTheme,
-  ChangeSortOrder,
-  ExtendedTranslator,
-  ExtendedSelectionAPI,
-} from '../../../../types';
+import { TableData, TableLayout, ChangeSortOrder, ExtendedSelectionAPI } from '../../../../types';
 import TestWithProviders from '../../../../__test__/test-with-providers';
 
 describe('<TableHeadWrapper />', () => {
-  const rootElement = {} as HTMLElement;
   let tableData: TableData;
-  let theme: ExtendedTheme;
   let layout: TableLayout;
   let changeSortOrder: ChangeSortOrder;
   let constraints: stardust.Constraints;
   let selectionsAPI: ExtendedSelectionAPI;
-  let keyboard: stardust.Keyboard;
-  let translator: ExtendedTranslator;
   let areBasicFeaturesEnabled: boolean;
-  let embed: stardust.Embed;
 
   const renderTableHead = (cellCoordMock?: [number, number]) =>
     render(
-      <TestWithProviders selectionsAPI={selectionsAPI} cellCoordMock={cellCoordMock}>
+      <TestWithProviders
+        selectionsAPI={selectionsAPI}
+        cellCoordMock={cellCoordMock}
+        constraints={constraints}
+        layout={layout}
+      >
         <TableHeadWrapper
-          rootElement={rootElement}
-          constraints={constraints}
-          selectionsAPI={selectionsAPI}
           tableData={tableData}
-          theme={theme}
-          layout={layout}
           changeSortOrder={changeSortOrder}
-          keyboard={keyboard}
-          translator={translator}
           areBasicFeaturesEnabled={areBasicFeaturesEnabled}
-          embed={embed}
         />
       </TestWithProviders>
     );
@@ -64,12 +49,6 @@ describe('<TableHeadWrapper />', () => {
       ],
       totalsPosition: { atTop: false, atBottom: false },
     } as unknown as TableData;
-    theme = {
-      getColorPickerColor: () => undefined,
-      name: () => undefined,
-      getStyle: () => undefined,
-      background: { isDark: false },
-    } as unknown as ExtendedTheme;
     layout = {
       qHyperCube: {
         qEffectiveInterColumnSortOrder: [0, 1],
@@ -82,10 +61,6 @@ describe('<TableHeadWrapper />', () => {
     selectionsAPI = {
       isModal: () => false,
     } as ExtendedSelectionAPI;
-    keyboard = {
-      enabled: false,
-    } as stardust.Keyboard;
-    translator = { get: (s) => s } as ExtendedTranslator;
     areBasicFeaturesEnabled = false;
   });
 

--- a/src/table/components/virtualized-table/Wrapper.tsx
+++ b/src/table/components/virtualized-table/Wrapper.tsx
@@ -11,10 +11,7 @@ import { TableContext, useContextSelector } from '../../context';
 
 export default function Wrapper(props: WrapperProps) {
   const { rect } = props;
-  const { layout, keyboard, translator, theme, constraints } = useContextSelector(
-    TableContext,
-    (value) => value.baseProps
-  );
+  const { layout, theme, constraints } = useContextSelector(TableContext, (value) => value.baseProps);
   const totalRowCount = layout.qHyperCube.qSize.qcy;
   const pageSize = Math.min(MAX_PAGE_SIZE, totalRowCount);
   const [page, setPage] = useState(0);
@@ -41,17 +38,13 @@ export default function Wrapper(props: WrapperProps) {
     <StyledTableWrapper data-key="wrapper" background={theme.background} dir="ltr">
       <Table rect={rect} pageInfo={pageInfo} paginationNeeded={paginationNeeded} />
       {paginationNeeded && (
-        <FooterWrapper theme={theme}>
+        <FooterWrapper>
           <PaginationContent
-            theme={theme}
             handleChangePage={(currentPage) => setPage(currentPage)}
             isSelectionMode={false}
             tableData={tableData}
             pageInfo={pageInfo}
             setPageInfo={() => {}}
-            keyboard={keyboard}
-            translator={translator}
-            constraints={constraints}
             rect={rect}
             announce={() => {}}
           />

--- a/src/table/components/virtualized-table/types/index.ts
+++ b/src/table/components/virtualized-table/types/index.ts
@@ -34,6 +34,8 @@ export interface VirtualTableRenderProps {
   theme: ExtendedTheme;
   keyboard: stardust.Keyboard;
   rect: stardust.Rect;
+  rootElement: HTMLElement;
+  embed: stardust.Embed;
 }
 
 export interface WrapperProps {

--- a/src/table/context/TableContext.tsx
+++ b/src/table/context/TableContext.tsx
@@ -27,14 +27,16 @@ export const TableContextProvider = ({
   constraints,
   theme,
   keyboard,
+  rootElement,
+  embed,
 }: ContextProviderProps) => {
   const [headRowHeight, setHeadRowHeight] = useState(0);
   const [focusedCellCoord, setFocusedCellCoord] = useState((cellCoordMock || [0, 0]) as [number, number]);
   const [selectionState, selectionDispatch] = useSelectionReducer(pageRows, selectionsAPI);
   const [hoverIndex, setHoverIndex] = useState(-1);
   const baseProps = useMemo(
-    () => ({ selectionsAPI, layout, model, translator, constraints, theme, keyboard }),
-    [selectionsAPI, layout, model, translator, constraints, theme.name(), keyboard] // eslint-disable-line react-hooks/exhaustive-deps
+    () => ({ selectionsAPI, layout, model, translator, constraints, theme, keyboard, rootElement, embed }),
+    [selectionsAPI, layout, model, translator, constraints, theme.name(), keyboard, rootElement, embed] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return (

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -86,6 +86,8 @@ export interface ContextValue {
     constraints: stardust.Constraints;
     theme: ExtendedTheme;
     keyboard: stardust.Keyboard;
+    rootElement: HTMLElement;
+    embed: stardust.Embed;
   };
 }
 
@@ -185,6 +187,8 @@ export interface ContextProviderProps {
   constraints: stardust.Constraints;
   theme: ExtendedTheme;
   keyboard: stardust.Keyboard;
+  rootElement: HTMLElement;
+  embed: stardust.Embed;
 }
 
 export interface RenderProps {
@@ -215,49 +219,30 @@ export interface RenderProps {
   embed?: stardust.Embed;
 }
 
-export interface CommonTableProps {
+export interface TableWrapperProps {
   tableData: TableData;
-  theme: ExtendedTheme;
-  keyboard: stardust.Keyboard;
-}
-
-export interface TableWrapperProps extends CommonTableProps {
   direction?: Direction;
-  selectionsAPI: ExtendedSelectionAPI;
-  rootElement: HTMLElement;
-  layout: TableLayout;
   changeSortOrder: ChangeSortOrder;
   rect: stardust.Rect;
   pageInfo: PageInfo;
   setPageInfo: SetPageInfo;
-  constraints: stardust.Constraints;
-  translator: ExtendedTranslator;
   footerContainer?: HTMLElement;
   announce: Announce;
   areBasicFeaturesEnabled: boolean;
-  embed: stardust.Embed;
 }
 
-export interface TableHeadWrapperProps extends CommonTableProps {
-  selectionsAPI: ExtendedSelectionAPI;
-  rootElement: HTMLElement;
-  layout: TableLayout;
+export interface TableHeadWrapperProps {
+  tableData: TableData;
   changeSortOrder: ChangeSortOrder;
-  constraints: stardust.Constraints;
-  translator: ExtendedTranslator;
   areBasicFeaturesEnabled: boolean;
-  embed: stardust.Embed;
 }
 
 export interface HeadCellMenuProps {
   headerStyle: GeneratedStyling;
-  translator: ExtendedTranslator;
   sortDirection: SortDirection;
   sortFromMenu: (evt: React.MouseEvent, sortOrder: SortDirection) => void;
   isInteractionEnabled: boolean;
   isCurrentColumnActive: boolean;
-  embed: stardust.Embed;
-  layout: TableLayout;
   columnIndex: number;
   isDimension: boolean;
 }
@@ -273,31 +258,25 @@ export interface HeadCellMenuItem {
   onClick: (evt: React.MouseEvent<HTMLLIElement>) => void;
 }
 
-export interface TableBodyWrapperProps extends CommonTableProps {
-  selectionsAPI: ExtendedSelectionAPI;
-  rootElement: HTMLElement;
-  layout: TableLayout;
-  constraints: stardust.Constraints;
+export interface TableBodyWrapperProps {
+  tableData: TableData;
   announce: Announce;
   setShouldRefocus(): void;
   tableWrapperRef: React.MutableRefObject<HTMLDivElement | null>;
   areBasicFeaturesEnabled: boolean;
 }
 
-export interface TableTotalsProps extends CommonTableProps {
-  rootElement: HTMLElement;
-  layout: TableLayout;
-  selectionsAPI: ExtendedSelectionAPI;
+export interface TableTotalsProps {
+  tableData: TableData;
   areBasicFeaturesEnabled: boolean;
 }
 
-export interface PaginationContentProps extends CommonTableProps {
+export interface PaginationContentProps {
+  tableData: TableData;
   direction?: 'ltr' | 'rtl';
   rect: stardust.Rect;
   pageInfo: PageInfo;
   setPageInfo: SetPageInfo;
-  constraints: stardust.Constraints;
-  translator: ExtendedTranslator;
   footerContainer?: HTMLElement;
   announce: Announce;
   isSelectionMode: boolean;
@@ -306,7 +285,6 @@ export interface PaginationContentProps extends CommonTableProps {
 
 export interface FooterWrapperProps {
   children: JSX.Element;
-  theme: ExtendedTheme;
   footerContainer?: HTMLElement;
   withoutBorders?: boolean;
   paginationNeeded?: boolean;


### PR DESCRIPTION
- use `baseProps` for pagination table, instead of props drilling
- add `rootElement` since it is very commonly used
- add `embed` since it is passed all the way to `listBoxWrapper` and that is the only place it is used

I think we can add more stuff. Anything that triggers a rerender all the way from index, would not create extra renders if they are put on the context