### PR TITLE
fix: totals font weight

### DIFF
--- a/src/table/virtualized-table/TotalsCell.tsx
+++ b/src/table/virtualized-table/TotalsCell.tsx
@@ -42,6 +42,7 @@ const TotalsCell = ({ index, style, data }: TotalsCellProps) => {
         justifyContent: index === 0 ? 'left' : 'right',
         boxSizing: 'border-box',
         cursor: 'default',
+        fontWeight: 'bold',
       }}
     >
       <CellText singleLine>{label}</CellText>


### PR DESCRIPTION
Farily sure we had bold font weight for totals row. This PR enables that again as it appears to have disappeared.