### PR TITLE
fix: error on remove column

### DIFF
--- a/src/table/virtualized-table/Body.tsx
+++ b/src/table/virtualized-table/Body.tsx
@@ -127,7 +127,7 @@ const Body = forwardRef<BodyRef, BodyProps>((props, ref) => {
       ref={gridRef}
       innerRef={innerForwardRef}
       style={{ overflow: 'hidden' }}
-      columnCount={layout.qHyperCube.qSize.qcx}
+      columnCount={columns.length}
       columnWidth={(index) => columnWidth[index]}
       height={bodyHeight}
       rowCount={deferredRowCount}

--- a/src/table/virtualized-table/Header.tsx
+++ b/src/table/virtualized-table/Header.tsx
@@ -23,7 +23,7 @@ const Header = (props: HeaderProps) => {
         background: headerStyle.background,
         boxSizing: 'border-box',
       }}
-      itemCount={layout.qHyperCube.qSize.qcx}
+      itemCount={columns.length}
       itemSize={(index) => columnWidth[index]}
       height={rowHeight}
       width={rect.width}

--- a/src/table/virtualized-table/Totals.tsx
+++ b/src/table/virtualized-table/Totals.tsx
@@ -25,7 +25,7 @@ const Totals = (props: TotalsProps) => {
         borderBottom: totals.atTop ? `1px solid ${styling.totals.borderBottomColor}` : '0px',
         boxSizing: 'border-box',
       }}
-      itemCount={layout.qHyperCube.qSize.qcx}
+      itemCount={columns.length}
       itemSize={(index) => columnWidth[index]}
       height={rowHeight}
       width={rect.width}


### PR DESCRIPTION
Fixes an issue where an error was throw after a dimension or measure was removed from the virtual scroll table.

I think this is a bit of a work around for the real issue which is that `tableData` is created based on the layout where the dimension/measure have been removed. BUT the due to how the`useContextSelector` appears to work, any cosumer of it will first get a "stale" layout (where the dimension/measure still exist) and than be re-rendered again with the updated layout.

Not really sure yet how to best solve this and prevent any further issue where you get stale vs non-stalve value.