### PR TITLE
fix: column width huc calculation

### DIFF
--- a/src/table/context/TableContext.tsx
+++ b/src/table/context/TableContext.tsx
@@ -44,7 +44,12 @@ export const TableContextProvider = ({
   const [selectionState, selectionDispatch] = useSelectionReducer(tableData.rows, selectionsAPI);
   const [hoverIndex, setHoverIndex] = useState(-1);
   const styling = useTableStyling(layout, theme, tableData, rootElement);
-  const [columnWidths, setColumnWidths, setYScrollbarWidth] = useColumnWidths(tableData.columns, tableWidth, styling);
+  const [columnWidths, setColumnWidths, setYScrollbarWidth] = useColumnWidths(
+    tableData.columns,
+    tableData.totalsPosition,
+    tableWidth,
+    styling
+  );
   const baseProps = useMemo(
     () => ({
       app,

--- a/src/table/hooks/__tests__/use-column-widths.spec.ts
+++ b/src/table/hooks/__tests__/use-column-widths.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { Column } from '../../../types';
+import { Column, TotalsPosition } from '../../../types';
 import { ColumnWidthTypes, MIN_COLUMN_WIDTH } from '../../constants';
 import { TableStyling } from '../../types';
 import useMeasureText, { MeasureTextHook } from '../../virtualized-table/hooks/use-measure-text';
@@ -15,6 +15,7 @@ describe('use-column-widths', () => {
   let columns: Column[];
   let tableWidth: number;
   let styling: TableStyling;
+  let totalsPosition: TotalsPosition;
 
   beforeEach(() => {
     mockedUseMeasureText = useMeasureText as jest.MockedFunction<typeof useMeasureText>;
@@ -46,6 +47,8 @@ describe('use-column-widths', () => {
       body: { fontFamily: 'Arial', fontSize: '12px' },
       head: { fontFamily: 'Arial', fontSize: '12px' },
     } as unknown as TableStyling;
+
+    totalsPosition = { atTop: true, atBottom: false };
   });
 
   afterEach(() => {
@@ -53,7 +56,8 @@ describe('use-column-widths', () => {
   });
 
   // only looking at the state not setState
-  const getColumnWidthsState = () => renderHook(() => useColumnWidths(columns, tableWidth, styling)).result.current[0];
+  const getColumnWidthsState = () =>
+    renderHook(() => useColumnWidths(columns, totalsPosition, tableWidth, styling)).result.current[0];
   const getTotalWidth = (widths: number[]) => widths.reduce((acc, w) => acc + w, 0);
 
   describe('getColumnWidths', () => {
@@ -91,8 +95,8 @@ describe('use-column-widths', () => {
         columns[2].columnWidth.type = ColumnWidthTypes.HUG;
 
         const widths = getColumnWidthsState();
-        expect(widths).toEqual([200, 200, 200]);
-        expect(getTotalWidth(widths)).toBe(200 * 3);
+        expect(widths).toEqual([270, 270, 270]);
+        expect(getTotalWidth(widths)).toBe(270 * 3);
       });
     });
 
@@ -137,7 +141,7 @@ describe('use-column-widths', () => {
         columns[2].columnWidth.type = ColumnWidthTypes.HUG;
 
         const widths = getColumnWidthsState();
-        expect(widths).toEqual([225, 225, 150]);
+        expect(widths).toEqual([190, 190, 220]);
         expect(getTotalWidth(widths)).toBe(tableWidth);
       });
     });

--- a/src/table/hooks/__tests__/use-column-widths.spec.ts
+++ b/src/table/hooks/__tests__/use-column-widths.spec.ts
@@ -95,8 +95,8 @@ describe('use-column-widths', () => {
         columns[2].columnWidth.type = ColumnWidthTypes.HUG;
 
         const widths = getColumnWidthsState();
-        expect(widths).toEqual([270, 270, 270]);
-        expect(getTotalWidth(widths)).toBe(270 * 3);
+        expect(widths).toEqual([275, 275, 275]);
+        expect(getTotalWidth(widths)).toBe(275 * 3);
       });
     });
 
@@ -141,7 +141,7 @@ describe('use-column-widths', () => {
         columns[2].columnWidth.type = ColumnWidthTypes.HUG;
 
         const widths = getColumnWidthsState();
-        expect(widths).toEqual([190, 190, 220]);
+        expect(widths).toEqual([187.5, 187.5, 225]);
         expect(getTotalWidth(widths)).toBe(tableWidth);
       });
     });

--- a/src/table/hooks/use-column-widths.ts
+++ b/src/table/hooks/use-column-widths.ts
@@ -10,15 +10,18 @@ import {
 import useMeasureText from '../virtualized-table/hooks/use-measure-text';
 import { TableStyling } from '../types';
 import useOnPropsChange from '../virtualized-table/hooks/use-on-props-change';
+import { BORDER_WIDTH } from '../styling-defaults';
 
-type GetHugWidth = (headLabel: string, totalsLabel: string, glyphCount: number) => number;
+type GetHugWidth = (headLabel: string, totalsLabel: string, glyphCount: number, isLocked: boolean) => number;
 
 const HEADER_CELL_BUTTON_PADDING = 8 * 2;
 const HEADER_CELL_PADDING = 4 * 2;
-const SORT_ICON = 12 + 8 - 2;
+const SORT_ICON = 12 + 8 + 2;
 const MENU_BUTTON = 24;
 const FLEX_BOX_GAP = 4;
-const ADJUSTED_HEADER_WIDTH = HEADER_CELL_BUTTON_PADDING + HEADER_CELL_PADDING + SORT_ICON + MENU_BUTTON + FLEX_BOX_GAP;
+const LOOK_BUTTON_AND_AUTO_MARGIN = 20 + 4;
+const ADJUSTED_HEADER_WIDTH =
+  HEADER_CELL_BUTTON_PADDING + HEADER_CELL_PADDING + SORT_ICON + MENU_BUTTON + FLEX_BOX_GAP + BORDER_WIDTH;
 const TOTALS_PADDING = 12 * 2;
 
 /**
@@ -59,7 +62,7 @@ export const getColumnWidths = (columns: Column[], tableWidth: number, getHugWid
           addKnownWidth();
           break;
         case ColumnWidthTypes.HUG:
-          newWidth = getHugWidth(label, totalInfo, qApprMaxGlyphCount);
+          newWidth = getHugWidth(label, totalInfo, qApprMaxGlyphCount, col.isLocked);
           addKnownWidth();
           break;
         case ColumnWidthTypes.FILL:
@@ -94,11 +97,14 @@ const useColumnWidths = (
   const showTotals = totalsPosition.atBottom || totalsPosition.atTop;
   const measureHeadLabel = useMeasureText(head.fontSize, head.fontFamily).measureText;
   const { measureText, estimateWidth } = useMeasureText(body.fontSize, body.fontFamily);
-  const getHugWidth = useMemo(
-    () => (headLabel: string, totalsLabel: string, glyphCount: number) => {
+  const getHugWidth = useMemo<GetHugWidth>(
+    () => (headLabel, totalsLabel, glyphCount, isLocked) => {
+      const HEAD_LABEL_WIDTH = isLocked
+        ? LOOK_BUTTON_AND_AUTO_MARGIN + ADJUSTED_HEADER_WIDTH + FLEX_BOX_GAP
+        : ADJUSTED_HEADER_WIDTH;
       return Math.max(
-        measureHeadLabel(headLabel) + ADJUSTED_HEADER_WIDTH,
-        showTotals ? measureText(totalsLabel) + TOTALS_PADDING : 0,
+        measureHeadLabel(headLabel) + HEAD_LABEL_WIDTH,
+        showTotals ? measureText(totalsLabel) + TOTALS_PADDING + BORDER_WIDTH : 0,
         estimateWidth(glyphCount)
       );
     },

--- a/src/table/hooks/use-column-widths.ts
+++ b/src/table/hooks/use-column-widths.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Column } from '../../types';
+import { Column, TotalsPosition } from '../../types';
 import {
   MIN_COLUMN_WIDTH,
   ColumnWidthTypes,
@@ -77,17 +77,30 @@ export const getColumnWidths = (columns: Column[], tableWidth: number, getHugWid
   return columnWidths;
 };
 
+const PADDING = 8 * 2 + 4 * 2;
+const ICON = 12 + 8 - 2;
+const MENU_BUTTON = 24;
+const FLEX_BOX_GAP = 4;
+const TOTALS_PADDING = 12 * 2;
+
 const useColumnWidths = (
   columns: Column[],
+  totalsPosition: TotalsPosition,
   tableWidth: number,
   { head, body }: TableStyling
 ): [number[], React.Dispatch<React.SetStateAction<number[]>>, React.Dispatch<React.SetStateAction<number>>] => {
+  const showTotals = totalsPosition.atBottom || totalsPosition.atTop;
   const measureHeadLabel = useMeasureText(head.fontSize, head.fontFamily).measureText;
   const { measureText, estimateWidth } = useMeasureText(body.fontSize, body.fontFamily);
   const getHugWidth = useMemo(
-    () => (headLabel: string, totalsLabel: string, glyphCount: number) =>
-      Math.max(measureHeadLabel(headLabel), measureText(totalsLabel), estimateWidth(glyphCount)),
-    [estimateWidth, measureHeadLabel, measureText]
+    () => (headLabel: string, totalsLabel: string, glyphCount: number) => {
+      return Math.max(
+        measureHeadLabel(headLabel) + PADDING + ICON + MENU_BUTTON + FLEX_BOX_GAP,
+        showTotals ? measureText(totalsLabel) + TOTALS_PADDING : 0,
+        estimateWidth(glyphCount)
+      );
+    },
+    [estimateWidth, measureHeadLabel, measureText, showTotals]
   );
   const [yScrollbarWidth, setYScrollbarWidth] = useState(0);
 

--- a/src/table/hooks/use-column-widths.ts
+++ b/src/table/hooks/use-column-widths.ts
@@ -13,6 +13,14 @@ import useOnPropsChange from '../virtualized-table/hooks/use-on-props-change';
 
 type GetHugWidth = (headLabel: string, totalsLabel: string, glyphCount: number) => number;
 
+const HEADER_CELL_BUTTON_PADDING = 8 * 2;
+const HEADER_CELL_PADDING = 4 * 2;
+const SORT_ICON = 12 + 8 - 2;
+const MENU_BUTTON = 24;
+const FLEX_BOX_GAP = 4;
+const ADJUSTED_HEADER_WIDTH = HEADER_CELL_BUTTON_PADDING + HEADER_CELL_PADDING + SORT_ICON + MENU_BUTTON + FLEX_BOX_GAP;
+const TOTALS_PADDING = 12 * 2;
+
 /**
  * Calculates column widths in pixels, based on column settings and the table width.
  * First, pixel values for the three independent types ('pixels', 'percentage', 'hug') are set.
@@ -77,12 +85,6 @@ export const getColumnWidths = (columns: Column[], tableWidth: number, getHugWid
   return columnWidths;
 };
 
-const PADDING = 8 * 2 + 4 * 2;
-const ICON = 12 + 8 - 2;
-const MENU_BUTTON = 24;
-const FLEX_BOX_GAP = 4;
-const TOTALS_PADDING = 12 * 2;
-
 const useColumnWidths = (
   columns: Column[],
   totalsPosition: TotalsPosition,
@@ -95,7 +97,7 @@ const useColumnWidths = (
   const getHugWidth = useMemo(
     () => (headLabel: string, totalsLabel: string, glyphCount: number) => {
       return Math.max(
-        measureHeadLabel(headLabel) + PADDING + ICON + MENU_BUTTON + FLEX_BOX_GAP,
+        measureHeadLabel(headLabel) + ADJUSTED_HEADER_WIDTH,
         showTotals ? measureText(totalsLabel) + TOTALS_PADDING : 0,
         estimateWidth(glyphCount)
       );

--- a/src/table/virtualized-table/hooks/use-measure-text.ts
+++ b/src/table/virtualized-table/hooks/use-measure-text.ts
@@ -6,7 +6,7 @@ export interface MeasureTextHook {
   measureText: (text: string) => number;
 }
 
-const MAGIC_DEFAULT_CHAR = 'M';
+const MAGIC_DEFAULT_CHAR = 'N';
 
 export default function useMeasureText(
   fontSize: string | undefined,


### PR DESCRIPTION
Fixes some issue with the hug calculation for column widths:
- Take header button and sort icon into account when measuring header label width
- Take padding into account when measuring totals label width
- Do not measure totals label if totals is not shown
- Adjust the estimated width based on glypth count

Comparison with the native table in Qlik Sense. Both native table and sn-table have "hug" as column width.
![Skärmavbild 2023-03-08 kl  14 01 05](https://user-images.githubusercontent.com/16608020/223727019-dc2a3e23-19a5-4a88-ba04-16c872e44fee.png)
