### PR TITLE
fix: scrollbar width vt mode

### DIFF
--- a/src/table/virtualized-table/hooks/__tests__/use-scrollbar-width.spec.ts
+++ b/src/table/virtualized-table/hooks/__tests__/use-scrollbar-width.spec.ts
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react';
+import useScrollbarWidth from '../use-scrollbar-width';
+
+describe('useScrollbarWidth', () => {
+  test('should handle null as ref value', async () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement>;
+    const { result } = renderHook(() => useScrollbarWidth(ref));
+
+    expect(result.current.xScrollbarWidth).toBe(0);
+    expect(result.current.yScrollbarWidth).toBe(0);
+  });
+
+  test('should update values on re-render', async () => {
+    let element = { offsetWidth: 10, offsetHeight: 20, clientWidth: 5, clientHeight: 10 };
+    let ref = { current: element } as React.RefObject<HTMLDivElement>;
+    const { result, rerender } = renderHook(() => useScrollbarWidth(ref));
+
+    expect(result.current.xScrollbarWidth).toBe(10);
+    expect(result.current.yScrollbarWidth).toBe(5);
+
+    element = { offsetWidth: 0, offsetHeight: 0, clientWidth: 0, clientHeight: 0 };
+    ref = Object.assign(ref, { current: element });
+    rerender(ref);
+
+    expect(result.current.xScrollbarWidth).toBe(0);
+    expect(result.current.yScrollbarWidth).toBe(0);
+  });
+});

--- a/src/table/virtualized-table/hooks/use-get-hypercube-data-queue.ts
+++ b/src/table/virtualized-table/hooks/use-get-hypercube-data-queue.ts
@@ -1,9 +1,5 @@
 import { useMemo, useRef } from 'react';
 
-export interface AbortablePromise {
-  isCancelled: boolean;
-}
-
 const pageToKey = ({ qLeft, qTop, qWidth, qHeight }: EngineAPI.INxPage) => `${qLeft}-${qTop}-${qWidth}-${qHeight}`;
 
 const useGetHyperCubeDataQueue = (

--- a/src/table/virtualized-table/hooks/use-get-hypercube-data-queue.ts
+++ b/src/table/virtualized-table/hooks/use-get-hypercube-data-queue.ts
@@ -16,7 +16,7 @@ const useGetHyperCubeDataQueue = (
 
   const queue = useMemo(
     () => ({
-      enqueue: (page: EngineAPI.INxPage) => {
+      enqueue: (page: EngineAPI.INxPage, onBeforeHandlePages?: () => void) => {
         const key = pageToKey(page);
 
         if (finished.current.has(key)) {
@@ -39,6 +39,7 @@ const useGetHyperCubeDataQueue = (
               const qDataPages = await getDataPages(qPages);
 
               if (ongoing.current.has(qPages)) {
+                onBeforeHandlePages?.();
                 handleDataPages(qDataPages);
               }
             } catch (error) {

--- a/src/table/virtualized-table/hooks/use-scroll-handler.ts
+++ b/src/table/virtualized-table/hooks/use-scroll-handler.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { VariableSizeList } from 'react-window';
 import { BodyRef } from '../types';
 
@@ -7,19 +7,16 @@ const useScrollHandler = (
   totalsRef: React.RefObject<VariableSizeList<any>>,
   bodyRef: React.RefObject<BodyRef>
 ) => {
-  const prevScrollTop = useRef(0);
   return useCallback(
     (event: React.SyntheticEvent) => {
       const { scrollHeight, clientHeight, scrollTop, scrollLeft } = event.currentTarget;
       const ratio = Math.max(0, Math.min(1, scrollTop / (scrollHeight - clientHeight)));
 
-      bodyRef.current?.interpolatedScrollTo(ratio, scrollLeft);
+      bodyRef.current?.interpolatedScrollTo(Number.isNaN(ratio) ? 0 : ratio, scrollLeft);
 
       headerRef.current?.scrollTo(scrollLeft);
 
       totalsRef.current?.scrollTo(scrollLeft);
-
-      prevScrollTop.current = scrollTop;
     },
     [headerRef, totalsRef, bodyRef]
   );

--- a/src/table/virtualized-table/hooks/use-scrollbar-width.ts
+++ b/src/table/virtualized-table/hooks/use-scrollbar-width.ts
@@ -1,0 +1,26 @@
+import { useRef, useState } from 'react';
+
+const useScrollbarWidth = (ref: React.RefObject<HTMLDivElement>) => {
+  const prevWidth = useRef({ x: 0, y: 0 });
+  const [xScrollbarWidth, setXScrollbarWidth] = useState(0);
+  const [yScrollbarWidth, setYScrollbarWidth] = useState(0);
+
+  if (ref.current) {
+    const widthDiff = ref.current.offsetWidth - ref.current.clientWidth;
+    const heightDiff = ref.current.offsetHeight - ref.current.clientHeight;
+
+    if (prevWidth.current.y !== widthDiff) {
+      setYScrollbarWidth(widthDiff);
+      prevWidth.current.y = widthDiff;
+    }
+
+    if (prevWidth.current.x !== heightDiff) {
+      setXScrollbarWidth(heightDiff);
+      prevWidth.current.x = heightDiff;
+    }
+  }
+
+  return { xScrollbarWidth, yScrollbarWidth };
+};
+
+export default useScrollbarWidth;

--- a/src/table/virtualized-table/hooks/use-scrollbar-width.ts
+++ b/src/table/virtualized-table/hooks/use-scrollbar-width.ts
@@ -1,24 +1,24 @@
-import { useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
+import useOnPropsChange from './use-on-props-change';
 
 const useScrollbarWidth = (ref: React.RefObject<HTMLDivElement>) => {
-  const prevWidth = useRef({ x: 0, y: 0 });
   const [xScrollbarWidth, setXScrollbarWidth] = useState(0);
   const [yScrollbarWidth, setYScrollbarWidth] = useState(0);
+  const { offsetWidth = 0, offsetHeight = 0, clientWidth = 0, clientHeight = 0 } = ref.current ?? {};
+  const widthDiff = offsetWidth - clientWidth;
+  const heightDiff = offsetHeight - clientHeight;
 
-  if (ref.current) {
-    const widthDiff = ref.current.offsetWidth - ref.current.clientWidth;
-    const heightDiff = ref.current.offsetHeight - ref.current.clientHeight;
-
-    if (prevWidth.current.y !== widthDiff) {
-      setYScrollbarWidth(widthDiff);
-      prevWidth.current.y = widthDiff;
+  useEffect(() => {
+    if (ref.current) {
+      setYScrollbarWidth(ref.current.offsetWidth - ref.current.clientWidth);
+      setXScrollbarWidth(ref.current.offsetHeight - ref.current.clientHeight);
     }
+  }, [ref]);
 
-    if (prevWidth.current.x !== heightDiff) {
-      setXScrollbarWidth(heightDiff);
-      prevWidth.current.x = heightDiff;
-    }
-  }
+  useOnPropsChange(() => {
+    setYScrollbarWidth(widthDiff);
+    setXScrollbarWidth(heightDiff);
+  }, [widthDiff, heightDiff]);
 
   return { xScrollbarWidth, yScrollbarWidth };
 };

--- a/src/table/virtualized-table/utils/to-rect.ts
+++ b/src/table/virtualized-table/utils/to-rect.ts
@@ -11,4 +11,11 @@ const toTableRect = (rect: stardust.Rect, paginationNeeded: boolean): Rect => {
   };
 };
 
+export const toStickyContainerRect = (rect: Rect, xScrollbarWidth: number, yScrollbarWidth: number) => {
+  return {
+    width: rect.width - yScrollbarWidth,
+    height: rect.height - xScrollbarWidth,
+  };
+};
+
 export default toTableRect;


### PR DESCRIPTION
As the width and height is computed by the table, when the browsers add a scrollbar, some of the space included in the width/height is occupyed by the scrollbar. This can cause the effect that a vertical scrollbar can trigger a horizontal scrollbar to appear, and vice-versa.

I had hoped I would be able to find a better solution but none so far. So in this PR there is an attempt to discover if there is a scrollbar, if so, measure its width and reduce that from the width/height of the table and re-render it.

