### PR TITLE
feat(a11y): make keyboard navigation work for head cell menu

### DIFF
--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -86,68 +86,12 @@ export default function HeadCellMenu({ column, tabIndex }: HeadCellMenuProps) {
                     {
                       id: 1,
                       itemTitle: translator.get('SNTable.MenuItem.SelectAll'),
-                      // onClick: async () => {
-                      //   setOpenMenuDropdown(false);
-                      //   await fieldInstance?.selectAll();
-                      // },
+                      onClick: async () => {
+                        setOpenMenuDropdown(false);
+                        await fieldInstance?.selectAll();
+                      },
                       icon: <SelectAll />,
-                      enabled: true,
-                      subMenus: [
-                        [
-                          {
-                            id: 1,
-                            itemTitle: translator.get('SNTable.MenuItem.SelectAll'),
-                            onClick: async () => {
-                              setOpenMenuDropdown(false);
-                              await fieldInstance?.selectAll();
-                            },
-                            icon: <SelectAll />,
-                            enabled: selectionActionsEnabledStatus.canSelectAll,
-                          },
-                          {
-                            id: 2,
-                            itemTitle: translator.get('SNTable.MenuItem.SelectPossible'),
-                            onClick: async () => {
-                              setOpenMenuDropdown(false);
-                              await fieldInstance?.selectPossible();
-                            },
-                            icon: <SelectPossible />,
-                            enabled: selectionActionsEnabledStatus.canSelectPossible,
-                          },
-                          {
-                            id: 3,
-                            itemTitle: translator.get('SNTable.MenuItem.SelectAlternative'),
-                            onClick: async () => {
-                              setOpenMenuDropdown(false);
-                              await fieldInstance?.selectAlternative();
-                            },
-                            icon: <SelectAlternative />,
-                            enabled: selectionActionsEnabledStatus.canSelectAlternative,
-                          },
-                          {
-                            id: 4,
-                            itemTitle: translator.get('SNTable.MenuItem.SelectExcluded'),
-                            onClick: async () => {
-                              setOpenMenuDropdown(false);
-                              await fieldInstance?.selectExcluded();
-                            },
-                            icon: <SelectExcluded />,
-                            enabled: selectionActionsEnabledStatus.canSelectExcluded,
-                          },
-                        ],
-                        [
-                          {
-                            id: 1,
-                            itemTitle: translator.get('SNTable.MenuItem.ClearSelections'),
-                            onClick: async () => {
-                              setOpenMenuDropdown(false);
-                              await fieldInstance?.clear();
-                            },
-                            icon: <ClearSelections />,
-                            enabled: selectionActionsEnabledStatus.canClearSelections,
-                          },
-                        ],
-                      ],
+                      enabled: selectionActionsEnabledStatus.canSelectAll,
                     },
                     {
                       id: 2,

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -86,12 +86,68 @@ export default function HeadCellMenu({ column, tabIndex }: HeadCellMenuProps) {
                     {
                       id: 1,
                       itemTitle: translator.get('SNTable.MenuItem.SelectAll'),
-                      onClick: async () => {
-                        setOpenMenuDropdown(false);
-                        await fieldInstance?.selectAll();
-                      },
+                      // onClick: async () => {
+                      //   setOpenMenuDropdown(false);
+                      //   await fieldInstance?.selectAll();
+                      // },
                       icon: <SelectAll />,
-                      enabled: selectionActionsEnabledStatus.canSelectAll,
+                      enabled: true,
+                      subMenus: [
+                        [
+                          {
+                            id: 1,
+                            itemTitle: translator.get('SNTable.MenuItem.SelectAll'),
+                            onClick: async () => {
+                              setOpenMenuDropdown(false);
+                              await fieldInstance?.selectAll();
+                            },
+                            icon: <SelectAll />,
+                            enabled: selectionActionsEnabledStatus.canSelectAll,
+                          },
+                          {
+                            id: 2,
+                            itemTitle: translator.get('SNTable.MenuItem.SelectPossible'),
+                            onClick: async () => {
+                              setOpenMenuDropdown(false);
+                              await fieldInstance?.selectPossible();
+                            },
+                            icon: <SelectPossible />,
+                            enabled: selectionActionsEnabledStatus.canSelectPossible,
+                          },
+                          {
+                            id: 3,
+                            itemTitle: translator.get('SNTable.MenuItem.SelectAlternative'),
+                            onClick: async () => {
+                              setOpenMenuDropdown(false);
+                              await fieldInstance?.selectAlternative();
+                            },
+                            icon: <SelectAlternative />,
+                            enabled: selectionActionsEnabledStatus.canSelectAlternative,
+                          },
+                          {
+                            id: 4,
+                            itemTitle: translator.get('SNTable.MenuItem.SelectExcluded'),
+                            onClick: async () => {
+                              setOpenMenuDropdown(false);
+                              await fieldInstance?.selectExcluded();
+                            },
+                            icon: <SelectExcluded />,
+                            enabled: selectionActionsEnabledStatus.canSelectExcluded,
+                          },
+                        ],
+                        [
+                          {
+                            id: 1,
+                            itemTitle: translator.get('SNTable.MenuItem.ClearSelections'),
+                            onClick: async () => {
+                              setOpenMenuDropdown(false);
+                              await fieldInstance?.clear();
+                            },
+                            icon: <ClearSelections />,
+                            enabled: selectionActionsEnabledStatus.canClearSelections,
+                          },
+                        ],
+                      ],
                     },
                     {
                       id: 2,

--- a/src/table/components/head/MenuList/MenuGroup.tsx
+++ b/src/table/components/head/MenuList/MenuGroup.tsx
@@ -5,6 +5,7 @@ import ArrowRight from '@qlik-trial/sprout/icons/react/ArrowRight';
 import { HeadCellMenuItem, MenuItemGroup } from '../../../types';
 import { StyledMenuItem, StyledListItemIcon, StyledMenuItemLabel } from '../styles';
 import RecursiveMenuList from './RecursiveMenuList';
+import { handleHeadCellMenuKeyDown } from '../../../utils/handle-key-press';
 
 export const interceptClickOnMenuItems = (menuGroups: MenuItemGroup[], cache: SubMenusOpenStatusCache) => {
   const result = menuGroups.map((grp) => {
@@ -31,64 +32,6 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
   const [openMenu, setOpenMenu] = useState(false);
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
-  const moveToNextFocusItem = (currentFocus: Element): Element | undefined => {
-    const nextItem = currentFocus.nextElementSibling;
-    if (!nextItem) {
-      return currentFocus.parentElement?.children?.[0];
-    }
-    if (nextItem.tagName === 'HR') {
-      return moveToNextFocusItem(nextItem);
-    }
-    return nextItem;
-  };
-
-  const moveToPreviousFocusItem = (currentFocus: Element): Element | undefined => {
-    const previousItem = currentFocus.previousElementSibling;
-    if (!previousItem) {
-      const menuItemAmount = currentFocus.parentElement?.children?.length as number;
-      return currentFocus.parentElement?.children?.[menuItemAmount - 1];
-    }
-    if (previousItem.tagName === 'HR') {
-      return moveToPreviousFocusItem(previousItem);
-    }
-    return previousItem;
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLLIElement>) => {
-    const { key } = event;
-
-    const currentFocus = document.activeElement ?? (event.target as HTMLElement);
-
-    // The rest key are handled by handleKeyDown in MUIMenuList
-    if (key === 'ArrowDown') {
-      // Prevent scroll of the page
-      event.preventDefault();
-      // Stop triggering handleKeyDown in MUIMenuList
-      event.stopPropagation();
-      let nextFocusItem = moveToNextFocusItem(currentFocus);
-      while (nextFocusItem) {
-        if (nextFocusItem.ariaDisabled === 'true') {
-          nextFocusItem = moveToNextFocusItem(nextFocusItem);
-        } else {
-          (nextFocusItem as HTMLElement).focus();
-          break;
-        }
-      }
-    } else if (key === 'ArrowUp') {
-      event.preventDefault();
-      event.stopPropagation();
-      let nextFocusItem = moveToPreviousFocusItem(currentFocus);
-      while (nextFocusItem) {
-        if (nextFocusItem.ariaDisabled === 'true') {
-          nextFocusItem = moveToPreviousFocusItem(nextFocusItem);
-        } else {
-          (nextFocusItem as HTMLElement).focus();
-          break;
-        }
-      }
-    }
-  };
-
   const handleOnClick = (evt: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
     if (onClick) {
       onClick(evt);
@@ -110,7 +53,7 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
         onClick={handleOnClick}
         disabled={!enabled}
         autoFocus={autoFocus}
-        onKeyDown={handleKeyDown}
+        onKeyDown={handleHeadCellMenuKeyDown}
       >
         <StyledMenuItemLabel>
           <StyledListItemIcon>{icon}</StyledListItemIcon>

--- a/src/table/components/head/MenuList/MenuGroup.tsx
+++ b/src/table/components/head/MenuList/MenuGroup.tsx
@@ -31,23 +31,25 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
   const [openMenu, setOpenMenu] = useState(false);
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
-  const moveToNextFocusItem = (currentFocus: Element) => {
-    let nextItem = currentFocus.nextElementSibling as HTMLDivElement;
+  const moveToNextFocusItem = (currentFocus: Element): Element | undefined => {
+    const nextItem = currentFocus.nextElementSibling;
     if (!nextItem) {
-      nextItem = currentFocus.parentElement?.children[0] as HTMLDivElement;
-    } else if (nextItem.tagName === 'HR') {
-      nextItem = moveToNextFocusItem(nextItem);
+      return currentFocus.parentElement?.children?.[0];
+    }
+    if (nextItem.tagName === 'HR') {
+      return moveToNextFocusItem(nextItem);
     }
     return nextItem;
   };
 
-  const moveToPreviousFocusItem = (currentFocus: Element) => {
-    let previousItem = currentFocus.previousElementSibling as HTMLDivElement;
+  const moveToPreviousFocusItem = (currentFocus: Element): Element | undefined => {
+    const previousItem = currentFocus.previousElementSibling;
     if (!previousItem) {
-      const menuItemAmount = currentFocus?.parentElement?.children.length;
-      (currentFocus?.parentElement?.children[(menuItemAmount as number) - 1] as HTMLDivElement).focus();
-    } else if (previousItem.tagName === 'HR') {
-      previousItem = moveToPreviousFocusItem(previousItem);
+      const menuItemAmount = currentFocus.parentElement?.children?.length as number;
+      return currentFocus.parentElement?.children?.[menuItemAmount - 1];
+    }
+    if (previousItem.tagName === 'HR') {
+      return moveToPreviousFocusItem(previousItem);
     }
     return previousItem;
   };
@@ -55,7 +57,7 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
   const handleKeyDown = (event: React.KeyboardEvent<HTMLLIElement>) => {
     const { key } = event;
 
-    const currentFocus = document.activeElement as Element;
+    const currentFocus = document.activeElement ?? (event.target as HTMLElement);
 
     // The rest key are handled by handleKeyDown in MUIMenuList
     if (key === 'ArrowDown') {
@@ -68,7 +70,7 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
         if (nextFocusItem.ariaDisabled === 'true') {
           nextFocusItem = moveToNextFocusItem(nextFocusItem);
         } else {
-          nextFocusItem.focus();
+          (nextFocusItem as HTMLElement).focus();
           break;
         }
       }
@@ -80,7 +82,7 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
         if (nextFocusItem.ariaDisabled === 'true') {
           nextFocusItem = moveToPreviousFocusItem(nextFocusItem);
         } else {
-          nextFocusItem.focus();
+          (nextFocusItem as HTMLElement).focus();
           break;
         }
       }

--- a/src/table/components/head/MenuList/MenuGroup.tsx
+++ b/src/table/components/head/MenuList/MenuGroup.tsx
@@ -105,6 +105,7 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
       <StyledMenuItem
         ref={subMenus ? anchorRef : null}
         key={id}
+        data-testid={`menu-item-${id}`}
         className="sn-table-head-menu-item"
         onClick={handleOnClick}
         disabled={!enabled}
@@ -133,7 +134,7 @@ const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subM
 };
 
 const MenuGroup = ({ menuGroup }: { menuGroup: HeadCellMenuItem[] }) => {
-  return menuGroup.map((groupItem) => <MenuGroupItems {...groupItem} />);
+  return menuGroup.map((groupItem) => <MenuGroupItems key={groupItem.id} {...groupItem} />);
 };
 
 export default MenuGroup;

--- a/src/table/components/head/MenuList/RecursiveMenuList.tsx
+++ b/src/table/components/head/MenuList/RecursiveMenuList.tsx
@@ -31,7 +31,6 @@ const RecursiveMenuList = ({
       open={open}
       anchorEl={anchorEl}
       onClose={onClose}
-      autoFocus={false}
       aria-labelledby={ariaLabel}
       {...(anchorOrigin ? { anchorOrigin } : {})}
       {...(transformOrigin ? { transformOrigin } : {})}

--- a/src/table/components/head/MenuList/__tests__/MenuGroup.spec.tsx
+++ b/src/table/components/head/MenuList/__tests__/MenuGroup.spec.tsx
@@ -60,7 +60,7 @@ describe('MenuGroup', () => {
       expect(screen.getByText('Menu#02')).toBeVisible();
     });
 
-    it('should render menu items with subMenu', () => {
+    it('should render menu items with subMenu with correct keyboard navigation', () => {
       menuGroup = [
         { id: 1, icon: <i />, itemTitle: 'Menu#01', enabled: true },
         {

--- a/src/table/components/head/MenuList/__tests__/MenuGroup.spec.tsx
+++ b/src/table/components/head/MenuList/__tests__/MenuGroup.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import MenuGroup, { interceptClickOnMenuItems } from '../MenuGroup';
 import { HeadCellMenuItem, MenuItemGroup } from '../../../../types';
 
@@ -68,15 +68,50 @@ describe('MenuGroup', () => {
           icon: <i />,
           itemTitle: 'Menu#02',
           enabled: true,
-          subMenus: [[{ id: 1, icon: <i />, itemTitle: 'SubMenu#01', enabled: true }]],
+          subMenus: [
+            [
+              { id: 3, icon: <i />, itemTitle: 'SubMenu#01', enabled: true },
+              { id: 4, icon: <i />, itemTitle: 'SubMenu#02', enabled: true },
+            ],
+            [{ id: 5, icon: <i />, itemTitle: 'SubMenu#03', enabled: true }],
+          ],
         },
       ];
       renderer(menuGroup);
 
       expect(screen.getByText('Menu#01')).toBeVisible();
       expect(screen.getByText('Menu#02')).toBeVisible();
+
+      act(() => {
+        screen.getByTestId('menu-item-1').focus();
+      });
+      fireEvent.keyDown(screen.getByTestId('menu-item-1'), {
+        key: 'ArrowDown',
+      });
+      expect(screen.getByTestId('menu-item-2')).toHaveFocus();
+      fireEvent.keyDown(screen.getByTestId('menu-item-2'), {
+        key: 'ArrowDown',
+      });
+      expect(screen.getByTestId('menu-item-1')).toHaveFocus();
+      fireEvent.keyDown(screen.getByTestId('menu-item-1'), {
+        key: 'ArrowUp',
+      });
+      expect(screen.getByTestId('menu-item-2')).toHaveFocus();
+
       fireEvent.click(screen.getByText('Menu#02'));
       expect(screen.getByText('SubMenu#01')).toBeVisible();
+
+      fireEvent.keyDown(screen.getByTestId('menu-item-3'), { key: 'ArrowUp' });
+      expect(screen.getByTestId('menu-item-5')).toHaveFocus();
+
+      fireEvent.keyDown(screen.getByTestId('menu-item-5'), { key: 'ArrowUp' });
+      expect(screen.getByTestId('menu-item-4')).toHaveFocus();
+
+      fireEvent.keyDown(screen.getByTestId('menu-item-4'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('menu-item-5')).toHaveFocus();
+
+      fireEvent.keyDown(screen.getByTestId('menu-item-5'), { key: 'ArrowDown' });
+      expect(screen.getByTestId('menu-item-3')).toHaveFocus();
     });
   });
 });

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -266,6 +266,7 @@ export interface HeadCellMenuProps {
 export type MenuItemGroup = HeadCellMenuItem[];
 
 export interface HeadCellMenuItem {
+  autoFocus?: boolean;
   id: number;
   icon: React.ReactElement;
   itemTitle: string;

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -13,6 +13,29 @@ const preventDefaultBehavior = (evt: React.KeyboardEvent) => {
   evt.preventDefault();
 };
 
+const getNextFocusItem = (currentFocus: Element): Element | undefined => {
+  const nextItem = currentFocus.nextElementSibling;
+  if (!nextItem) {
+    return currentFocus.parentElement?.children?.[0];
+  }
+  if (nextItem.tagName === 'HR') {
+    return getNextFocusItem(nextItem);
+  }
+  return nextItem;
+};
+
+const getPreviousFocusItem = (currentFocus: Element): Element | undefined => {
+  const previousItem = currentFocus.previousElementSibling;
+  if (!previousItem) {
+    const menuItemAmount = currentFocus.parentElement?.children?.length as number;
+    return currentFocus.parentElement?.children?.[menuItemAmount - 1];
+  }
+  if (previousItem.tagName === 'HR') {
+    return getPreviousFocusItem(previousItem);
+  }
+  return previousItem;
+};
+
 const isCtrlShift = (evt: React.KeyboardEvent) => evt.shiftKey && (evt.ctrlKey || evt.metaKey);
 
 const isArrowKey = (key: string) =>
@@ -143,6 +166,40 @@ export const handleHeadKeyDown = ({
     }
     default:
       break;
+  }
+};
+
+/**
+ * handles ArrowDown and ArrowUp events for the head cell menu (move focus)
+ */
+export const handleHeadCellMenuKeyDown = (event: React.KeyboardEvent<HTMLLIElement>) => {
+  const { key, target } = event;
+  const currentFocus = document.activeElement ?? (target as HTMLElement);
+  // The rest key are handled by handleKeyDown in MUIMenuList
+  if (key === 'ArrowDown') {
+    // Prevent scroll of the page
+    // Stop triggering handleKeyDown in MUIMenuList
+    preventDefaultBehavior(event);
+    let nextFocusItem = getNextFocusItem(currentFocus);
+    while (nextFocusItem) {
+      if (nextFocusItem.ariaDisabled === 'true') {
+        nextFocusItem = getNextFocusItem(nextFocusItem);
+      } else {
+        (nextFocusItem as HTMLElement).focus();
+        break;
+      }
+    }
+  } else if (key === 'ArrowUp') {
+    preventDefaultBehavior(event);
+    let previousFocusItem = getPreviousFocusItem(currentFocus);
+    while (previousFocusItem) {
+      if (previousFocusItem.ariaDisabled === 'true') {
+        previousFocusItem = getPreviousFocusItem(previousFocusItem);
+      } else {
+        (previousFocusItem as HTMLElement).focus();
+        break;
+      }
+    }
   }
 };
 

--- a/src/table/utils/handle-key-press.ts
+++ b/src/table/utils/handle-key-press.ts
@@ -174,29 +174,20 @@ export const handleHeadKeyDown = ({
  */
 export const handleHeadCellMenuKeyDown = (event: React.KeyboardEvent<HTMLLIElement>) => {
   const { key, target } = event;
-  const currentFocus = document.activeElement ?? (target as HTMLElement);
+  const currentFocusItem = document.activeElement ?? (target as HTMLElement);
   // The rest key are handled by handleKeyDown in MUIMenuList
-  if (key === 'ArrowDown') {
+  if (key === 'ArrowDown' || key === 'ArrowUp') {
+    const getNewFocusItem = (currentItem: Element) =>
+      key === 'ArrowDown' ? getNextFocusItem(currentItem) : getPreviousFocusItem(currentItem);
     // Prevent scroll of the page
     // Stop triggering handleKeyDown in MUIMenuList
     preventDefaultBehavior(event);
-    let nextFocusItem = getNextFocusItem(currentFocus);
-    while (nextFocusItem) {
-      if (nextFocusItem.ariaDisabled === 'true') {
-        nextFocusItem = getNextFocusItem(nextFocusItem);
+    let newFocusItem = getNewFocusItem(currentFocusItem);
+    while (newFocusItem) {
+      if (newFocusItem.ariaDisabled === 'true') {
+        newFocusItem = getNewFocusItem(newFocusItem);
       } else {
-        (nextFocusItem as HTMLElement).focus();
-        break;
-      }
-    }
-  } else if (key === 'ArrowUp') {
-    preventDefaultBehavior(event);
-    let previousFocusItem = getPreviousFocusItem(currentFocus);
-    while (previousFocusItem) {
-      if (previousFocusItem.ariaDisabled === 'true') {
-        previousFocusItem = getPreviousFocusItem(previousFocusItem);
-      } else {
-        (previousFocusItem as HTMLElement).focus();
+        (newFocusItem as HTMLElement).focus();
         break;
       }
     }


### PR DESCRIPTION
- should focus on the first option in the menu when opening
- should open the cascading menu when activating the button
- should focus the ... button again when closing the menu
	- either by esc or by choosing an option

https://user-images.githubusercontent.com/4471489/222143020-5f44758b-ae38-4659-a2e1-e32a831699c6.mov