### PR TITLE
fix: disable select all for chart exploration column handler

### DIFF
--- a/src/ext/index.js
+++ b/src/ext/index.js
@@ -9,7 +9,7 @@ const getExploration = (env) =>
         columnHandler: {
           component: 'column-handler',
           search: true,
-          selectAll: true,
+          selectAll: false,
         },
       },
       classification: {


### PR DESCRIPTION
As request we need to disable the select all option for chart exploration column handler component