### PR TITLE
fix: text alignment should be based on numeric or not numeric

### DIFF
--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -83,7 +83,7 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
   const isLocked = isDim && (info as ExtendedNxDimensionInfo).qLocked;
   const { qDimensionType } = info as ExtendedNxDimensionInfo;
   const autoHeadCellTextAlign = qDimensionType === 'N' || qDimensionType === undefined ? 'right' : 'left';
-  const autoTotalsCellTextAlgin = isDim ? 'left' : 'right';
+  const autoTotalsCellTextAlign = isDim ? 'left' : 'right';
 
   let fieldIndex = 0;
   let fieldId = '';
@@ -110,7 +110,7 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
       sortDirection: qSortIndicator && qSortIndicator !== 'N' ? qSortIndicator : 'A',
       totalInfo: getTotalInfo(layout, colIdx, pageColIdx, numDims),
       autoHeadCellTextAlign,
-      autoTotalsCellTextAlgin,
+      autoTotalsCellTextAlign,
       textAlign: {
         auto: !textAlign || textAlign.auto,
         align: textAlign?.align,

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -48,7 +48,8 @@ export function getTotalPosition(layout: TableLayout, areBasicFeaturesEnabled = 
 }
 
 /**
- * Gets the totals text for a column
+ * Gets the totals label in the first column
+ * Gets the qText for each of the rest of columns
  */
 export function getTotalInfo(layout: TableLayout, colIdx: number, pageColIdx: number, numDims: number) {
   if (colIdx >= numDims) return layout.qHyperCube.qGrandTotalRow[colIdx - numDims]?.qText ?? '';
@@ -66,6 +67,7 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
   const info = (isDim ? qDimensionInfo[colIdx] : qMeasureInfo[colIdx - numDims]) as
     | ExtendedNxMeasureInfo
     | ExtendedNxDimensionInfo;
+
   const {
     qError,
     qFallbackTitle,
@@ -79,7 +81,9 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
   } = info;
   const isHidden = qError?.qErrorCode === 7005;
   const isLocked = isDim && (info as ExtendedNxDimensionInfo).qLocked;
-  const autoAlign = isDim ? 'left' : 'right';
+  const { qDimensionType } = info as ExtendedNxDimensionInfo;
+  const autoHeadCellTextAlign = qDimensionType === 'N' || qDimensionType === undefined ? 'right' : 'left';
+  const autoTotalsCellTextAlgin = isDim ? 'left' : 'right';
 
   let fieldIndex = 0;
   let fieldId = '';
@@ -101,11 +105,16 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
       columnWidth,
       id: `col-${pageColIdx}`,
       label: qFallbackTitle,
-      align: !textAlign || textAlign.auto ? autoAlign : textAlign.align,
       stylingIDs: qAttrExprInfo.map((expr) => expr.id),
       // making sure that qSortIndicator is either A or D
       sortDirection: qSortIndicator && qSortIndicator !== 'N' ? qSortIndicator : 'A',
       totalInfo: getTotalInfo(layout, colIdx, pageColIdx, numDims),
+      autoHeadCellTextAlign,
+      autoTotalsCellTextAlgin,
+      textAlign: {
+        auto: !textAlign || textAlign.auto,
+        align: textAlign?.align,
+      },
     }
   );
 }

--- a/src/table/components/head/HeadCellContent.tsx
+++ b/src/table/components/head/HeadCellContent.tsx
@@ -8,7 +8,7 @@ import { VisuallyHidden, StyledSortButton, StyledHeadCellContent } from './style
 import HeadCellMenu from './HeadCellMenu';
 import { handleHeadKeyDown } from '../../utils/handle-keyboard';
 
-function HeadCellContent({ children, column, isActive, areBasicFeaturesEnabled }: HeadCellContentProps) {
+function HeadCellContent({ children, column, isActive, align, areBasicFeaturesEnabled }: HeadCellContentProps) {
   const { constraints, keyboard, translator, rootElement, changeSortOrder } = useContextSelector(
     TableContext,
     (value) => value.baseProps
@@ -17,7 +17,8 @@ function HeadCellContent({ children, column, isActive, areBasicFeaturesEnabled }
   const isFocusInHead = useContextSelector(TableContext, (value) => value.focusedCellCoord[0] === 0);
   const isInSelectionMode = useContextSelector(TableContext, (value) => value.baseProps.selectionsAPI.isModal());
 
-  const { startIcon, endIcon, lockIcon } = getHeadIcons(column);
+  const { sortDirection, pageColIdx } = column;
+  const { startIcon, endIcon, lockIcon } = getHeadIcons(column, align);
   const isInteractionEnabled = !constraints.active && !isInSelectionMode;
   const tabIndex = isInteractionEnabled && !keyboard.enabled ? 0 : -1;
 
@@ -26,7 +27,7 @@ function HeadCellContent({ children, column, isActive, areBasicFeaturesEnabled }
     handleHeadKeyDown({
       evt,
       rootElement,
-      cellCoord: [0, column.pageColIdx],
+      cellCoord: [0, pageColIdx],
       setFocusedCellCoord,
       isInteractionEnabled,
       areBasicFeaturesEnabled,
@@ -39,8 +40,8 @@ function HeadCellContent({ children, column, isActive, areBasicFeaturesEnabled }
       <StyledSortButton
         className="sn-table-head-label"
         isActive={isActive}
-        textAlign={column.align}
-        title={!constraints.passive ? FullSortDirection[column.sortDirection] : undefined} // passive: turn off tooltips.
+        textAlign={align}
+        title={!constraints.passive ? FullSortDirection[sortDirection] : undefined} // passive: turn off tooltips.
         color="inherit"
         size="small"
         startIcon={startIcon}
@@ -51,13 +52,15 @@ function HeadCellContent({ children, column, isActive, areBasicFeaturesEnabled }
       >
         {children}
         {isFocusInHead && (
-          <VisuallyHidden data-testid={`VHL-for-col-${column.pageColIdx}`}>
+          <VisuallyHidden data-testid={`VHL-for-col-${pageColIdx}`}>
             {translator.get('SNTable.SortLabel.PressSpaceToSort')}
           </VisuallyHidden>
         )}
       </StyledSortButton>
 
-      {areBasicFeaturesEnabled && isInteractionEnabled && <HeadCellMenu column={column} tabIndex={tabIndex} />}
+      {areBasicFeaturesEnabled && isInteractionEnabled && (
+        <HeadCellMenu column={column} tabIndex={tabIndex} align={align} />
+      )}
     </StyledHeadCellContent>
   );
 }

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -19,7 +19,7 @@ import { TableLayout } from '../../../types';
 import RecursiveMenuList from './MenuList/RecursiveMenuList';
 import { DEFAULT_FONT_SIZE } from '../../styling-defaults';
 
-export default function HeadCellMenu({ column, tabIndex }: HeadCellMenuProps) {
+export default function HeadCellMenu({ column, tabIndex, align }: HeadCellMenuProps) {
   const showSearchMenuItem = column.isDim;
   const anchorRef = useRef<HTMLDivElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
@@ -162,7 +162,7 @@ export default function HeadCellMenu({ column, tabIndex }: HeadCellMenuProps) {
   );
 
   return menuItemGroups.length ? (
-    <HeadCellMenuWrapper rightAligned={column.align === 'right'}>
+    <HeadCellMenuWrapper rightAligned={align === 'right'}>
       <StyledMenuIconButton
         isVisible={openListboxDropdown || openMenuDropdown}
         ref={anchorRef}

--- a/src/table/components/head/__tests__/HeadCellContent.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellContent.spec.tsx
@@ -41,7 +41,7 @@ describe('<HeadCellContent />', () => {
     column = {
       id: '1',
       autoHeadCellTextAlign: 'left',
-      autoTotalsCellTextAlgin: 'left',
+      autoTotalsCellTextAlign: 'left',
       textAlign: {
         auto: true,
         align: 'left',

--- a/src/table/components/head/__tests__/HeadCellContent.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellContent.spec.tsx
@@ -3,13 +3,14 @@ import { stardust } from '@nebula.js/stardust';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import HeadCellContent from '../HeadCellContent';
-import { TableLayout, ChangeSortOrder, ExtendedSelectionAPI, Column } from '../../../../types';
+import { TableLayout, ChangeSortOrder, ExtendedSelectionAPI, Column, Align } from '../../../../types';
 import TestWithProviders from '../../../../__test__/test-with-providers';
 import CellText from '../../CellText';
 
 describe('<HeadCellContent />', () => {
   let column: Column;
   let isActive: boolean;
+  let align: Align;
   let layout: TableLayout;
   let changeSortOrder: ChangeSortOrder;
   let constraints: stardust.Constraints;
@@ -25,7 +26,12 @@ describe('<HeadCellContent />', () => {
         layout={layout}
         changeSortOrder={changeSortOrder}
       >
-        <HeadCellContent column={column} isActive={isActive} areBasicFeaturesEnabled={areBasicFeaturesEnabled}>
+        <HeadCellContent
+          column={column}
+          isActive={isActive}
+          align={align}
+          areBasicFeaturesEnabled={areBasicFeaturesEnabled}
+        >
           <CellText>{column.label}</CellText>
         </HeadCellContent>
       </TestWithProviders>
@@ -34,7 +40,12 @@ describe('<HeadCellContent />', () => {
   beforeEach(() => {
     column = {
       id: '1',
-      align: 'left',
+      autoHeadCellTextAlign: 'left',
+      autoTotalsCellTextAlgin: 'left',
+      textAlign: {
+        auto: true,
+        align: 'left',
+      },
       label: 'someDim',
       sortDirection: 'A',
       isDim: true,

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { stardust } from '@nebula.js/stardust';
 import { render, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
-import { Column, TableLayout } from '../../../../types';
+import { Column, TableLayout, Align } from '../../../../types';
 import HeadCellMenu from '../HeadCellMenu';
 import TestWithProviders from '../../../../__test__/test-with-providers';
 import * as useFieldSelectionHook from '../../../hooks/use-field-selection';
@@ -18,6 +18,7 @@ describe('<HeadCellMenu />', () => {
   let embed: ExtendedEmbed;
   let layout: TableLayout;
   let column: Column;
+  let align: Align;
   let defaultListboxAnchorOpts: any;
   let fieldInstanceMock: EngineAPI.IField;
   let selectionActionsEnabledStatusMock: Record<string, boolean>;
@@ -44,7 +45,7 @@ describe('<HeadCellMenu />', () => {
         embed={embed}
         model={model}
       >
-        <HeadCellMenu column={column} tabIndex={0} />
+        <HeadCellMenu column={column} tabIndex={0} align={align} />
       </TestWithProviders>
     );
 

--- a/src/table/pagination-table/components/body/TableBodyWrapper.tsx
+++ b/src/table/pagination-table/components/body/TableBodyWrapper.tsx
@@ -61,8 +61,10 @@ function TableBodyWrapper({
           className="sn-table-row"
         >
           {columns.map((column, columnIndex) => {
-            const { id, align } = column;
+            const { id, textAlign } = column;
             const cell = row[id] as Cell;
+            const autoAlign = () => (cell.qNum && !Number.isNaN(+cell.qNum) ? 'right' : 'left');
+            const align = textAlign.auto ? autoAlign() : textAlign.align;
             const CellRenderer = columnRenderers[columnIndex];
             const tabIndex = rowIndex === 0 && columnIndex === 0 && !totalsPosition.atTop && !keyboard.enabled ? 0 : -1;
             const handleKeyDown = (evt: React.KeyboardEvent) => {

--- a/src/table/pagination-table/components/body/TableTotals.tsx
+++ b/src/table/pagination-table/components/body/TableTotals.tsx
@@ -23,15 +23,18 @@ function TableTotals() {
   return (
     <TableRow className="sn-table-row">
       {columns.map((column, columnIndex) => {
+        const { textAlign, autoTotalsCellTextAlgin } = column;
         const cellCoord: [number, number] = [atTop ? 1 : rows.length + 1, columnIndex];
         const tabIndex = atTop && columnIndex === 0 ? 0 : -1;
+        const align = textAlign.auto ? autoTotalsCellTextAlgin : textAlign.align;
+
         return (
           <StyledTotalsCell
             totalsStyle={styling.totals}
             headRowHeight={headRowHeight}
             atTop={atTop}
             key={column.id}
-            align={column.align}
+            align={align}
             className="sn-table-cell"
             tabIndex={tabIndex}
             onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {

--- a/src/table/pagination-table/components/body/TableTotals.tsx
+++ b/src/table/pagination-table/components/body/TableTotals.tsx
@@ -23,10 +23,10 @@ function TableTotals() {
   return (
     <TableRow className="sn-table-row">
       {columns.map((column, columnIndex) => {
-        const { textAlign, autoTotalsCellTextAlgin } = column;
+        const { textAlign, autoTotalsCellTextAlign } = column;
         const cellCoord: [number, number] = [atTop ? 1 : rows.length + 1, columnIndex];
         const tabIndex = atTop && columnIndex === 0 ? 0 : -1;
-        const align = textAlign.auto ? autoTotalsCellTextAlgin : textAlign.align;
+        const align = textAlign.auto ? autoTotalsCellTextAlign : textAlign.align;
 
         return (
           <StyledTotalsCell

--- a/src/table/pagination-table/components/head/TableHeadWrapper.tsx
+++ b/src/table/pagination-table/components/head/TableHeadWrapper.tsx
@@ -28,11 +28,13 @@ function TableHeadWrapper({ areBasicFeaturesEnabled }: TableHeadWrapperProps) {
     <TableHead>
       <TableRow ref={headRowRef} className="sn-table-row">
         {columns.map((column, columnIndex) => {
+          const { id, label, colIdx, sortDirection, textAlign, autoHeadCellTextAlign } = column;
           // The first cell in the head is focusable in sequential keyboard navigation,
           // when nebula does not handle keyboard navigation
-          const isActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.colIdx;
-          const ariaSort = isActive ? FullSortDirection[column.sortDirection] : undefined;
+          const isActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === colIdx;
+          const ariaSort = isActive ? FullSortDirection[sortDirection] : undefined;
           const isLastColumn = columnIndex === columns.length - 1;
+          const align = textAlign.auto ? autoHeadCellTextAlign : textAlign.align;
 
           const widthStyle = {
             ...(areBasicFeaturesEnabled && {
@@ -46,14 +48,19 @@ function TableHeadWrapper({ areBasicFeaturesEnabled }: TableHeadWrapperProps) {
           return (
             <StyledHeadCell
               headerStyle={{ ...styling.head, ...widthStyle }}
-              key={column.id}
-              align={column.align}
+              key={id}
+              align={align}
               className="sn-table-head-cell sn-table-cell"
               aria-sort={ariaSort}
               tabIndex={-1}
             >
-              <HeadCellContent column={column} isActive={isActive} areBasicFeaturesEnabled={areBasicFeaturesEnabled}>
-                <CellText fontSize={styling.head.fontSize}>{column.label}</CellText>
+              <HeadCellContent
+                column={column}
+                isActive={isActive}
+                align={align}
+                areBasicFeaturesEnabled={areBasicFeaturesEnabled}
+              >
+                <CellText fontSize={styling.head.fontSize}>{label}</CellText>
               </HeadCellContent>
               {areBasicFeaturesEnabled && <ColumnAdjuster column={column} isLastColumn={isLastColumn} />}
             </StyledHeadCell>

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -15,6 +15,7 @@ import {
   TotalsPosition,
   Row,
   ApplyColumnWidths,
+  Align,
 } from '../types';
 import { FocusTypes, SelectionActions } from './constants';
 
@@ -272,12 +273,14 @@ export interface HeadCellContentProps {
   children: JSX.Element;
   column: Column;
   isActive: boolean;
+  align: Align;
   areBasicFeaturesEnabled: boolean;
 }
 
 export interface HeadCellMenuProps {
   column: Column;
   tabIndex: number;
+  align: Align;
 }
 
 export type MenuItemGroup = HeadCellMenuItem[];

--- a/src/table/utils/__tests__/get-head-icons.spec.tsx
+++ b/src/table/utils/__tests__/get-head-icons.spec.tsx
@@ -4,7 +4,7 @@ import Descending from '@qlik-trial/sprout/icons/react/Descending';
 import Ascending from '@qlik-trial/sprout/icons/react/Ascending';
 
 import getHeadIcons from '../get-head-icons';
-import { Column } from '../../../types';
+import { Column, Align } from '../../../types';
 import { DEFAULT_FONT_SIZE } from '../../styling-defaults';
 import { LockWrapper } from '../../components/head/styles';
 
@@ -17,46 +17,47 @@ describe('getHeadIcons', () => {
     </LockWrapper>
   );
   let column: Column;
+  let align: Align;
 
   beforeEach(() => {
+    align = 'left';
     column = {
       sortDirection: 'A',
       isLocked: false,
-      align: 'left',
     } as Column;
   });
 
   it('should return ascending as endIcon and no lock icon when sortDirection i A and align is left', () => {
-    const icons = getHeadIcons(column);
+    const icons = getHeadIcons(column, align);
     expect(icons).toEqual({ endIcon: ascending, lockIcon: undefined });
   });
 
   it('should return descending as endIcon and no lock icon when sortDirection i D and align is left', () => {
     column.sortDirection = 'D';
 
-    const icons = getHeadIcons(column);
+    const icons = getHeadIcons(column, align);
     expect(icons).toEqual({ endIcon: descending, lockIcon: undefined });
   });
 
   it('should return ascending as endIcon and no lock icon when sortDirection i A and align is right', () => {
-    column.align = 'right';
+    align = 'right';
 
-    const icons = getHeadIcons(column);
+    const icons = getHeadIcons(column, align);
     expect(icons).toEqual({ startIcon: ascending, lockIcon: undefined });
   });
 
   it('should return descending as endIcon and no lock icon when sortDirection i D and align is right', () => {
-    column.align = 'right';
+    align = 'right';
     column.sortDirection = 'D';
 
-    const icons = getHeadIcons(column);
+    const icons = getHeadIcons(column, align);
     expect(icons).toEqual({ startIcon: descending, lockIcon: undefined });
   });
 
   it('should return defined lock icon when isLocked is true', () => {
     column.isLocked = true;
 
-    const { lockIcon } = getHeadIcons(column);
+    const { lockIcon } = getHeadIcons(column, align);
     expect(lockIcon).toEqual(lock);
   });
 });

--- a/src/table/utils/get-head-icons.tsx
+++ b/src/table/utils/get-head-icons.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import Lock from '@qlik-trial/sprout/icons/react/Lock';
 import Descending from '@qlik-trial/sprout/icons/react/Descending';
 import Ascending from '@qlik-trial/sprout/icons/react/Ascending';
-import { Column } from '../../types';
+import { Column, Align } from '../../types';
 import { DEFAULT_FONT_SIZE } from '../styling-defaults';
 import { LockWrapper } from '../components/head/styles';
 
-const getHeadIcons = ({ sortDirection, isLocked, align }: Column) => {
+const getHeadIcons = ({ sortDirection, isLocked }: Column, align: Align) => {
   const sortIcon =
     sortDirection === 'A' ? <Ascending height={DEFAULT_FONT_SIZE} /> : <Descending height={DEFAULT_FONT_SIZE} />;
   const lockIcon = isLocked ? (

--- a/src/table/virtualized-table/Cell.tsx
+++ b/src/table/virtualized-table/Cell.tsx
@@ -8,6 +8,7 @@ import CellText from '../components/CellText';
 import getCellStyle from './utils/get-cell-style';
 import { ItemData } from './types';
 import { BORDER_WIDTH, PADDING_LEFT_RIGHT } from './constants';
+import { Cell as CellType } from '../../types';
 
 interface CellProps {
   columnIndex: number;
@@ -18,21 +19,19 @@ interface CellProps {
 
 const Cell = ({ columnIndex, rowIndex, style, data }: CellProps) => {
   const { rowsInPage, columns, bodyStyle, isHoverEnabled, maxLineCount } = data;
-  const cell = rowsInPage[rowIndex]?.[`col-${columnIndex}`];
+  const cell = rowsInPage[rowIndex]?.[`col-${columnIndex}`] as CellType;
 
   const rowIsHovered = useContextSelector(TableContext, (value) => value.hoverIndex === rowIndex);
   const setHoverIndex = useContextSelector(TableContext, (value) => value.setHoverIndex);
 
   const { handleMouseDown, handleMouseOver, handleMouseUp, cellSelectionState } = useSelector(cell);
 
+  const column = columns[columnIndex];
+  const autoAlign = () => (cell.qNum && !Number.isNaN(+cell.qNum) ? 'right' : 'left');
+  const align = column.textAlign.auto ? autoAlign() : column.textAlign.align;
+
   if (typeof cell === 'object') {
-    const cellStyle = getCellStyle(
-      cell,
-      columns[columnIndex],
-      isHoverEnabled && rowIsHovered,
-      cellSelectionState,
-      bodyStyle
-    );
+    const cellStyle = getCellStyle(cell, column, isHoverEnabled && rowIsHovered, cellSelectionState, bodyStyle);
 
     return (
       <div
@@ -46,7 +45,7 @@ const Cell = ({ columnIndex, rowIndex, style, data }: CellProps) => {
           borderBottomWidth: cell.isLastRow ? '0px' : `${BORDER_WIDTH}px`,
           borderRightWidth: cell.isLastColumn ? '0px' : `${BORDER_WIDTH}px`,
           borderStyle: 'solid',
-          justifyContent: columns[columnIndex].align,
+          justifyContent: align,
           padding: `4px ${PADDING_LEFT_RIGHT}px`,
           boxSizing: 'border-box',
           cursor: 'default',

--- a/src/table/virtualized-table/HeaderCell.tsx
+++ b/src/table/virtualized-table/HeaderCell.tsx
@@ -23,9 +23,11 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
 
   const { layout } = useContextSelector(TableContext, (value) => value.baseProps);
   const column = columns[index];
+  const { colIdx, textAlign, autoHeadCellTextAlign, label } = column;
   const isLastColumn = columns.length - 1 === index;
-  const isActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.colIdx;
-  const flexDirection = column.align === 'right' ? 'row-reverse' : 'row';
+  const isActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === colIdx;
+  const align = textAlign.auto ? autoHeadCellTextAlign : textAlign.align;
+  const flexDirection = align === 'right' ? 'row-reverse' : 'row';
 
   return (
     <div
@@ -38,7 +40,7 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
         borderStyle: 'solid',
         borderWidth: isLastColumn ? '0px 0px 1px 0px' : '0px 1px 1px 0px',
         padding: '4px',
-        justifyContent: column.align,
+        justifyContent: align,
         boxSizing: 'border-box',
         cursor: 'default',
         zIndex: columns.length - index,
@@ -46,9 +48,9 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
         userSelect: 'none',
       }}
     >
-      <HeadCellContent column={column} isActive={isActive} areBasicFeaturesEnabled>
+      <HeadCellContent column={column} isActive={isActive} align={align} areBasicFeaturesEnabled>
         <CellText wordBreak lines={3}>
-          {column.label}
+          {label}
         </CellText>
       </HeadCellContent>
       <ColumnAdjuster column={column} isLastColumn={isLastColumn} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
 import { Direction } from '@mui/material';
 import { stardust } from '@nebula.js/stardust';
 
+export type Align = 'left' | 'center' | 'right';
 interface TextAlign {
   auto: boolean;
-  align: 'left' | 'center' | 'right';
+  align: Align;
 }
 
 // properties
@@ -95,6 +96,7 @@ export interface Cell {
   qText?: string;
   qAttrExps?: EngineAPI.INxAttributeExpressionValues;
   qElemNumber: number;
+  qNum?: number | string;
   rowIdx: number;
   colIdx: number;
   pageRowIdx: number;
@@ -126,7 +128,9 @@ export interface Column {
   colIdx: number;
   pageColIdx: number;
   label: string;
-  align: 'left' | 'center' | 'right';
+  autoHeadCellTextAlign: Align;
+  autoTotalsCellTextAlgin: Align;
+  textAlign: TextAlign;
   stylingIDs: string[];
   sortDirection: SortDirection;
   qReverseSort: boolean;


### PR DESCRIPTION
- head cell 
	- column is measure: right
	- column is dimension
		- 	qDimensionType is N: right
		- otherwise: left

- totals cell
	- column is dimension: left
	- column is measure right

- inner body cell
	- cell's qNum is number: right
	- cell's qNum is not number: left


user-set text alignment should override the above.