### PR TITLE
refactor: move rect to table context

### DIFF
--- a/src/__test__/test-with-providers.tsx
+++ b/src/__test__/test-with-providers.tsx
@@ -33,8 +33,8 @@ interface ProviderProps {
   embed?: stardust.Embed;
   changeSortOrder?: ChangeSortOrder;
   applyColumnWidths?: ApplyColumnWidths;
-  tableWidth?: number;
   initialDataPages?: EngineAPI.INxDataPage[];
+  rect?: stardust.Rect;
 }
 
 type HookWrapperProps = { children: JSX.Element };
@@ -68,7 +68,7 @@ const TestWithProviders = ({
   embed = {} as stardust.Embed,
   changeSortOrder = async () => {},
   applyColumnWidths = undefined,
-  tableWidth = 0,
+  rect = { width: 0, height: 0, top: 0, left: 0 },
   initialDataPages = undefined,
 }: ProviderProps) => {
   return (
@@ -89,7 +89,7 @@ const TestWithProviders = ({
         embed={embed}
         changeSortOrder={changeSortOrder}
         applyColumnWidths={applyColumnWidths}
-        tableWidth={tableWidth}
+        rect={rect}
         initialDataPages={initialDataPages}
       >
         {children as JSX.Element}

--- a/src/table/Root.tsx
+++ b/src/table/Root.tsx
@@ -29,6 +29,7 @@ export function renderPaginationTable(props: RenderProps, reactRoot?: ReactDom.R
     changeSortOrder,
     applyColumnWidths,
     tableData,
+    rect,
     ...wrapperProps
   } = props;
   const muiTheme = muiSetup(direction);
@@ -50,7 +51,7 @@ export function renderPaginationTable(props: RenderProps, reactRoot?: ReactDom.R
           embed={embed as stardust.Embed}
           changeSortOrder={changeSortOrder}
           applyColumnWidths={applyColumnWidths as ApplyColumnWidths}
-          tableWidth={props.rect.width}
+          rect={rect}
         >
           <TableWrapper {...(wrapperProps as TableWrapperProps)} />
         </TableContextProvider>
@@ -98,12 +99,12 @@ export function renderVirtualizedTable(props: VirtualTableRenderProps, reactRoot
           changeSortOrder={changeSortOrder}
           tableData={tableData}
           applyColumnWidths={applyColumnWidths}
-          tableWidth={rect.width}
+          rect={rect}
           setPage={setPage}
           pageInfo={pageInfo}
           initialDataPages={initialDataPages}
         >
-          <VirtualizedTable rect={rect} />
+          <VirtualizedTable />
         </TableContextProvider>
       </ThemeProvider>
     </React.StrictMode>

--- a/src/table/components/footer/PaginationContent.tsx
+++ b/src/table/components/footer/PaginationContent.tsx
@@ -45,13 +45,15 @@ function PaginationContent({
   setPageInfo,
   footerContainer,
   isSelectionMode,
-  rect,
   handleChangePage,
   announce,
 }: PaginationContentProps) {
   const { totalRowCount, totalColumnCount, totalPages } = useContextSelector(TableContext, (value) => value.tableData);
   const { page, rowsPerPage, rowsPerPageOptions } = pageInfo;
-  const { keyboard, translator, theme, constraints } = useContextSelector(TableContext, (value) => value.baseProps);
+  const { keyboard, translator, theme, constraints, rect } = useContextSelector(
+    TableContext,
+    (value) => value.baseProps
+  );
   const footerStyle = useMemo(() => getFooterStyle(theme.background), [theme]);
   const onFirstPage = page === 0;
   const onLastPage = page >= totalPages - 1;

--- a/src/table/components/footer/__tests__/PaginationContent.spec.tsx
+++ b/src/table/components/footer/__tests__/PaginationContent.spec.tsx
@@ -22,14 +22,13 @@ describe('<PaginationContent />', () => {
 
   const renderPagination = () =>
     render(
-      <TestWithProviders keyboard={keyboard} tableData={tableData}>
+      <TestWithProviders keyboard={keyboard} tableData={tableData} rect={rect}>
         <PaginationContent
           direction={direction}
           pageInfo={pageInfo}
           setPageInfo={setPageInfo}
           footerContainer={footerContainer}
           isSelectionMode={isSelectionMode}
-          rect={rect}
           handleChangePage={handleChangePage}
           announce={announce}
         />

--- a/src/table/context/TableContext.tsx
+++ b/src/table/context/TableContext.tsx
@@ -38,7 +38,7 @@ export const TableContextProvider = ({
   setPage,
   pageInfo,
   initialDataPages,
-  tableWidth = 0,
+  rect,
 }: ContextProviderProps) => {
   const [headRowHeight, setHeadRowHeight] = useState(0);
   const [focusedCellCoord, setFocusedCellCoord] = useState<[number, number]>(cellCoordMock || FIRST_HEADER_CELL_COORD);
@@ -48,7 +48,7 @@ export const TableContextProvider = ({
   const [columnWidths, setColumnWidths, setYScrollbarWidth, showRightBorder] = useColumnWidths(
     tableData.columns,
     tableData.totalsPosition,
-    tableWidth,
+    rect.width,
     styling
   );
   const baseProps = useMemo(
@@ -66,6 +66,7 @@ export const TableContextProvider = ({
       changeSortOrder,
       applyColumnWidths,
       styling,
+      rect,
     }),
     [
       app,
@@ -81,6 +82,7 @@ export const TableContextProvider = ({
       changeSortOrder,
       applyColumnWidths,
       styling,
+      rect,
     ]
   );
 

--- a/src/table/pagination-table/components/TableWrapper.tsx
+++ b/src/table/pagination-table/components/TableWrapper.tsx
@@ -23,7 +23,7 @@ function TableWrapper(props: TableWrapperProps) {
 
   const { totalColumnCount, totalRowCount, totalPages, paginationNeeded, rows, columns, totalsPosition } =
     useContextSelector(TableContext, (value) => value.tableData);
-  const { selectionsAPI, rootElement, keyboard, translator, theme, constraints, styling } = useContextSelector(
+  const { selectionsAPI, rootElement, keyboard, translator, theme, constraints, styling, rect } = useContextSelector(
     TableContext,
     (value) => value.baseProps
   );
@@ -132,7 +132,12 @@ function TableWrapper(props: TableWrapperProps) {
       </StyledTableContainer>
       {!constraints.active && (
         <FooterWrapper footerContainer={footerContainer} paginationNeeded={paginationNeeded}>
-          <PaginationContent {...props} handleChangePage={handleChangePage} isSelectionMode={isSelectionMode} />
+          <PaginationContent
+            {...props}
+            rect={rect}
+            handleChangePage={handleChangePage}
+            isSelectionMode={isSelectionMode}
+          />
         </FooterWrapper>
       )}
     </StyledTableWrapper>

--- a/src/table/pagination-table/components/TableWrapper.tsx
+++ b/src/table/pagination-table/components/TableWrapper.tsx
@@ -23,7 +23,7 @@ function TableWrapper(props: TableWrapperProps) {
 
   const { totalColumnCount, totalRowCount, totalPages, paginationNeeded, rows, columns, totalsPosition } =
     useContextSelector(TableContext, (value) => value.tableData);
-  const { selectionsAPI, rootElement, keyboard, translator, theme, constraints, styling, rect } = useContextSelector(
+  const { selectionsAPI, rootElement, keyboard, translator, theme, constraints, styling } = useContextSelector(
     TableContext,
     (value) => value.baseProps
   );
@@ -132,12 +132,7 @@ function TableWrapper(props: TableWrapperProps) {
       </StyledTableContainer>
       {!constraints.active && (
         <FooterWrapper footerContainer={footerContainer} paginationNeeded={paginationNeeded}>
-          <PaginationContent
-            {...props}
-            rect={rect}
-            handleChangePage={handleChangePage}
-            isSelectionMode={isSelectionMode}
-          />
+          <PaginationContent {...props} handleChangePage={handleChangePage} isSelectionMode={isSelectionMode} />
         </FooterWrapper>
       )}
     </StyledTableWrapper>

--- a/src/table/pagination-table/components/__tests__/TableWrapper.spec.tsx
+++ b/src/table/pagination-table/components/__tests__/TableWrapper.spec.tsx
@@ -23,11 +23,16 @@ describe('<TableWrapper />', () => {
 
   const renderTableWrapper = () =>
     render(
-      <TestWithProviders layout={layout} constraints={constraints} rootElement={rootElement} tableData={tableData}>
+      <TestWithProviders
+        layout={layout}
+        constraints={constraints}
+        rootElement={rootElement}
+        tableData={tableData}
+        rect={rect}
+      >
         <TableWrapper
           pageInfo={pageInfo}
           setPageInfo={setPageInfo}
-          rect={rect}
           direction={direction}
           announce={announce}
           areBasicFeaturesEnabled={areBasicFeaturesEnabled}

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -116,6 +116,7 @@ export interface ContextValue {
     changeSortOrder: ChangeSortOrder;
     applyColumnWidths?: ApplyColumnWidths;
     styling: TableStyling;
+    rect: stardust.Rect;
   };
   tableData: TableData;
   setYScrollbarWidth: (width: number) => void;
@@ -220,7 +221,7 @@ export interface ContextProviderProps {
   embed: stardust.Embed;
   changeSortOrder: ChangeSortOrder;
   applyColumnWidths?: ApplyColumnWidths;
-  tableWidth?: number;
+  rect: stardust.Rect;
   pageInfo?: PageInfo;
   setPage?: stardust.SetStateFn<number>;
   initialDataPages?: EngineAPI.INxDataPage[];
@@ -257,7 +258,6 @@ export interface RenderProps {
 
 export interface TableWrapperProps {
   direction?: Direction;
-  rect: stardust.Rect;
   pageInfo: PageInfo;
   setPageInfo: SetPageInfo;
   footerContainer?: HTMLElement;

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -302,7 +302,6 @@ export interface TableBodyWrapperProps {
 
 export interface PaginationContentProps {
   direction?: 'ltr' | 'rtl';
-  rect: stardust.Rect;
   pageInfo: PageInfo;
   setPageInfo: SetPageInfo;
   footerContainer?: HTMLElement;

--- a/src/table/virtualized-table/Wrapper.tsx
+++ b/src/table/virtualized-table/Wrapper.tsx
@@ -5,11 +5,10 @@ import { StyledTableWrapper } from '../components/styles';
 import FooterWrapper from '../components/footer/FooterWrapper';
 import Table from './Table';
 import { TableContext, useContextSelector } from '../context';
-import { WrapperProps } from './types';
 import { PageInfo } from '../../types';
 
-const Wrapper = ({ rect }: WrapperProps) => {
-  const { theme } = useContextSelector(TableContext, (value) => value.baseProps);
+const Wrapper = () => {
+  const { theme, rect } = useContextSelector(TableContext, (value) => value.baseProps);
   const { paginationNeeded } = useContextSelector(TableContext, (value) => value.tableData);
   const pageInfo = useContextSelector(TableContext, (value) => value.pageInfo) as PageInfo;
   const setPage = useContextSelector(TableContext, (value) => value.setPage) as stardust.SetStateFn<number>;

--- a/src/table/virtualized-table/Wrapper.tsx
+++ b/src/table/virtualized-table/Wrapper.tsx
@@ -23,7 +23,6 @@ const Wrapper = () => {
             isSelectionMode={false}
             pageInfo={pageInfo}
             setPageInfo={() => {}}
-            rect={rect}
             announce={() => {}}
           />
         </FooterWrapper>

--- a/src/table/virtualized-table/__tests__/Table.spec.tsx
+++ b/src/table/virtualized-table/__tests__/Table.spec.tsx
@@ -45,7 +45,7 @@ describe('<Table />', () => {
           constraints={constraints}
           tableData={tableData}
           rootElement={rootElement}
-          tableWidth={rect.width}
+          rect={rect}
           initialDataPages={initialDataPages}
         >
           <TestableTable pageInfo={pageInfo} rect={rect} />

--- a/src/table/virtualized-table/__tests__/Wrapper.spec.tsx
+++ b/src/table/virtualized-table/__tests__/Wrapper.spec.tsx
@@ -33,8 +33,8 @@ describe('<Wrapper />', () => {
     };
 
     render(
-      <TestWithProviders layout={layout} tableData={tableData}>
-        <Wrapper rect={rect} />
+      <TestWithProviders layout={layout} tableData={tableData} rect={rect}>
+        <Wrapper />
       </TestWithProviders>
     );
   };

--- a/src/table/virtualized-table/types/index.ts
+++ b/src/table/virtualized-table/types/index.ts
@@ -47,10 +47,6 @@ export interface VirtualTableRenderProps {
   initialDataPages: EngineAPI.INxDataPage[];
 }
 
-export interface WrapperProps {
-  rect: stardust.Rect;
-}
-
 export interface TableProps {
   rect: stardust.Rect;
   pageInfo: PageInfo;


### PR DESCRIPTION
Moves the rect to the TableContext. It's required for fixing another issue, otherwise the VT table will run in to issue with the `columnWidths` and `rect` being out-of-sync.