### PR TITLE
feat: hide head sort buttons/head cell menu buttons when they are not needed

### DIFF
--- a/src/table/components/head/HeadCellContent.tsx
+++ b/src/table/components/head/HeadCellContent.tsx
@@ -18,32 +18,39 @@ function HeadCellContent({ children, column, isActive, areBasicFeaturesEnabled }
   const tabIndex = !keyboard.enabled ? 0 : -1;
   const isInteractionEnabled = !constraints.active && !selectionsAPI.isModal();
 
-  const handleSort = () => isInteractionEnabled && changeSortOrder(column);
-
   return (
     <StyledHeadCellContent>
       {lockIcon}
-
-      <StyledSortButton
-        isActive={isActive}
-        textAlign={column.align}
-        title={!constraints.passive ? FullSortDirection[column.sortDirection] : undefined} // passive: turn off tooltips.
-        color="inherit"
-        size="small"
-        startIcon={startIcon}
-        endIcon={endIcon}
-        onClick={handleSort}
-        tabIndex={tabIndex}
-      >
-        {children}
-        {isFocusInHead && (
-          <VisuallyHidden data-testid={`VHL-for-col-${column.pageColIdx}`}>
-            {translator.get('SNTable.SortLabel.PressSpaceToSort')}
-          </VisuallyHidden>
-        )}
-      </StyledSortButton>
-
-      {areBasicFeaturesEnabled && <HeadCellMenu column={column} tabIndex={tabIndex} />}
+      {isInteractionEnabled ? (
+        <StyledSortButton
+          isActive={isActive}
+          textAlign={column.align}
+          title={!constraints.passive ? FullSortDirection[column.sortDirection] : undefined} // passive: turn off tooltips.
+          color="inherit"
+          size="small"
+          startIcon={startIcon}
+          endIcon={endIcon}
+          onClick={() => changeSortOrder(column)}
+          tabIndex={tabIndex}
+        >
+          {children}
+          {isFocusInHead && (
+            <VisuallyHidden data-testid={`VHL-for-col-${column.pageColIdx}`}>
+              {translator.get('SNTable.SortLabel.PressSpaceToSort')}
+            </VisuallyHidden>
+          )}
+        </StyledSortButton>
+      ) : (
+        <>
+          {children}
+          {isFocusInHead && (
+            <VisuallyHidden data-testid={`VHL-for-col-${column.pageColIdx}`}>
+              {translator.get('SNTable.SortLabel.PressSpaceToSort')}
+            </VisuallyHidden>
+          )}
+        </>
+      )}
+      {areBasicFeaturesEnabled && isInteractionEnabled && <HeadCellMenu column={column} tabIndex={tabIndex} />}
     </StyledHeadCellContent>
   );
 }

--- a/src/table/components/head/__tests__/HeadCellContent.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellContent.spec.tsx
@@ -104,24 +104,22 @@ describe('<HeadCellContent />', () => {
     expect(changeSortOrder).toHaveBeenCalledWith(column);
   });
 
-  it('should not call changeSortOrder when clicking a header cell and constraints.active is true', () => {
+  it('should hide the sort button/head menu button when constraints.active is true in edit mode', () => {
     constraints = {
       active: true,
     };
     renderTableHead();
-    fireEvent.click(screen.getByText(column.label));
 
-    expect(changeSortOrder).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('should not call changeSortOrder when clicking a header cell and cells are selected', () => {
+  it('should hide the sort button/head menu button when clicking a header cell and cells are selected', () => {
     selectionsAPI = {
       isModal: () => true,
     } as ExtendedSelectionAPI;
     renderTableHead();
-    fireEvent.click(screen.getByText(column.label));
 
-    expect(changeSortOrder).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('should show the lock icon only when the selections on dimensions are locked', () => {


### PR DESCRIPTION
- should hide the head sort button/head menu button when constraints.active is true in edit mode
- should hide the head sort button/head menu button when clicking a header cell and cells are selected

<img width="359" alt="Screenshot 2023-03-03 at 11 31 26" src="https://user-images.githubusercontent.com/4471489/222697770-e211169a-96c5-48a9-8618-13f4e2a39bf3.png">

