### PR TITLE
fix: dimensions no longer have measure number formatting

### DIFF
--- a/src/ext/property-panel/data.js
+++ b/src/ext/property-panel/data.js
@@ -252,9 +252,6 @@ const dimensionItems = {
     translation: 'properties.dimensions.showNull',
     inverted: true,
   },
-  numberFormatting: {
-    uses: 'measures.items.numberFormatting',
-  },
   createMasterItemButton: {}, // To be filled by DataAssetsPanel in anlytics
   divider: { uses: 'divider' },
   dimensionLimits: {


### PR DESCRIPTION
Dimension number formatting is using measure number formatting that only works for measure, we need to make a new number formatting for dimensions that work but in the meanwhile we can remove this one.

Before: 
![Screenshot 2023-03-21 at 10 21 52](https://user-images.githubusercontent.com/8957233/226564586-9334107b-93a7-4bb0-bb9a-9b44f995023e.png)

Now:
![Screenshot 2023-03-21 at 10 21 25](https://user-images.githubusercontent.com/8957233/226564670-c7527200-0449-41b5-bdd3-1ce1a415eb55.png)

Heres a video that shows that number formatting works on measures but not on dimensions.
https://user-images.githubusercontent.com/8957233/226564951-3bf7ab9b-50aa-4ce5-84ed-3a944bf7bd0e.mov

