### PR TITLE
fix: align header content to bottom

### DIFF
--- a/src/table/virtualized-table/HeaderCell.tsx
+++ b/src/table/virtualized-table/HeaderCell.tsx
@@ -36,7 +36,7 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
         ...style,
         ...applicableStyle,
         display: 'flex',
-        alignItems: 'center',
+        alignItems: 'flex-end',
         borderStyle: 'solid',
         borderWidth: isLastColumn ? '0px 0px 1px 0px' : '0px 1px 1px 0px',
         padding: '4px',


### PR DESCRIPTION
for VT, align HeadCellContent to the bottom of the head cell. It use to be centered
![Screenshot 2023-03-20 at 09 49 32](https://user-images.githubusercontent.com/9249820/226290170-4e1499a8-1082-49da-a3b1-8afac7698ce8.png)
