### PR TITLE
test: use global measureText mock

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom';
+
+beforeEach(() => {
+  const context = {
+    measureText(text) {
+      return {
+        width: text?.length ?? 0
+      }
+    },
+    set font(f) {}
+  };
+  jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context);
+});

--- a/src/table/hooks/__tests__/use-column-widths.spec.ts
+++ b/src/table/hooks/__tests__/use-column-widths.spec.ts
@@ -5,18 +5,11 @@ import { TableStyling } from '../../types';
 import useColumnWidths from '../use-column-widths';
 
 describe('use-column-widths', () => {
-  let measureTextMock: jest.Mock<{ width: number }>;
   let columns: Column[];
   let tableWidth: number;
   let styling: TableStyling;
 
   beforeEach(() => {
-    measureTextMock = jest.fn();
-    const context = {
-      measureText: measureTextMock,
-    } as unknown as CanvasRenderingContext2D;
-    jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context);
-
     columns = [
       {
         label: 'col1',
@@ -39,10 +32,6 @@ describe('use-column-widths', () => {
       body: { fontFamily: 'Arial', fontSize: '12px' },
       head: { fontFamily: 'Arial', fontSize: '12px' },
     } as unknown as TableStyling;
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   // only looking at the state not setState
@@ -77,7 +66,6 @@ describe('use-column-widths', () => {
       });
 
       it('should return one size for hug and equal sizes for two columns with fill', () => {
-        measureTextMock.mockReturnValue({ width: 10 });
         columns[0].columnWidth.type = ColumnWidthTypes.HUG;
         columns[1].columnWidth.type = ColumnWidthTypes.HUG;
         columns[2].columnWidth.type = ColumnWidthTypes.HUG;
@@ -124,7 +112,6 @@ describe('use-column-widths', () => {
       });
 
       it('should return one size for hug and equal sizes for two columns with fill', () => {
-        measureTextMock.mockReturnValue({ width: 10 });
         columns[2].columnWidth.type = ColumnWidthTypes.HUG;
 
         const widths = getColumnWidthsState();

--- a/src/table/virtualized-table/__tests__/Table.spec.tsx
+++ b/src/table/virtualized-table/__tests__/Table.spec.tsx
@@ -9,7 +9,6 @@ import { generateDataPages, generateLayout } from '../../../__test__/generate-te
 import TestWithProviders from '../../../__test__/test-with-providers';
 
 describe('<Table />', () => {
-  let measureTextMock: jest.Mock<{ width: number }>;
   let rect: stardust.Rect;
   let layout: TableLayout;
   let pageInfo: PageInfo;
@@ -32,13 +31,6 @@ describe('<Table />', () => {
 
   beforeEach(() => {
     user = userEvent.setup();
-
-    measureTextMock = jest.fn();
-    const context = {
-      measureText: measureTextMock,
-    } as unknown as CanvasRenderingContext2D;
-    jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context);
-    measureTextMock.mockReturnValue({ width: 150 });
 
     layout = generateLayout(dimensionCount, measureCount, rowCount);
     layout.qHyperCube.qEffectiveInterColumnSortOrder = [0, 1, 2];

--- a/src/table/virtualized-table/hooks/__tests__/use-measure-text.test.ts
+++ b/src/table/virtualized-table/hooks/__tests__/use-measure-text.test.ts
@@ -2,35 +2,19 @@ import { renderHook } from '@testing-library/react';
 import useMeasureText from '../use-measure-text';
 
 describe('useMeasureText', () => {
-  let measureTextMock: jest.Mock<{ width: number }>;
-
-  beforeEach(() => {
-    measureTextMock = jest.fn();
-    const context = {
-      measureText: measureTextMock,
-    } as unknown as CanvasRenderingContext2D;
-    jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   describe('estimateWidth', () => {
     test('should estimate width', () => {
-      measureTextMock.mockReturnValue({ width: 150 });
       const { result } = renderHook(() => useMeasureText('13px', 'font'));
 
-      expect(result.current.estimateWidth(2)).toBe(300);
+      expect(result.current.estimateWidth(2)).toBe(2);
     });
   });
 
   describe('measureText', () => {
     test('should measure width', () => {
-      measureTextMock.mockReturnValue({ width: 150 });
       const { result } = renderHook(() => useMeasureText('13px', 'font'));
 
-      expect(result.current.measureText('some string')).toBe(150);
+      expect(result.current.measureText('some string')).toBe(11);
     });
   });
 });

--- a/src/table/virtualized-table/hooks/use-measure-text.ts
+++ b/src/table/virtualized-table/hooks/use-measure-text.ts
@@ -10,16 +10,10 @@ const MAGIC_DEFAULT_CHAR = 'M';
 
 export default function useMeasureText(fontSize: string | undefined, fontFamily: string | undefined): MeasureTextHook {
   const { estimateWidth, measureText } = useMemo((): MeasureTextHook => {
-    const context = document.createElement('canvas').getContext('2d');
-    let memoizedMeasureText: (text: string) => { width: number };
+    const context = document.createElement('canvas').getContext('2d') as CanvasRenderingContext2D;
+    context.font = `${fontSize} ${fontFamily}`;
 
-    // When testing, context is undefined, so we mock measure text
-    if (context) {
-      context.font = `${fontSize} ${fontFamily}`;
-      memoizedMeasureText = memoize(context.measureText.bind(context));
-    } else {
-      memoizedMeasureText = memoize(() => ({ width: 10 }));
-    }
+    const memoizedMeasureText = memoize(context.measureText.bind(context)) as (text: string) => TextMetrics;
 
     return {
       measureText: (text) => memoizedMeasureText(text).width,


### PR DESCRIPTION
All test will now use a global measureText mock.

Had to put in int a `beforeEach` callback as some test calls `jest.restoreAllMock()` which would reset it for all subsequent tests.