### PR TITLE
test: fix act error for `useFieldSelection`

### DIFF
--- a/src/table/hooks/__tests__/use-field-selection.spec.tsx
+++ b/src/table/hooks/__tests__/use-field-selection.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { Column, TableLayout } from '../../../types';
 import useFieldSelection from '../use-field-selection';
 import TestWithProviders from '../../../__test__/test-with-providers';
@@ -65,78 +65,92 @@ describe('useFieldSelection()', () => {
 
     it('`canSelectAll` and `canSelectPossible` and should be true after calling `updateSelectionActionsEnabledStatus` with `qOptions`', () => {
       const state = { qOption: 1 } as EngineAPI.INxStateCounts;
-      expect(triggerHook(state)).toMatchObject({
-        canSelectAll: true,
-        canClearSelections: false,
-        canSelectPossible: true,
-        canSelectAlternative: false,
-        canSelectExcluded: false,
+      waitFor(() => {
+        expect(triggerHook(state)).toMatchObject({
+          canSelectAll: true,
+          canClearSelections: false,
+          canSelectPossible: true,
+          canSelectAlternative: false,
+          canSelectExcluded: false,
+        });
       });
     });
 
     it('`canSelectAll`, `canSelectAlternative` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qAlternative`', () => {
       const state = { qAlternative: 1 } as EngineAPI.INxStateCounts;
-      expect(triggerHook(state)).toMatchObject({
-        canSelectAll: true,
-        canClearSelections: false,
-        canSelectPossible: false,
-        canSelectAlternative: true,
-        canSelectExcluded: true,
+      waitFor(() => {
+        expect(triggerHook(state)).toMatchObject({
+          canSelectAll: true,
+          canClearSelections: false,
+          canSelectPossible: false,
+          canSelectAlternative: true,
+          canSelectExcluded: true,
+        });
       });
     });
 
     it('`canSelectAll` should be true after calling `updateSelectionActionsEnabledStatus` with `qDeselected`', () => {
       const state = { qDeselected: 1 } as EngineAPI.INxStateCounts;
-      expect(triggerHook(state)).toMatchObject({
-        canSelectAll: true,
-        canClearSelections: false,
-        canSelectPossible: false,
-        canSelectAlternative: false,
-        canSelectExcluded: false,
+      waitFor(() => {
+        expect(triggerHook(state)).toMatchObject({
+          canSelectAll: true,
+          canClearSelections: false,
+          canSelectPossible: false,
+          canSelectAlternative: false,
+          canSelectExcluded: false,
+        });
       });
     });
 
     it('`canClearSelections` should be true after calling `updateSelectionActionsEnabledStatus` with `qSelected`', () => {
       const state = { qSelected: 1 } as EngineAPI.INxStateCounts;
-      expect(triggerHook(state)).toMatchObject({
-        canSelectAll: false,
-        canClearSelections: true,
-        canSelectPossible: false,
-        canSelectAlternative: false,
-        canSelectExcluded: false,
+      waitFor(() => {
+        expect(triggerHook(state)).toMatchObject({
+          canSelectAll: false,
+          canClearSelections: true,
+          canSelectPossible: false,
+          canSelectAlternative: false,
+          canSelectExcluded: false,
+        });
       });
     });
 
     it('`canSelectAll` and `canSelectPossible` should be true after calling `updateSelectionActionsEnabledStatus` with `qOption`', () => {
       const state = { qOption: 1 } as EngineAPI.INxStateCounts;
-      expect(triggerHook(state)).toMatchObject({
-        canSelectAll: true,
-        canClearSelections: false,
-        canSelectPossible: true,
-        canSelectAlternative: false,
-        canSelectExcluded: false,
+      waitFor(() => {
+        expect(triggerHook(state)).toMatchObject({
+          canSelectAll: true,
+          canClearSelections: false,
+          canSelectPossible: true,
+          canSelectAlternative: false,
+          canSelectExcluded: false,
+        });
       });
     });
 
     it('`canSelectAll`, `canSelectAlternative` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qAlternative`', () => {
       const state = { qAlternative: 1 } as EngineAPI.INxStateCounts;
-      expect(triggerHook(state)).toMatchObject({
-        canSelectAll: true,
-        canClearSelections: false,
-        canSelectPossible: false,
-        canSelectAlternative: true,
-        canSelectExcluded: true,
+      waitFor(() => {
+        expect(triggerHook(state)).toMatchObject({
+          canSelectAll: true,
+          canClearSelections: false,
+          canSelectPossible: false,
+          canSelectAlternative: true,
+          canSelectExcluded: true,
+        });
       });
     });
 
     it('`canSelectAll` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qExcluded`', () => {
       const state = { qExcluded: 1 } as EngineAPI.INxStateCounts;
-      expect(triggerHook(state)).toMatchObject({
-        canSelectAll: true,
-        canClearSelections: false,
-        canSelectPossible: false,
-        canSelectAlternative: false,
-        canSelectExcluded: true,
+      waitFor(() => {
+        expect(triggerHook(state)).toMatchObject({
+          canSelectAll: true,
+          canClearSelections: false,
+          canSelectPossible: false,
+          canSelectAlternative: false,
+          canSelectExcluded: true,
+        });
       });
     });
 
@@ -148,21 +162,27 @@ describe('useFieldSelection()', () => {
         },
       } as TableLayout;
       act(() => result.current.updateSelectionActionsEnabledStatus(mockLayout));
-      expect(result.current.selectionActionsEnabledStatus).toMatchObject({
-        canSelectAll: true,
-        canClearSelections: false,
-        canSelectPossible: false,
-        canSelectAlternative: false,
-        canSelectExcluded: true,
+
+      waitFor(() => {
+        expect(result.current.selectionActionsEnabledStatus).toMatchObject({
+          canSelectAll: true,
+          canClearSelections: false,
+          canSelectPossible: false,
+          canSelectAlternative: false,
+          canSelectExcluded: true,
+        });
       });
 
       act(() => result.current.resetSelectionActionsEnabledStatus());
-      expect(result.current.selectionActionsEnabledStatus).toMatchObject({
-        canSelectAll: false,
-        canClearSelections: false,
-        canSelectPossible: false,
-        canSelectAlternative: false,
-        canSelectExcluded: false,
+
+      waitFor(() => {
+        expect(result.current.selectionActionsEnabledStatus).toMatchObject({
+          canSelectAll: false,
+          canClearSelections: false,
+          canSelectPossible: false,
+          canSelectAlternative: false,
+          canSelectExcluded: false,
+        });
       });
     });
   });

--- a/src/table/hooks/__tests__/use-field-selection.spec.tsx
+++ b/src/table/hooks/__tests__/use-field-selection.spec.tsx
@@ -63,9 +63,9 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('`canSelectAll` and `canSelectPossible` and should be true after calling `updateSelectionActionsEnabledStatus` with `qOptions`', () => {
+    it('`canSelectAll` and `canSelectPossible` and should be true after calling `updateSelectionActionsEnabledStatus` with `qOptions`', async () => {
       const state = { qOption: 1 } as EngineAPI.INxStateCounts;
-      waitFor(() => {
+      await waitFor(() => {
         expect(triggerHook(state)).toMatchObject({
           canSelectAll: true,
           canClearSelections: false,
@@ -76,9 +76,9 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('`canSelectAll`, `canSelectAlternative` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qAlternative`', () => {
+    it('`canSelectAll`, `canSelectAlternative` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qAlternative`', async () => {
       const state = { qAlternative: 1 } as EngineAPI.INxStateCounts;
-      waitFor(() => {
+      await waitFor(() => {
         expect(triggerHook(state)).toMatchObject({
           canSelectAll: true,
           canClearSelections: false,
@@ -89,9 +89,9 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('`canSelectAll` should be true after calling `updateSelectionActionsEnabledStatus` with `qDeselected`', () => {
+    it('`canSelectAll` should be true after calling `updateSelectionActionsEnabledStatus` with `qDeselected`', async () => {
       const state = { qDeselected: 1 } as EngineAPI.INxStateCounts;
-      waitFor(() => {
+      await waitFor(() => {
         expect(triggerHook(state)).toMatchObject({
           canSelectAll: true,
           canClearSelections: false,
@@ -102,9 +102,9 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('`canClearSelections` should be true after calling `updateSelectionActionsEnabledStatus` with `qSelected`', () => {
+    it('`canClearSelections` should be true after calling `updateSelectionActionsEnabledStatus` with `qSelected`', async () => {
       const state = { qSelected: 1 } as EngineAPI.INxStateCounts;
-      waitFor(() => {
+      await waitFor(() => {
         expect(triggerHook(state)).toMatchObject({
           canSelectAll: false,
           canClearSelections: true,
@@ -115,9 +115,9 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('`canSelectAll` and `canSelectPossible` should be true after calling `updateSelectionActionsEnabledStatus` with `qOption`', () => {
+    it('`canSelectAll` and `canSelectPossible` should be true after calling `updateSelectionActionsEnabledStatus` with `qOption`', async () => {
       const state = { qOption: 1 } as EngineAPI.INxStateCounts;
-      waitFor(() => {
+      await waitFor(() => {
         expect(triggerHook(state)).toMatchObject({
           canSelectAll: true,
           canClearSelections: false,
@@ -128,9 +128,9 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('`canSelectAll`, `canSelectAlternative` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qAlternative`', () => {
+    it('`canSelectAll`, `canSelectAlternative` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qAlternative`', async () => {
       const state = { qAlternative: 1 } as EngineAPI.INxStateCounts;
-      waitFor(() => {
+      await waitFor(() => {
         expect(triggerHook(state)).toMatchObject({
           canSelectAll: true,
           canClearSelections: false,
@@ -141,9 +141,9 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('`canSelectAll` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qExcluded`', () => {
+    it('`canSelectAll` and `canSelectExcluded` should be true after calling `updateSelectionActionsEnabledStatus` with `qExcluded`', async () => {
       const state = { qExcluded: 1 } as EngineAPI.INxStateCounts;
-      waitFor(() => {
+      await waitFor(() => {
         expect(triggerHook(state)).toMatchObject({
           canSelectAll: true,
           canClearSelections: false,
@@ -154,7 +154,7 @@ describe('useFieldSelection()', () => {
       });
     });
 
-    it('shoud reset state after calling `resetSelectionActionsEnabledStatus`', () => {
+    it('shoud reset state after calling `resetSelectionActionsEnabledStatus`', async () => {
       const { result } = getFieldSelectionResult();
       const mockLayout = {
         qHyperCube: {
@@ -163,7 +163,7 @@ describe('useFieldSelection()', () => {
       } as TableLayout;
       act(() => result.current.updateSelectionActionsEnabledStatus(mockLayout));
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(result.current.selectionActionsEnabledStatus).toMatchObject({
           canSelectAll: true,
           canClearSelections: false,
@@ -175,7 +175,7 @@ describe('useFieldSelection()', () => {
 
       act(() => result.current.resetSelectionActionsEnabledStatus());
 
-      waitFor(() => {
+      await waitFor(() => {
         expect(result.current.selectionActionsEnabledStatus).toMatchObject({
           canSelectAll: false,
           canClearSelections: false,


### PR DESCRIPTION
fixed act error for `useFieldSelection`

root cause was this error here:https://github.com/qlik-oss/sn-table/blob/7734f4b60b38f2f675eafbd91c39d187cbe99140/src/table/hooks/use-field-selection.ts#L32-L35

because it was setting state after `app.getField(...)` being resolved!