### PR TITLE
fix: remove sort options for head menu

### DIFF
--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -2,8 +2,6 @@ import React, { useRef, useState, useMemo } from 'react';
 import Menu from '@mui/material/Menu';
 import More from '@qlik-trial/sprout/icons/More';
 import Search from '@qlik-trial/sprout/icons/Search';
-import Descending from '@qlik-trial/sprout/icons/Descending';
-import Ascending from '@qlik-trial/sprout/icons/Ascending';
 
 import { useContextSelector, TableContext } from '../../context';
 import { HeadCellMenuProps, MenuItemGroup } from '../../types';
@@ -11,14 +9,7 @@ import { StyledMenuIconButton, NebulaListBox } from './styles';
 import { ListBoxWrapper, ListBoxWrapperRenderProps } from './ListBoxWrapper';
 import MenuItems from './MenuItems';
 
-export default function HeadCellMenu({
-  sortDirection,
-  sortFromMenu,
-  columnIndex,
-  isInteractionEnabled,
-  isCurrentColumnActive,
-  isDimension,
-}: HeadCellMenuProps) {
+export default function HeadCellMenu({ columnIndex, isDimension }: HeadCellMenuProps) {
   const { translator } = useContextSelector(TableContext, (value) => value.baseProps);
   const [openMenuDropdown, setOpenMenuDropdown] = useState(false);
   const [openListboxDropdown, setOpenListboxDropdown] = useState(false);
@@ -26,28 +17,6 @@ export default function HeadCellMenu({
 
   const menuItemGroups = useMemo<MenuItemGroup[]>(
     () => [
-      [
-        {
-          id: 1,
-          itemTitle: translator.get('SNTable.MenuItem.SortAscending'),
-          onClick: (evt: React.MouseEvent<HTMLLIElement>) => {
-            sortFromMenu(evt, 'A');
-            setOpenMenuDropdown(false);
-          },
-          icon: <Ascending />,
-          isDisabled: !isInteractionEnabled || (isCurrentColumnActive && sortDirection === 'A'),
-        },
-        {
-          id: 2,
-          itemTitle: translator.get('SNTable.MenuItem.SortDescending'),
-          onClick: (evt: React.MouseEvent<HTMLLIElement>) => {
-            sortFromMenu(evt, 'D');
-            setOpenMenuDropdown(false);
-          },
-          icon: <Descending />,
-          isDisabled: !isInteractionEnabled || (isCurrentColumnActive && sortDirection === 'D'),
-        },
-      ],
       ...(isDimension
         ? [
             [
@@ -66,10 +35,10 @@ export default function HeadCellMenu({
           ]
         : []),
     ],
-    [translator, isInteractionEnabled, isCurrentColumnActive, sortDirection, isDimension]
+    [translator, isDimension]
   );
 
-  return (
+  return menuItemGroups.length ? (
     <>
       <StyledMenuIconButton
         isVisible={openListboxDropdown || openMenuDropdown}
@@ -102,5 +71,5 @@ export default function HeadCellMenu({
         </ListBoxWrapper>
       </Menu>
     </>
-  );
+  ) : null;
 }

--- a/src/table/components/head/TableHeadWrapper.tsx
+++ b/src/table/components/head/TableHeadWrapper.tsx
@@ -12,7 +12,6 @@ import {
   handleClickToFocusHead,
   handleClickToSort,
 } from '../../utils/handle-click';
-import { SortDirection } from '../../../types';
 import { TableHeadWrapperProps } from '../../types';
 import HeadCellMenu from './HeadCellMenu';
 import CellText from '../CellText';
@@ -70,11 +69,6 @@ function TableHeadWrapper({ tableData, changeSortOrder, areBasicFeaturesEnabled 
             });
           };
 
-          const sortFromMenu = (evt: React.MouseEvent, newSortDirection: SortDirection) => {
-            evt.stopPropagation();
-            changeSortOrder(column, newSortDirection);
-          };
-
           return (
             <StyledHeadCell
               headerStyle={headerStyle}
@@ -108,17 +102,7 @@ function TableHeadWrapper({ tableData, changeSortOrder, areBasicFeaturesEnabled 
                   )}
                 </StyledSortLabel>
 
-                {areBasicFeaturesEnabled && (
-                  <HeadCellMenu
-                    headerStyle={headerStyle}
-                    sortFromMenu={sortFromMenu}
-                    columnIndex={columnIndex}
-                    sortDirection={column.sortDirection}
-                    isInteractionEnabled={isInteractionEnabled}
-                    isCurrentColumnActive={isCurrentColumnActive}
-                    isDimension={column.isDim}
-                  />
-                )}
+                {areBasicFeaturesEnabled && <HeadCellMenu columnIndex={columnIndex} isDimension={column.isDim} />}
               </HeadCellContent>
             </StyledHeadCell>
           );

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -1,46 +1,25 @@
 import React from 'react';
 import { stardust } from '@nebula.js/stardust';
 import { render, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { SortDirection, TableLayout } from '../../../../types';
-import { GeneratedStyling } from '../../../types';
+import { TableLayout } from '../../../../types';
 import HeadCellMenu from '../HeadCellMenu';
 import TestWithProviders from '../../../../__test__/test-with-providers';
 
 describe('<HeadCellMenu />', () => {
-  let headerStyle: GeneratedStyling;
-  let sortFromMenu: (evt: React.MouseEvent, sortOrder: string) => void;
-  const sortDirection: SortDirection = 'A';
-  let isInteractionEnabled: boolean = true;
-  let isCurrentColumnActive: boolean = false;
   let embed: stardust.Embed;
   let layout: TableLayout;
   const columnIndex = 0;
   const direction: 'ltr' | 'rtl' = 'ltr';
+  let isDimension: boolean;
 
   const renderTableHeadCellMenu = (cellCoordMock?: [number, number]) =>
     render(
       <TestWithProviders cellCoordMock={cellCoordMock} layout={layout} direction={direction} embed={embed}>
-        <HeadCellMenu
-          isDimension
-          headerStyle={headerStyle}
-          sortDirection={sortDirection}
-          sortFromMenu={sortFromMenu}
-          isInteractionEnabled={isInteractionEnabled}
-          isCurrentColumnActive={isCurrentColumnActive}
-          columnIndex={columnIndex}
-        />
+        <HeadCellMenu isDimension={isDimension} columnIndex={columnIndex} />
       </TestWithProviders>
     );
 
   beforeEach(() => {
-    headerStyle = {
-      borderBottomColor: '#4287f5',
-      borderRightColor: '#4287f5',
-      borderLeftColor: '#4287f5',
-      borderTopColor: '#4287f5',
-    };
-    sortFromMenu = jest.fn();
     embed = {
       field: jest.fn().mockResolvedValueOnce({ mount: jest.fn(), unmount: jest.fn() }),
       render: jest.fn(),
@@ -53,6 +32,7 @@ describe('<HeadCellMenu />', () => {
         qDimensionInfo: [{ qFallbackTitle: 'someTitle' }],
       },
     } as TableLayout;
+    isDimension = true;
   });
 
   afterEach(() => {
@@ -67,38 +47,21 @@ describe('<HeadCellMenu />', () => {
     expect(element).not.toBeVisible();
   });
 
+  it('should not render head cell menu button when isDimension is false', () => {
+    isDimension = false;
+    renderTableHeadCellMenu();
+
+    const element = screen.queryByRole('button');
+    expect(element).toBeNull();
+  });
+
   it('should open the menu only when the button is clicked', () => {
     renderTableHeadCellMenu();
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByRole('menu')).toBeVisible();
-    expect(screen.getByText('SNTable.MenuItem.SortAscending')).toBeVisible();
-    expect(screen.getByText('SNTable.MenuItem.SortDescending')).toBeVisible();
-  });
-
-  it.skip('should disable sorting option when the column order is already set on that option', () => {
-    isCurrentColumnActive = true;
-    const { getByRole, getByText } = renderTableHeadCellMenu();
-    fireEvent.click(getByRole('button'));
-    const element = getByText('SNTable.MenuItem.SortAscending').closest('.sn-table-head-menu-item-button');
-    expect(element).toHaveAttribute('aria-disabled', 'true');
-    userEvent.click(element as HTMLElement);
-    expect(sortFromMenu).not.toHaveBeenCalled();
-  });
-
-  it.skip('should disable sorting option when the column is in selection mode', () => {
-    isInteractionEnabled = false;
-    const { getByRole, getByText } = renderTableHeadCellMenu();
-    fireEvent.click(getByRole('button'));
-    const ascendingBtn = getByText('SNTable.MenuItem.SortAscending').closest('.sn-table-head-menu-item');
-    const descendingBtn = getByText('SNTable.MenuItem.SortDescending').closest('.sn-table-head-menu-item');
-    expect(ascendingBtn).toHaveAttribute('aria-disabled', 'true');
-    expect(descendingBtn).toHaveAttribute('aria-disabled', 'true');
-    userEvent.click(ascendingBtn as HTMLElement);
-    expect(sortFromMenu).not.toHaveBeenCalled();
-    userEvent.click(descendingBtn as HTMLElement);
-    expect(sortFromMenu).not.toHaveBeenCalled();
+    expect(screen.getByText('SNTable.MenuItem.Search')).toBeVisible();
   });
 
   it('should close the menu when the menu item is clicked', async () => {
@@ -109,7 +72,7 @@ describe('<HeadCellMenu />', () => {
     await waitFor(() => {
       expect(menu).toBeVisible();
     });
-    fireEvent.click(screen.getByText('SNTable.MenuItem.SortAscending'));
+    fireEvent.click(screen.getByText('SNTable.MenuItem.Search'));
     await waitForElementToBeRemoved(menu);
   });
 
@@ -124,15 +87,6 @@ describe('<HeadCellMenu />', () => {
     });
     fireEvent.click(button);
     await waitForElementToBeRemoved(menu);
-  });
-
-  it.skip('should call changeSortOrder when the sort item is clicked', () => {
-    const { getByRole, getByText } = renderTableHeadCellMenu();
-    fireEvent.click(getByRole('button'));
-    fireEvent.click(getByText('SNTable.MenuItem.SortAscending'));
-    expect(sortFromMenu).toHaveBeenCalled();
-    fireEvent.click(getByText('SNTable.MenuItem.SortDescending'));
-    expect(sortFromMenu).toHaveBeenCalled();
   });
 
   it('should call `embed.field` once while trying to open listbox filter for a library dimension', async () => {

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -14,7 +14,6 @@ import {
   TableLayout,
   TotalsPosition,
   Row,
-  SortDirection,
 } from '../types';
 import { SelectionActions } from './constants';
 
@@ -238,11 +237,6 @@ export interface TableHeadWrapperProps {
 }
 
 export interface HeadCellMenuProps {
-  headerStyle: GeneratedStyling;
-  sortDirection: SortDirection;
-  sortFromMenu: (evt: React.MouseEvent, sortOrder: SortDirection) => void;
-  isInteractionEnabled: boolean;
-  isCurrentColumnActive: boolean;
   columnIndex: number;
   isDimension: boolean;
 }


### PR DESCRIPTION
Now only showing the search option, thus there is no menu for measures currently. There will be as soon as we add options that exist for both measures and dimensions