### PR TITLE
fix: styling label missing

### DIFF
--- a/src/ext/property-panel/settings.js
+++ b/src/ext/property-panel/settings.js
@@ -4,6 +4,7 @@ const stylingPanel = {
     {
       component: 'styling-panel',
       chartTitle: 'Object.StraightTable',
+      subtitle: 'LayerStyleEditor.component.styling',
       translation: 'LayerStyleEditor.component.styling',
       ref: 'components',
       useGeneral: true,


### PR DESCRIPTION
translation is used for the "Styling -->" button in property panel, subtitle is the subtitle in the styling panel header, under the chart name