### PR TITLE
fix: column widths effect dependencies

### DIFF
--- a/src/table/hooks/use-column-widths.ts
+++ b/src/table/hooks/use-column-widths.ts
@@ -95,7 +95,7 @@ const useColumnWidths = (
 
   useOnPropsChange(() => {
     setColumnWidths(getColumnWidths(columns, tableWidth - yScrollbarWidth, getHugWidth));
-  }, [columns, tableWidth, yScrollbarWidth]);
+  }, [columns, tableWidth, yScrollbarWidth, getHugWidth]);
 
   return [columnWidths, setColumnWidths, setYScrollbarWidth];
 };


### PR DESCRIPTION
Fixes an issue where column widths would not be re-calculated when needed.

The issue could be reproduce like this:
1.  Create a table with a single dimension (1 dim because you don't need more)
2. Set the dimensions `resize type` to `hug`
3. Change the theme in your current context (ex. Qlik Sense) to a theme with a large font-size for the body.

Result:
The column widths would not adjust to the new font-size from the theme.