### PR TITLE
fix: reduce flickering with stale data

### DIFF
--- a/src/table/components/virtualized-table/Body.tsx
+++ b/src/table/components/virtualized-table/Body.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, memo, useMemo } from 'react';
+import React, { memo, useMemo, useLayoutEffect } from 'react';
 import { VariableSizeGrid } from 'react-window';
 import useData from './hooks/use-data';
 import { BodyProps } from './types';
@@ -31,14 +31,12 @@ const Body = (props: BodyProps) => {
     columnWidth,
     rowHeight
   );
-  let { height: bodyHeight } = rect;
-  bodyHeight -= headerAndTotalsHeight;
-  bodyHeight = Math.min(rowCount * rowHeight, bodyHeight);
 
-  const { rowsInPage, loadRows, loadColumns } = useData(
+  const { rowsInPage, deferredRowCount, loadRows, loadColumns } = useData(
     layout,
     model as EngineAPI.IGenericObject,
     pageInfo,
+    rowCount,
     visibleRowCount,
     visibleColumnCount,
     columns
@@ -50,7 +48,7 @@ const Body = (props: BodyProps) => {
     loadColumns,
     verticalScrollDirection,
     horizontalScrollDirection,
-    rowCount,
+    rowCount: deferredRowCount,
     pageInfo,
   });
 
@@ -68,6 +66,10 @@ const Body = (props: BodyProps) => {
     forwardRef.current.scrollTo({ scrollLeft: 0, scrollTop: 0 });
   }, [layout, pageInfo.page, forwardRef, columnWidth]);
 
+  let { height: bodyHeight } = rect;
+  bodyHeight -= headerAndTotalsHeight;
+  bodyHeight = Math.min(deferredRowCount * rowHeight, bodyHeight);
+
   return (
     <VariableSizeGrid
       data-key="body"
@@ -77,7 +79,7 @@ const Body = (props: BodyProps) => {
       columnCount={layout.qHyperCube.qSize.qcx}
       columnWidth={(index) => columnWidth[index]}
       height={bodyHeight}
-      rowCount={rowCount}
+      rowCount={deferredRowCount}
       rowHeight={() => rowHeight}
       estimatedRowHeight={rowHeight}
       width={rect.width}

--- a/src/table/components/virtualized-table/Table.tsx
+++ b/src/table/components/virtualized-table/Table.tsx
@@ -13,7 +13,7 @@ import useOnPropsChange from './hooks/use-on-props-change';
 import useTableCount from './hooks/use-table-count';
 import ScrollableContainer from './ScrollableContainer';
 import StickyContainer from './StickyContainer';
-import { toTableRect, toStickyContainerRect } from './utils/to-rect';
+import toTableRect from './utils/to-rect';
 import { useContextSelector, TableContext } from '../../context';
 import getHeights from './utils/get-height';
 
@@ -36,12 +36,11 @@ const Table = (props: TableProps) => {
   );
   const { headerRowHeight, bodyRowHeight, headerAndTotalsHeight } = getHeights(headerStyle, bodyStyle, totals);
   const columns = useMemo(() => getColumns(layout), [layout]);
-  const tableRect = toTableRect(rect, paginationNeeded);
+  const tableRect = useMemo(() => toTableRect(rect, paginationNeeded), [rect, paginationNeeded]);
   const { width } = useColumnSize(tableRect, columns, headerStyle, bodyStyle);
   const { rowCount } = useTableCount(layout, pageInfo, tableRect, width, bodyRowHeight);
   const containerWidth = columns.reduce((prev, curr, index) => prev + width[index], 0);
   const [containerHeight, setContainerHeight] = useState(rowCount * bodyRowHeight + headerAndTotalsHeight);
-  const stickyContainerRect = toStickyContainerRect(tableRect, rowCount, headerAndTotalsHeight, bodyRowHeight);
   const scrollHandler = useScrollHandler(
     headerRef,
     totalsRef,
@@ -65,7 +64,7 @@ const Table = (props: TableProps) => {
 
   const TotalsComponent = (
     <Totals
-      rect={stickyContainerRect}
+      rect={tableRect}
       pageInfo={pageInfo}
       columns={columns}
       columnWidth={width}
@@ -78,10 +77,10 @@ const Table = (props: TableProps) => {
   return (
     <ScrollableContainer ref={ref} width={tableRect.width} height={tableRect.height} onScroll={scrollHandler}>
       <FullSizeContainer width={containerWidth} height={containerHeight}>
-        <StickyContainer rect={stickyContainerRect}>
+        <StickyContainer rect={tableRect}>
           <Header
             headerStyle={headerStyle}
-            rect={stickyContainerRect}
+            rect={tableRect}
             pageInfo={pageInfo}
             columns={columns}
             columnWidth={width}
@@ -91,7 +90,7 @@ const Table = (props: TableProps) => {
           {totals.atTop ? TotalsComponent : null}
           <Body
             bodyStyle={bodyStyle}
-            rect={stickyContainerRect}
+            rect={tableRect}
             pageInfo={pageInfo}
             columns={columns}
             columnWidth={width}

--- a/src/table/components/virtualized-table/hooks/__tests__/use-data.test.ts
+++ b/src/table/components/virtualized-table/hooks/__tests__/use-data.test.ts
@@ -7,6 +7,7 @@ interface OverrideUseDataProps {
   model?: EngineAPI.IGenericObject;
   layout?: TableLayout;
   pageInfo?: PageInfo;
+  rowCount?: number;
   visibleRowCount?: number;
   visibleColumnCount?: number;
   columns?: Column[];
@@ -50,6 +51,7 @@ describe('useData', () => {
             renderWithProps.layout ?? layout,
             renderWithProps.model ?? model,
             renderWithProps.pageInfo ?? pageInfo,
+            renderWithProps.rowCount ?? 20,
             renderWithProps.visibleRowCount ?? 1,
             renderWithProps.visibleColumnCount ?? 1,
             renderWithProps.columns ?? columns

--- a/src/table/components/virtualized-table/utils/to-rect.ts
+++ b/src/table/components/virtualized-table/utils/to-rect.ts
@@ -2,22 +2,7 @@ import { stardust } from '@nebula.js/stardust';
 import { PAGINATION_HEIGHT } from '../constants';
 import { Rect } from '../types';
 
-export const toStickyContainerRect = (
-  rect: Rect,
-  rowCount: number,
-  headerAndTotalsHeight: number,
-  bodyRowHeight: number
-): Rect => {
-  const fullHeight = rowCount * bodyRowHeight + headerAndTotalsHeight;
-  const height = Math.min(fullHeight, rect.height);
-
-  return {
-    width: rect.width,
-    height,
-  };
-};
-
-export const toTableRect = (rect: stardust.Rect, paginationNeeded: boolean): Rect => {
+const toTableRect = (rect: stardust.Rect, paginationNeeded: boolean): Rect => {
   const height = rect.height - (paginationNeeded ? PAGINATION_HEIGHT : 0);
 
   return {
@@ -25,3 +10,5 @@ export const toTableRect = (rect: stardust.Rect, paginationNeeded: boolean): Rec
     height,
   };
 };
+
+export default toTableRect;


### PR DESCRIPTION
This PR reduces the occurrence of flickering when data becomes stale, ex. new layout triggered by selections in some other object, property changes or changing page.

**`Body` component re-render flow:**

BEFORE:
1. Reset data state to an empty array
2. Render Body with the empty array as data (this would cause the flickering)
3. Call engine to fetch new data
4. Set state with new data
5. Render Body with new data

AFTER:
1. Render Body with previous data (use the deferred row count to guard against row count changes that does not match the length of the previous data)
2. Call engine to fetch new data
3. Set state with new data
4. Render Body with new data

There as still an issue with the scroll position being reset on step 1, which under certain circumstances can be seen as a kind of flickering.