### PR TITLE
fix: default props was not populated properly

### DIFF
--- a/src/ext/property-panel/data.js
+++ b/src/ext/property-panel/data.js
@@ -289,9 +289,10 @@ const getData = (env) =>
         translation: 'Common.Data',
         component: 'data-assets-panel',
         items: {
-          dimension: {
-            type: 'items',
+          dimensions: {
+            type: 'array',
             component: 'expandable-items',
+            ref: 'qHyperCubeDef.qDimensions',
             items: {
               field: {
                 type: 'items',
@@ -305,9 +306,10 @@ const getData = (env) =>
               },
             },
           },
-          measure: {
-            type: 'items',
+          measures: {
+            type: 'array',
             component: 'expandable-items',
+            ref: 'qHyperCubeDef.qMeasures',
             items: {
               field: {
                 type: 'items',


### PR DESCRIPTION
The default props of a dimension or measure were populated in sense-client by a function `getCreatePropertyHandler` in `default-extension.js`. It expects the definition to be in certain structure so the structure we have for chart exploration was not compatible. This PR fix the problem.