### PR TITLE
fix: scroll to top on resize

### DIFF
--- a/src/table/components/head/ColumnAdjuster.tsx
+++ b/src/table/components/head/ColumnAdjuster.tsx
@@ -13,7 +13,7 @@ import { focusHeadMenuButton } from '../../utils/accessibility-utils';
  * When you start dragging, mouse move and mouse up listeners are added.
  * While dragging the current column is updated, and on mouse up all other columns are updated.
  */
-const ColumnAdjuster = ({ column, isLastColumn }: AdjusterProps) => {
+const ColumnAdjuster = ({ column, isLastColumn, onColumnResize }: AdjusterProps) => {
   const { pageColIdx } = column;
   const { rootElement, applyColumnWidths, constraints } = useContextSelector(TableContext, (value) => value.baseProps);
   const columnWidths = useContextSelector(TableContext, (value) => value.columnWidths);
@@ -24,6 +24,7 @@ const ColumnAdjuster = ({ column, isLastColumn }: AdjusterProps) => {
   if (!applyColumnWidths || constraints.active) return null;
 
   const updateWidth = (adjustedWidth: number) => {
+    onColumnResize?.();
     tempWidths.current.columnWidth = adjustedWidth;
     const newColumnWidths = [...columnWidths];
     newColumnWidths[pageColIdx] = adjustedWidth;

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -313,6 +313,7 @@ export interface PaginationContentProps {
 export interface AdjusterProps {
   column: Column;
   isLastColumn: boolean;
+  onColumnResize?: () => void;
 }
 
 export interface FooterWrapperProps {

--- a/src/table/virtualized-table/Body.tsx
+++ b/src/table/virtualized-table/Body.tsx
@@ -35,7 +35,7 @@ const Body = forwardRef<BodyRef, BodyProps>((props, ref) => {
     rowHeight
   );
 
-  const { setCellSize, getRowHeight, rowMeta, estimatedRowHeight, maxLineCount, updateCellHeight } =
+  const { setCellSize, getRowHeight, rowMeta, estimatedRowHeight, maxLineCount, resizeVisibleCells } =
     useDynamicRowHeight({
       pageInfo,
       style: bodyStyle,
@@ -99,7 +99,6 @@ const Body = forwardRef<BodyRef, BodyProps>((props, ref) => {
   // calculated based on the layout and/or container element size changes
   useOnPropsChange(() => {
     gridRef.current?.resetAfterIndices({ columnIndex: 0, rowIndex: 0, shouldForceUpdate: false });
-    updateCellHeight(rowsInPage);
   }, [columnWidths]);
 
   useImperativeHandle(
@@ -120,9 +119,12 @@ const Body = forwardRef<BodyRef, BodyProps>((props, ref) => {
             gridRef.current?.scrollTo({ scrollTop, scrollLeft });
           }
         },
+        resizeCells: () => {
+          resizeVisibleCells(rowsInPage);
+        },
       };
     },
-    [innerForwardRef, bodyHeight, rowMeta, rowCount]
+    [innerForwardRef, bodyHeight, rowMeta, rowCount, resizeVisibleCells, rowsInPage]
   );
 
   return (

--- a/src/table/virtualized-table/Header.tsx
+++ b/src/table/virtualized-table/Header.tsx
@@ -6,7 +6,7 @@ import { useContextSelector, TableContext } from '../context';
 import useResetHeader from './hooks/use-reset-header';
 
 const Header = (props: HeaderProps) => {
-  const { rect, forwardRef, columns, pageInfo, headerStyle, rowHeight } = props;
+  const { rect, forwardRef, columns, pageInfo, headerStyle, rowHeight, columResizeHandler } = props;
   const { layout } = useContextSelector(TableContext, (value) => value.baseProps);
   const columnWidths = useContextSelector(TableContext, (value) => value.columnWidths);
 
@@ -24,7 +24,7 @@ const Header = (props: HeaderProps) => {
       itemSize={(index) => columnWidths[index]}
       height={rowHeight}
       width={rect.width}
-      itemData={{ columns, headerStyle }}
+      itemData={{ columns, headerStyle, columResizeHandler }}
     >
       {HeaderCell}
     </VariableSizeList>

--- a/src/table/virtualized-table/HeaderCell.tsx
+++ b/src/table/virtualized-table/HeaderCell.tsx
@@ -12,6 +12,7 @@ interface HeaderCellProps {
   data: {
     columns: Column[];
     headerStyle: GeneratedStyling;
+    columResizeHandler: () => void;
   };
 }
 
@@ -19,6 +20,7 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
   const {
     columns,
     headerStyle: { ...applicableStyle },
+    columResizeHandler,
   } = data;
 
   const { layout } = useContextSelector(TableContext, (value) => value.baseProps);
@@ -51,7 +53,7 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
           {column.label}
         </CellText>
       </HeadCellContent>
-      <ColumnAdjuster column={column} isLastColumn={isLastColumn} />
+      <ColumnAdjuster column={column} isLastColumn={isLastColumn} onColumnResize={columResizeHandler} />
     </div>
   );
 };

--- a/src/table/virtualized-table/Table.tsx
+++ b/src/table/virtualized-table/Table.tsx
@@ -65,6 +65,14 @@ const Table = (props: TableProps) => {
     [containerHeight, headerAndTotalsHeight, stickyContainerRect.height]
   );
 
+  const columResizeHandler = useCallback(() => {
+    if (ref.current) {
+      ref.current.scrollTop = 0;
+    }
+
+    bodyRef.current?.resizeCells();
+  }, [ref]);
+
   useLayoutEffect(() => {
     if (ref.current) {
       ref.current.scrollLeft = 0;
@@ -76,7 +84,7 @@ const Table = (props: TableProps) => {
     if (ref.current) {
       ref.current.scrollTop = 0;
     }
-  }, [columnWidths, pageInfo, rowCount]);
+  }, [pageInfo, rowCount]);
 
   useDidUpdateEffect(() => {
     setYScrollbarWidth(yScrollbarWidth);
@@ -104,6 +112,7 @@ const Table = (props: TableProps) => {
             columns={columns}
             forwardRef={headerRef}
             rowHeight={headerRowHeight}
+            columResizeHandler={columResizeHandler}
           />
           {totalsPosition.atTop ? TotalsComponent : null}
           <Body

--- a/src/table/virtualized-table/hooks/__tests__/use-dynamic-row-height.spec.tsx
+++ b/src/table/virtualized-table/hooks/__tests__/use-dynamic-row-height.spec.tsx
@@ -118,7 +118,7 @@ describe('useDynamicRowHeight', () => {
     await waitFor(() => expect(result.current.getRowHeight(1)).toEqual(25));
   });
 
-  describe('updateCellHeight', () => {
+  describe('resizeVisibleCells', () => {
     test('should update cell size for rendered rows', async () => {
       const rows = Array(rowCount)
         .fill(undefined)
@@ -134,7 +134,7 @@ describe('useDynamicRowHeight', () => {
 
       const { result } = renderHook(() => useDynamicRowHeight(props), { wrapper });
 
-      act(() => result.current.updateCellHeight(rows));
+      act(() => result.current.resizeVisibleCells(rows));
 
       await waitFor(() => expect(result.current.rowMeta.current.count).toEqual(rows.length));
       await waitFor(() => expect(result.current.rowMeta.current.heights).toEqual(Array(rowCount).fill(25)));
@@ -160,7 +160,7 @@ describe('useDynamicRowHeight', () => {
 
       const { result } = renderHook(() => useDynamicRowHeight(props), { wrapper });
 
-      act(() => result.current.updateCellHeight(rows));
+      act(() => result.current.resizeVisibleCells(rows));
 
       await waitFor(() => expect(result.current.rowMeta.current.count).toEqual(qcy));
       await waitFor(() => expect(result.current.rowMeta.current.heights).toEqual(Array(qcy).fill(25)));
@@ -182,7 +182,7 @@ describe('useDynamicRowHeight', () => {
       const { result } = renderHook(() => useDynamicRowHeight(props), { wrapper });
 
       act(() => result.current.setCellSize('123456789', 0, 0));
-      act(() => result.current.updateCellHeight(rows));
+      act(() => result.current.resizeVisibleCells(rows));
 
       await waitFor(() => expect(result.current.rowMeta.current.count).toEqual(1));
       await waitFor(() => expect(result.current.rowMeta.current.heights).toEqual([25]));
@@ -212,19 +212,6 @@ describe('useDynamicRowHeight', () => {
       await waitFor(() => expect(result.current.rowMeta.current.count).toEqual(1));
       await act(() => {
         rerender({ ...props, pageInfo: { ...pageInfo } });
-      });
-
-      await waitFor(() => expect(result.current.rowMeta.current.count).toEqual(0));
-    });
-
-    test('should reset row meta when column width is updated', async () => {
-      const { result, rerender } = renderHook((p) => useDynamicRowHeight(p), { initialProps: props, wrapper });
-
-      await act(() => result.current.setCellSize('123456789', 0, 0));
-
-      await waitFor(() => expect(result.current.rowMeta.current.count).toEqual(1));
-      await act(() => {
-        rerender({ ...props, columnWidths: [...columnWidths] });
       });
 
       await waitFor(() => expect(result.current.rowMeta.current.count).toEqual(0));

--- a/src/table/virtualized-table/hooks/__tests__/use-scroll-hander.test.ts
+++ b/src/table/virtualized-table/hooks/__tests__/use-scroll-hander.test.ts
@@ -14,7 +14,7 @@ describe('useScrollHandler', () => {
   beforeEach(() => {
     listInstance = { scrollTo: () => {} } as unknown as VariableSizeList;
     listTotalsInstance = { scrollTo: () => {} } as unknown as VariableSizeList;
-    refHandler = { interpolatedScrollTo: () => {} } as BodyRef;
+    refHandler = { interpolatedScrollTo: () => {}, resizeCells: () => {} } as BodyRef;
 
     headerRef = { current: listInstance };
     totalsRef = { current: listTotalsInstance };

--- a/src/table/virtualized-table/hooks/use-data/index.ts
+++ b/src/table/virtualized-table/hooks/use-data/index.ts
@@ -126,7 +126,7 @@ const useData = ({
      * - Layout change (layout)
      */
     const { qcx, qcy } = layout.qHyperCube.qSize;
-    const rowStart = 0;
+    const rowStart = gridState.current.overscanRowStartIndex;
     const qLeft = gridState.current.overscanColumnStartIndex;
     const qTop = rowStart + pageInfo.page * pageInfo.rowsPerPage;
 

--- a/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
+++ b/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
@@ -108,6 +108,15 @@ const useDynamicRowHeight = ({
     [rowMeta, estimatedRowHeight]
   );
 
+  const resetRowMeta = useCallback(() => {
+    rowMeta.current.lastScrollToRatio = 0;
+    rowMeta.current.resetAfterRowIndex = 0;
+    rowMeta.current.heights = [];
+    rowMeta.current.totalHeight = 0;
+    rowMeta.current.count = 0;
+    rowMeta.current.measuredCells.clear();
+  }, [rowMeta]);
+
   /**
    * Some user actions and events can trigger row heights to be invalidated
    * - A column is re-sized
@@ -117,16 +126,13 @@ const useDynamicRowHeight = ({
    * - Container element is re-sized (object re-sized in Qlik Sense or browser window re-sized)
    */
   useOnPropsChange(() => {
-    rowMeta.current.lastScrollToRatio = 0;
-    rowMeta.current.resetAfterRowIndex = 0;
-    rowMeta.current.heights = [];
-    rowMeta.current.totalHeight = 0;
-    rowMeta.current.count = 0;
-    rowMeta.current.measuredCells.clear();
-  }, [layout, pageInfo, getCellSize]);
+    resetRowMeta();
+  }, [layout, pageInfo]);
 
-  const updateCellHeight = (rows: Row[]) => {
+  const resizeVisibleCells = (rows: Row[]) => {
     if (!gridState) return;
+
+    resetRowMeta();
 
     const { overscanRowStartIndex: rowStart, overscanRowStopIndex } = gridState.current;
     const rowStop = Math.min(overscanRowStopIndex, layout.qHyperCube.qSize.qcy - 1);
@@ -149,7 +155,7 @@ const useDynamicRowHeight = ({
     lineRef.current.resetAfterIndex(rowMeta.current.resetAfterRowIndex, false);
   }
 
-  return { setCellSize, getRowHeight, rowMeta, estimatedRowHeight, maxLineCount, updateCellHeight };
+  return { setCellSize, getRowHeight, rowMeta, estimatedRowHeight, maxLineCount, resizeVisibleCells };
 };
 
 export default useDynamicRowHeight;

--- a/src/table/virtualized-table/types/index.ts
+++ b/src/table/virtualized-table/types/index.ts
@@ -63,6 +63,7 @@ export interface HeaderProps {
   columns: Column[];
   headerStyle: GeneratedStyling;
   rowHeight: number;
+  columResizeHandler: () => void;
 }
 
 export interface TotalsProps {
@@ -87,6 +88,7 @@ export interface BodyProps {
 
 export interface BodyRef {
   interpolatedScrollTo: (scrollTopRatio: number, scrollLeft: number) => void;
+  resizeCells: () => void;
 }
 
 export interface RowMeta {


### PR DESCRIPTION
Fixes an issue where the virtual scroll table would always scroll to the top when the table was resize. For example in Qlik Sense, changing the size of the table by re-sizing it on the grid or enter full screen mode.

Resizing a column still scrolls to the top to avoid issues with cells heights not being properly updated and rather "jumpy" experience during resize.