### PR TITLE
fix: show chart exploration visibility option only if its enabled

### DIFF
--- a/src/ext/property-panel/settings.js
+++ b/src/ext/property-panel/settings.js
@@ -210,6 +210,7 @@ const getChartExploration = (env) =>
           ref: 'enableChartExploration',
         },
         visibilityToggler: {
+          show: (itemData) => itemData.enableChartExploration,
           component: 'buttongroup',
           translation: 'properties.ChartExploration.VisibilityOption',
           ref: 'chartExploration.menuVisibility',


### PR DESCRIPTION
By design we only want to show visibility option if chart exploration is toggled on