### PR TITLE
fix: detect scrollbar size logic

### DIFF
--- a/src/__test__/test-with-providers.tsx
+++ b/src/__test__/test-with-providers.tsx
@@ -36,6 +36,8 @@ interface ProviderProps {
   tableWidth?: number;
 }
 
+type HookWrapperProps = { children: JSX.Element };
+
 const TestWithProviders = ({
   children,
   app = { getField: () => Promise.resolve({}) } as unknown as EngineAPI.IApp,
@@ -92,5 +94,7 @@ const TestWithProviders = ({
     </ThemeProvider>
   );
 };
+
+export const wrapper = ({ children }: HookWrapperProps) => <TestWithProviders>{children}</TestWithProviders>;
 
 export default TestWithProviders;

--- a/src/table/virtualized-table/hooks/__tests__/use-scrollbar-width.spec.tsx
+++ b/src/table/virtualized-table/hooks/__tests__/use-scrollbar-width.spec.tsx
@@ -1,10 +1,12 @@
 import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { wrapper } from '../../../../__test__/test-with-providers';
 import useScrollbarWidth from '../use-scrollbar-width';
 
 describe('useScrollbarWidth', () => {
   test('should handle null as ref value', async () => {
     const ref = { current: null } as React.RefObject<HTMLDivElement>;
-    const { result } = renderHook(() => useScrollbarWidth(ref));
+    const { result } = renderHook(() => useScrollbarWidth(ref), { wrapper });
 
     expect(result.current.xScrollbarWidth).toBe(0);
     expect(result.current.yScrollbarWidth).toBe(0);
@@ -13,7 +15,7 @@ describe('useScrollbarWidth', () => {
   test('should update values on re-render', async () => {
     let element = { offsetWidth: 10, offsetHeight: 20, clientWidth: 5, clientHeight: 10 };
     let ref = { current: element } as React.RefObject<HTMLDivElement>;
-    const { result, rerender } = renderHook(() => useScrollbarWidth(ref));
+    const { result, rerender } = renderHook(() => useScrollbarWidth(ref), { wrapper });
 
     expect(result.current.xScrollbarWidth).toBe(10);
     expect(result.current.yScrollbarWidth).toBe(5);

--- a/src/table/virtualized-table/hooks/use-scrollbar-width.ts
+++ b/src/table/virtualized-table/hooks/use-scrollbar-width.ts
@@ -1,24 +1,21 @@
-import { useEffect, useState } from 'react';
-import useOnPropsChange from './use-on-props-change';
+import { useLayoutEffect, useState } from 'react';
+import { useContextSelector, TableContext } from '../../context';
 
 const useScrollbarWidth = (ref: React.RefObject<HTMLDivElement>) => {
+  const { layout } = useContextSelector(TableContext, (value) => value.baseProps);
+  const columnWidths = useContextSelector(TableContext, (value) => value.columnWidths);
   const [xScrollbarWidth, setXScrollbarWidth] = useState(0);
   const [yScrollbarWidth, setYScrollbarWidth] = useState(0);
-  const { offsetWidth = 0, offsetHeight = 0, clientWidth = 0, clientHeight = 0 } = ref.current ?? {};
-  const widthDiff = offsetWidth - clientWidth;
-  const heightDiff = offsetHeight - clientHeight;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (ref.current) {
-      setYScrollbarWidth(ref.current.offsetWidth - ref.current.clientWidth);
-      setXScrollbarWidth(ref.current.offsetHeight - ref.current.clientHeight);
+      const { offsetWidth = 0, offsetHeight = 0, clientWidth = 0, clientHeight = 0 } = ref.current ?? {};
+      const widthDiff = offsetWidth - clientWidth;
+      const heightDiff = offsetHeight - clientHeight;
+      setYScrollbarWidth(widthDiff);
+      setXScrollbarWidth(heightDiff);
     }
-  }, [ref]);
-
-  useOnPropsChange(() => {
-    setYScrollbarWidth(widthDiff);
-    setXScrollbarWidth(heightDiff);
-  }, [widthDiff, heightDiff]);
+  }, [ref, layout, columnWidths]);
 
   return { xScrollbarWidth, yScrollbarWidth };
 };


### PR DESCRIPTION
The old logic could end up in what appeared to be a race-condition when it measured the element to determine if there was a scrollbar. I found it occur sometimes when doing selections with the selection toolbar that reduced or increased the number of rows.