### PR TITLE
fix: remove white space before measuring cell

### DIFF
--- a/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
+++ b/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
@@ -55,7 +55,7 @@ const useDynamicRowHeight = ({ bodyStyle, columnWidth, gridRef, rowHeight, layou
 
   const getCellSize = useCallback(
     (text: string, colIdx: number) => {
-      const width = measureText(text);
+      const width = measureText(text.trim());
       const cellWidth = subtractCellPaddingAndBorder(columnWidth[colIdx]);
       const estimatedLineCount = Math.min(maxLineCount, Math.ceil(width / cellWidth));
       const textHeight = Math.max(1, estimatedLineCount) * lineHeight;


### PR DESCRIPTION
A cell that contained only white space could line break into multiple lines in the virtual scroll table. This not how the pagination table does it, it just ignores all white space. So this fix replicates that.