### PR TITLE
fix: calculate hug based on real font style

### DIFF
--- a/src/__test__/handle-data.spec.ts
+++ b/src/__test__/handle-data.spec.ts
@@ -191,10 +191,10 @@ describe('handle-data', () => {
       expect(getTotalInfo(layout, 1, 3, 2)).toBe('');
     });
 
-    it('should not get any total measure value when qGrandTotalRow has no value', () => {
+    it('should return empty string as total measure value when qGrandTotalRow has no value', () => {
       layout.qHyperCube.qGrandTotalRow = [];
-      expect(getTotalInfo(layout, 2, 2, 2)).toBe(undefined);
-      expect(getTotalInfo(layout, 3, 3, 2)).toBe(undefined);
+      expect(getTotalInfo(layout, 2, 2, 2)).toBe('');
+      expect(getTotalInfo(layout, 3, 3, 2)).toBe('');
     });
 
     it('should return new total label value', () => {

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -47,7 +47,7 @@ export function getTotalPosition(layout: TableLayout) {
  * Gets the totals text for a column
  */
 export function getTotalInfo(layout: TableLayout, colIdx: number, pageColIdx: number, numDims: number) {
-  if (colIdx >= numDims) return layout.qHyperCube.qGrandTotalRow[colIdx - numDims]?.qText || '';
+  if (colIdx >= numDims) return layout.qHyperCube.qGrandTotalRow[colIdx - numDims]?.qText ?? '';
   if (colIdx === 0 && pageColIdx === 0) return layout.totals.label;
   return '';
 }

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -47,7 +47,7 @@ export function getTotalPosition(layout: TableLayout) {
  * Gets the totals text for a column
  */
 export function getTotalInfo(layout: TableLayout, colIdx: number, pageColIdx: number, numDims: number) {
-  if (colIdx >= numDims) return layout.qHyperCube.qGrandTotalRow[colIdx - numDims]?.qText;
+  if (colIdx >= numDims) return layout.qHyperCube.qGrandTotalRow[colIdx - numDims]?.qText || '';
   if (colIdx === 0 && pageColIdx === 0) return layout.totals.label;
   return '';
 }

--- a/src/table/context/TableContext.tsx
+++ b/src/table/context/TableContext.tsx
@@ -39,8 +39,8 @@ export const TableContextProvider = ({
   const [focusedCellCoord, setFocusedCellCoord] = useState((cellCoordMock || [0, 0]) as [number, number]);
   const [selectionState, selectionDispatch] = useSelectionReducer(tableData.rows, selectionsAPI);
   const [hoverIndex, setHoverIndex] = useState(-1);
-  const [columnWidths, setColumnWidths] = useColumnWidths(tableData.columns, tableWidth);
   const styling = useTableStyling(layout, theme, tableData, rootElement);
+  const [columnWidths, setColumnWidths] = useColumnWidths(tableData.columns, tableWidth, styling);
   const baseProps = useMemo(
     () => ({
       selectionsAPI,

--- a/src/table/hooks/__tests__/use-column-widths.spec.ts
+++ b/src/table/hooks/__tests__/use-column-widths.spec.ts
@@ -1,12 +1,14 @@
 import { renderHook } from '@testing-library/react';
 import { Column } from '../../../types';
 import { ColumnWidthTypes, MIN_COLUMN_WIDTH } from '../../constants';
+import { TableStyling } from '../../types';
 import useColumnWidths from '../use-column-widths';
 
-describe('useMeasureText', () => {
+describe('use-column-widths', () => {
   let measureTextMock: jest.Mock<{ width: number }>;
   let columns: Column[];
   let tableWidth: number;
+  let styling: TableStyling;
 
   beforeEach(() => {
     measureTextMock = jest.fn();
@@ -33,6 +35,10 @@ describe('useMeasureText', () => {
       } as Column,
     ];
     tableWidth = 600;
+    styling = {
+      body: { fontFamily: 'Arial', fontSize: '12px' },
+      head: { fontFamily: 'Arial', fontSize: '12px' },
+    } as unknown as TableStyling;
   });
 
   afterEach(() => {
@@ -40,10 +46,10 @@ describe('useMeasureText', () => {
   });
 
   // only looking at the state not setState
-  const getColumnWidthsState = () => renderHook(() => useColumnWidths(columns, tableWidth)).result.current[0];
+  const getColumnWidthsState = () => renderHook(() => useColumnWidths(columns, tableWidth, styling)).result.current[0];
   const getTotalWidth = (widths: number[]) => widths.reduce((acc, w) => acc + w, 0);
 
-  describe('use-column-widths', () => {
+  describe('getColumnWidths', () => {
     describe('all have same type', () => {
       it('should return equal sizes when all cols have fill type', () => {
         const widths = getColumnWidthsState();

--- a/src/table/hooks/use-column-widths.ts
+++ b/src/table/hooks/use-column-widths.ts
@@ -84,17 +84,8 @@ const useColumnWidths = (
 ): [number[], React.Dispatch<React.SetStateAction<number[]>>] => {
   const measureHeadLabel = useMeasureText(head.fontSize, head.fontFamily).measureText;
   const { measureText, estimateWidth } = useMeasureText(body.fontSize, body.fontFamily);
-  const getHugWidth = (headLabel: string, totalsLabel: string, glyphCount: number) => {
-    console.log(
-      'head',
-      measureHeadLabel(headLabel),
-      'totals',
-      measureText(totalsLabel),
-      'body',
-      estimateWidth(glyphCount)
-    );
-    return Math.max(measureHeadLabel(headLabel), measureText(totalsLabel), estimateWidth(glyphCount));
-  };
+  const getHugWidth = (headLabel: string, totalsLabel: string, glyphCount: number) =>
+    Math.max(measureHeadLabel(headLabel), measureText(totalsLabel), estimateWidth(glyphCount));
 
   const [columnWidths, setColumnWidths] = useState(getColumnWidths(columns, tableWidth, getHugWidth));
 

--- a/src/table/hooks/use-column-widths.ts
+++ b/src/table/hooks/use-column-widths.ts
@@ -87,7 +87,7 @@ const useColumnWidths = (
   const getHugWidth = (headLabel: string, totalsLabel: string, glyphCount: number) =>
     Math.max(measureHeadLabel(headLabel), measureText(totalsLabel), estimateWidth(glyphCount));
 
-  const [columnWidths, setColumnWidths] = useState(getColumnWidths(columns, tableWidth, getHugWidth));
+  const [columnWidths, setColumnWidths] = useState(() => getColumnWidths(columns, tableWidth, getHugWidth));
 
   useDidUpdateEffect(() => {
     setColumnWidths(getColumnWidths(columns, tableWidth, getHugWidth));

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,7 @@ export interface Column {
   stylingIDs: string[];
   sortDirection: SortDirection;
   qReverseSort: boolean;
-  totalInfo?: string;
+  totalInfo: string;
   qApprMaxGlyphCount: number;
   columnWidth: ColumnWidth;
 }


### PR DESCRIPTION
using the head and body styling to calculate/estimate the width of header, totals and body. 

Currently ignoring the extra padding differences between header and body. My next step is to fix the header label button for text wrap and font size. Then it makes sense to get an optimized result for hug.