### PR TITLE
fix: reset scroll position on theme change

### DIFF
--- a/src/table/virtualized-table/Table.tsx
+++ b/src/table/virtualized-table/Table.tsx
@@ -80,11 +80,12 @@ const Table = (props: TableProps) => {
     }
   }, [columns.length]);
 
+  const themeName = theme.name();
   useLayoutEffect(() => {
     if (ref.current) {
       ref.current.scrollTop = 0;
     }
-  }, [pageInfo, rowCount]);
+  }, [pageInfo, rowCount, themeName]);
 
   useDidUpdateEffect(() => {
     setYScrollbarWidth(yScrollbarWidth);


### PR DESCRIPTION
Reset scroll position on theme change. This is how the old native table in Qlik Sense acts on theme change. It will also make the fix for wrong cell heights on theme changes easier.