### PR TITLE
fix: white space before totals

### DIFF
--- a/src/table/pagination-table/components/head/TableHeadWrapper.tsx
+++ b/src/table/pagination-table/components/head/TableHeadWrapper.tsx
@@ -19,8 +19,10 @@ function TableHeadWrapper({ areBasicFeaturesEnabled }: TableHeadWrapperProps) {
   const headRowRef = useRef<HTMLTableRowElement>(null);
 
   useEffect(() => {
-    headRowRef.current && setHeadRowHeight(headRowRef.current.getBoundingClientRect().height);
-  }, [headRowRef.current, styling.head.fontSize, headRowRef.current?.getBoundingClientRect().height]);
+    if (headRowRef.current) {
+      setHeadRowHeight(headRowRef.current.getBoundingClientRect().height);
+    }
+  }, [styling.head.fontSize, columnWidths, setHeadRowHeight]);
 
   return (
     <TableHead>


### PR DESCRIPTION
Fixes an issue in the pagination table where the totals row would be incorrectly positioned (see screenshot below). This could happen when the table was re-sized. Ex. via object re-size in Qlik Sense or browser window re-sizing.

It did not happen every time. You had to find a scenario where the height of the header row would grow smaller as the table was re-sized.

**Before:**
![Skärmavbild 2023-03-07 kl  13 15 44](https://user-images.githubusercontent.com/16608020/223427073-7464d097-63ff-4893-bac5-7dbe6009907a.png)

**After:**
![Skärmavbild 2023-03-07 kl  13 17 52](https://user-images.githubusercontent.com/16608020/223427080-2dcc5a0b-54f3-43b0-9125-5289deafc53b.png)
