### PR TITLE
fix: adjusting column size by keyboard also scrolls the table

### DIFF
--- a/src/table/components/head/ColumnAdjuster.tsx
+++ b/src/table/components/head/ColumnAdjuster.tsx
@@ -69,6 +69,8 @@ const ColumnAdjuster = ({ column, isLastColumn, onColumnResize }: AdjusterProps)
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === KeyCodes.LEFT || event.key === KeyCodes.RIGHT) {
+      event.preventDefault();
+
       const RESIZE_DISTANCE = 5;
       const prevWidth = columnWidths[pageColIdx];
       const columnWidth = event.key === KeyCodes.LEFT ? prevWidth - RESIZE_DISTANCE : prevWidth + RESIZE_DISTANCE;


### PR DESCRIPTION
in the virtual scroll table, adjusting column size by keyboard also scrolls the table

https://user-images.githubusercontent.com/4471489/225260914-2d76cc6c-d79f-4923-8495-42edec213fba.mov

