### PR TITLE
fix: flickering on resize

### DIFF
--- a/src/table/virtualized-table/Body.tsx
+++ b/src/table/virtualized-table/Body.tsx
@@ -96,13 +96,7 @@ const Body = forwardRef<BodyRef, BodyProps>((props, ref) => {
     gridRef.current.scrollTo({ scrollLeft: 0, scrollTop: 0 });
   }, [layout, pageInfo.page, gridRef, columnWidth, rowMeta, theme.name()]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const bodyHeight = getBodyHeight(
-    rect,
-    headerAndTotalsHeight,
-    deferredRowCount,
-    estimatedRowHeight,
-    rowMeta.current.totalHeight
-  );
+  const bodyHeight = getBodyHeight(rect, headerAndTotalsHeight, deferredRowCount, estimatedRowHeight);
 
   useImperativeHandle(
     ref,

--- a/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
+++ b/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
@@ -80,7 +80,7 @@ const useDynamicRowHeight = ({ bodyStyle, columnWidth, gridRef, rowHeight, layou
         rowMeta.current.heights[rowIdx] = height;
       }
 
-      setEstimatedRowHeight(Math.round(rowMeta.current.totalHeight / rowMeta.current.count));
+      setEstimatedRowHeight(rowMeta.current.totalHeight / rowMeta.current.count);
     },
     [getCellSize]
   );

--- a/src/table/virtualized-table/utils/get-height.ts
+++ b/src/table/virtualized-table/utils/get-height.ts
@@ -5,10 +5,10 @@ import { MIN_BODY_ROW_HEIGHT, MIN_HEADER_HEIGHT } from '../constants';
 import { BodyStyle, Rect, Totals } from '../types';
 
 const getHeaderRowHeight = ({ fontSize = COMMON_CELL_STYLING.fontSize }: GeneratedStyling) =>
-  Math.max(MIN_HEADER_HEIGHT, Math.round(fontSizeToRowHeight(fontSize)));
+  Math.max(MIN_HEADER_HEIGHT, fontSizeToRowHeight(fontSize));
 
 const getBodyRowHeight = ({ fontSize = COMMON_CELL_STYLING.fontSize }: BodyStyle) =>
-  Math.max(MIN_BODY_ROW_HEIGHT, Math.round(fontSizeToRowHeight(fontSize)));
+  Math.max(MIN_BODY_ROW_HEIGHT, fontSizeToRowHeight(fontSize));
 
 const getHeights = (headerStyle: GeneratedStyling, bodyStyle: BodyStyle, totals: Totals) => {
   const headerRowHeight = getHeaderRowHeight(headerStyle);
@@ -26,13 +26,12 @@ export const getBodyHeight = (
   rect: Rect,
   headerAndTotalsHeight: number,
   deferredRowCount: number,
-  estimatedRowHeight: number,
-  totalHeight: number
+  estimatedRowHeight: number
 ) => {
   let { height: bodyHeight } = rect;
   bodyHeight -= headerAndTotalsHeight;
   if (deferredRowCount * estimatedRowHeight < bodyHeight) {
-    bodyHeight = Math.min(totalHeight, bodyHeight);
+    bodyHeight = Math.min(deferredRowCount * estimatedRowHeight, bodyHeight);
   }
 
   return bodyHeight;


### PR DESCRIPTION
When the table was resized in virtual scroll mode, rows would appear to be flickering a lot. That was due to `Math.round` was used in some places but not others. So when computed row height, it would jump between a rounded value and a decimal value.