### PR TITLE
refactor: structuring `getColumnInfo` and text alignment logic

### DIFF
--- a/src/__test__/handle-data.spec.ts
+++ b/src/__test__/handle-data.spec.ts
@@ -29,9 +29,9 @@ describe('handle-data', () => {
       isLocked,
       qApprMaxGlyphCount: 3,
       qReverseSort: false,
-      textAlign: 'auto',
-      totalsCellTextAlign: 'left',
-      headCellTextAlign: 'right',
+      bodyTextAlign: 'auto',
+      totalsTextAlign: 'left',
+      headTextAlign: 'right',
     });
 
     it('should return column info for dimension', () => {
@@ -42,9 +42,9 @@ describe('handle-data', () => {
     it('should return column info for dimension with align center', () => {
       layout.qHyperCube.qDimensionInfo[colIdx].textAlign = { auto: false, align: 'center' };
       const expected = getExpectedInfo(true);
-      expected.textAlign = 'center';
-      expected.headCellTextAlign = 'center';
-      expected.totalsCellTextAlign = 'center';
+      expected.bodyTextAlign = 'center';
+      expected.headTextAlign = 'center';
+      expected.totalsTextAlign = 'center';
 
       const columnInfo = getColumnInfo(layout, colIdx, pageColIdx);
       expect(columnInfo).toEqual(expected);
@@ -54,7 +54,7 @@ describe('handle-data', () => {
       layout.qHyperCube.qDimensionInfo[colIdx].qDimensionType = 'N';
       const columnInfo = getColumnInfo(layout, colIdx, pageColIdx);
       const expected = getExpectedInfo(true);
-      expected.headCellTextAlign = 'right';
+      expected.headTextAlign = 'right';
 
       expect(columnInfo).toEqual(expected);
     });
@@ -93,7 +93,7 @@ describe('handle-data', () => {
       colIdx = 3;
       const columnInfo = getColumnInfo(layout, colIdx, pageColIdx);
       const expected = getExpectedInfo(false, undefined, false, '200');
-      expected.totalsCellTextAlign = 'right';
+      expected.totalsTextAlign = 'right';
 
       expect(columnInfo).toEqual(expected);
     });

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -61,7 +61,7 @@ export function getTotalInfo(layout: TableLayout, colIdx: number, pageColIdx: nu
 
 /**
  * Gets the totals alignment for head, totals and body
- * bodyTextAlign is later used to determine independent call alignment for each body cell
+ * bodyTextAlign is later used to determine independent alignment for each body cell
  */
 export function getAlignInfo(
   textAlign: TextAlign,
@@ -90,7 +90,7 @@ export const getBodyCellAlign = (cell: EngineAPI.INxCell, textAlign: Align | 'au
 /**
  * Gets all column info, returns false if hidden
  */
-export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: number): Column | false {
+export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: number): false | Column {
   const { qDimensionInfo, qMeasureInfo } = layout.qHyperCube;
   const numDims = qDimensionInfo.length;
   const isDim = colIdx < numDims;

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -1,4 +1,3 @@
-import { getBodyCellAlign } from './table/utils/styling-utils';
 import {
   TableLayout,
   PageInfo,
@@ -8,6 +7,8 @@ import {
   ExtendedNxDimensionInfo,
   Column,
   TableData,
+  Align,
+  TextAlign,
 } from './types';
 
 const MAX_CELLS = 10000;
@@ -59,17 +60,57 @@ export function getTotalInfo(layout: TableLayout, colIdx: number, pageColIdx: nu
 }
 
 /**
+ * Gets the totals alignment for head, totals and body
+ * bodyTextAlign is later used to determine independent call alignment for each body cell
+ */
+export function getAlignInfo(
+  textAlign: TextAlign,
+  qDimensionType: EngineAPI.DimensionType | undefined,
+  isDim: boolean
+) {
+  const autoHeadTextAlign = qDimensionType === 'N' || qDimensionType === undefined ? 'right' : 'left';
+  const autoTotalsTextAlign = isDim ? 'left' : 'right';
+  const headTextAlign: Align = !textAlign || textAlign.auto ? autoHeadTextAlign : textAlign.align;
+  const totalsTextAlign: Align = !textAlign || textAlign.auto ? autoTotalsTextAlign : textAlign.align;
+  const bodyTextAlign: Align | 'auto' = !textAlign || textAlign.auto ? 'auto' : textAlign.align;
+
+  return { headTextAlign, totalsTextAlign, bodyTextAlign };
+}
+
+/**
+ * Gets the correct text alignment for body cells, based on the text alignment info from the column and cell content
+ */
+export const getBodyCellAlign = (cell: EngineAPI.INxCell, textAlign: Align | 'auto') => {
+  if (textAlign === 'auto') {
+    return ((cell.qNum || cell.qNum === 0) && !Number.isNaN(+cell.qNum) ? 'right' : 'left') as Align;
+  }
+  return textAlign;
+};
+
+/**
  * Gets all column info, returns false if hidden
  */
-export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: number): false | Column {
+export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: number): Column {
   const { qDimensionInfo, qMeasureInfo } = layout.qHyperCube;
   const numDims = qDimensionInfo.length;
   const isDim = colIdx < numDims;
   const info = (isDim ? qDimensionInfo[colIdx] : qMeasureInfo[colIdx - numDims]) as
     | ExtendedNxMeasureInfo
     | ExtendedNxDimensionInfo;
+
+  let fieldIndex = 0;
+  let fieldId = '';
+  let isLocked = false;
+  let qDimensionType;
+  if (isDim) {
+    const dimInfo = info as ExtendedNxDimensionInfo;
+    fieldIndex = dimInfo.qGroupPos;
+    fieldId = dimInfo.qGroupFieldDefs[fieldIndex];
+    isLocked = dimInfo.qLocked;
+    ({ qDimensionType } = dimInfo);
+  }
+
   const {
-    qError,
     qFallbackTitle,
     textAlign,
     qAttrExprInfo,
@@ -79,43 +120,25 @@ export function getColumnInfo(layout: TableLayout, colIdx: number, pageColIdx: n
     columnWidth,
     qLibraryId,
   } = info;
-  const isHidden = qError?.qErrorCode === 7005;
-  const isLocked = isDim && (info as ExtendedNxDimensionInfo).qLocked;
-  const { qDimensionType } = info as ExtendedNxDimensionInfo;
-  const autoHeadCellTextAlign = qDimensionType === 'N' || qDimensionType === undefined ? 'right' : 'left';
-  const headCellTextAlign = !textAlign || textAlign.auto ? autoHeadCellTextAlign : textAlign.align;
-  const autoTotalsCellTextAlign = isDim ? 'left' : 'right';
-  const totalsCellTextAlign = !textAlign || textAlign.auto ? autoTotalsCellTextAlign : textAlign.align;
 
-  let fieldIndex = 0;
-  let fieldId = '';
-  if (isDim) {
-    fieldIndex = (info as ExtendedNxDimensionInfo).qGroupPos;
-    fieldId = (info as ExtendedNxDimensionInfo).qGroupFieldDefs[fieldIndex];
-  }
-
-  return (
-    !isHidden && {
-      isDim,
-      isLocked,
-      fieldId,
-      colIdx,
-      qLibraryId,
-      pageColIdx,
-      qApprMaxGlyphCount,
-      qReverseSort,
-      columnWidth,
-      id: `col-${pageColIdx}`,
-      label: qFallbackTitle,
-      headCellTextAlign,
-      totalsCellTextAlign,
-      textAlign: !textAlign || textAlign.auto ? 'auto' : textAlign.align,
-      stylingIDs: qAttrExprInfo.map((expr) => expr.id),
-      // making sure that qSortIndicator is either A or D
-      sortDirection: qSortIndicator && qSortIndicator !== 'N' ? qSortIndicator : 'A',
-      totalInfo: getTotalInfo(layout, colIdx, pageColIdx, numDims),
-    }
-  );
+  return {
+    isDim,
+    isLocked,
+    fieldId,
+    colIdx,
+    qLibraryId,
+    pageColIdx,
+    qApprMaxGlyphCount,
+    qReverseSort,
+    columnWidth,
+    id: `col-${pageColIdx}`,
+    label: qFallbackTitle,
+    stylingIDs: qAttrExprInfo.map((expr) => expr.id),
+    // making sure that qSortIndicator is either A or D
+    sortDirection: qSortIndicator && qSortIndicator !== 'N' ? qSortIndicator : 'A',
+    totalInfo: getTotalInfo(layout, colIdx, pageColIdx, numDims),
+    ...getAlignInfo(textAlign, qDimensionType, isDim),
+  };
 }
 
 /**
@@ -126,10 +149,16 @@ export const getColumns = (layout: TableLayout) => {
   const {
     qHyperCube: { qColumnOrder, qDimensionInfo, qMeasureInfo },
   } = layout;
-  const columnsLength = qDimensionInfo.length + qMeasureInfo.length;
+  const numDims = qDimensionInfo.length;
+  const columnsLength = numDims + qMeasureInfo.length;
   const columnOrder = qColumnOrder?.length === columnsLength ? qColumnOrder : Array.from(Array(columnsLength).keys());
 
-  return columnOrder.map((colIdx, pageColIdx) => getColumnInfo(layout, colIdx, pageColIdx)).filter(Boolean) as Column[];
+  const visibleColumnsOrder = columnOrder.filter((colIdx) => {
+    const { qError } = colIdx < numDims ? qDimensionInfo[colIdx] : qMeasureInfo[colIdx - numDims];
+    return qError?.qErrorCode !== 7005;
+  });
+
+  return visibleColumnsOrder.map((colIdx, pageColIdx) => getColumnInfo(layout, colIdx, pageColIdx));
 };
 
 /**
@@ -176,7 +205,7 @@ export default async function manageData(
     columns.forEach((c, pageColIdx) => {
       row[c.id] = {
         ...r[pageColIdx],
-        align: getBodyCellAlign(r[pageColIdx], c.textAlign),
+        align: getBodyCellAlign(r[pageColIdx], c.bodyTextAlign),
         rowIdx: pageRowIdx + top,
         colIdx: c.colIdx,
         pageRowIdx,

--- a/src/handle-data.ts
+++ b/src/handle-data.ts
@@ -67,24 +67,27 @@ export function getAlignInfo(
   textAlign: TextAlign,
   qDimensionType: EngineAPI.DimensionType | undefined,
   isDim: boolean
-) {
-  const autoHeadTextAlign = qDimensionType === 'N' || qDimensionType === undefined ? 'right' : 'left';
-  const autoTotalsTextAlign = isDim ? 'left' : 'right';
-  const headTextAlign: Align = !textAlign || textAlign.auto ? autoHeadTextAlign : textAlign.align;
-  const totalsTextAlign: Align = !textAlign || textAlign.auto ? autoTotalsTextAlign : textAlign.align;
-  const bodyTextAlign: Align | 'auto' = !textAlign || textAlign.auto ? 'auto' : textAlign.align;
+): { headTextAlign: Align; totalsTextAlign: Align; bodyTextAlign: Align | 'auto' } {
+  if (textAlign && !textAlign.auto) {
+    return { headTextAlign: textAlign.align, totalsTextAlign: textAlign.align, bodyTextAlign: textAlign.align };
+  }
 
-  return { headTextAlign, totalsTextAlign, bodyTextAlign };
+  return {
+    headTextAlign: qDimensionType === 'N' || qDimensionType === undefined ? 'right' : 'left',
+    totalsTextAlign: isDim ? 'left' : 'right',
+    bodyTextAlign: 'auto',
+  };
 }
 
 /**
  * Gets the correct text alignment for body cells, based on the text alignment info from the column and cell content
  */
 export const getBodyCellAlign = (cell: EngineAPI.INxCell, textAlign: Align | 'auto') => {
-  if (textAlign === 'auto') {
-    return ((cell.qNum || cell.qNum === 0) && !Number.isNaN(+cell.qNum) ? 'right' : 'left') as Align;
+  if (textAlign !== 'auto') {
+    return textAlign;
   }
-  return textAlign;
+
+  return ((cell.qNum || cell.qNum === 0) && !Number.isNaN(+cell.qNum) ? 'right' : 'left') as Align;
 };
 
 /**

--- a/src/table/components/head/HeadCellContent.tsx
+++ b/src/table/components/head/HeadCellContent.tsx
@@ -37,14 +37,14 @@ function HeadCellContent({ children, column, isActive, areBasicFeaturesEnabled }
     <StyledHeadCellContent
       onKeyDown={onKeyDown}
       isLocked={Boolean(lockIcon)}
-      className={`aligned-${column.headCellTextAlign}`}
+      className={`aligned-${column.headTextAlign}`}
     >
       {lockIcon && <StyledHeadCellIconWrapper>{lockIcon}</StyledHeadCellIconWrapper>}
 
       <StyledSortButton
         className="sn-table-head-label"
         isActive={isActive}
-        textAlign={column.headCellTextAlign}
+        textAlign={column.headTextAlign}
         title={!constraints.passive ? FullSortDirection[column.sortDirection] : undefined} // passive: turn off tooltips.
         color="inherit"
         size="small"

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -162,7 +162,7 @@ export default function HeadCellMenu({ column, tabIndex }: HeadCellMenuProps) {
   );
 
   return menuItemGroups.length ? (
-    <HeadCellMenuWrapper rightAligned={column.headCellTextAlign === 'right'}>
+    <HeadCellMenuWrapper rightAligned={column.headTextAlign === 'right'}>
       <StyledMenuIconButton
         isVisible={openListboxDropdown || openMenuDropdown}
         ref={anchorRef}

--- a/src/table/components/head/__tests__/HeadCellContent.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellContent.spec.tsx
@@ -34,9 +34,9 @@ describe('<HeadCellContent />', () => {
   beforeEach(() => {
     column = {
       id: '1',
-      headCellTextAlign: 'left',
-      totalsCellTextAlign: 'left',
-      textAlign: 'left',
+      headTextAlign: 'left',
+      totalsTextAlign: 'left',
+      bodyTextAlign: 'left',
       label: 'someDim',
       sortDirection: 'A',
       isDim: true,

--- a/src/table/hooks/use-selection-reducer.ts
+++ b/src/table/hooks/use-selection-reducer.ts
@@ -14,7 +14,7 @@ const useSelectionReducer = (
     pageRows,
     rows: {},
     colIdx: -1,
-    api: selectionsAPI as ExtendedSelectionAPI, // TODO: update nebula api with correct selection api type
+    api: selectionsAPI,
     isSelectMultiValues: false,
   });
 

--- a/src/table/pagination-table/components/body/TableTotals.tsx
+++ b/src/table/pagination-table/components/body/TableTotals.tsx
@@ -32,7 +32,7 @@ function TableTotals() {
             headRowHeight={headRowHeight}
             atTop={atTop}
             key={column.id}
-            align={column.totalsCellTextAlign}
+            align={column.totalsTextAlign}
             className="sn-table-cell"
             tabIndex={tabIndex}
             onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {

--- a/src/table/pagination-table/components/head/TableHeadWrapper.tsx
+++ b/src/table/pagination-table/components/head/TableHeadWrapper.tsx
@@ -47,7 +47,7 @@ function TableHeadWrapper({ areBasicFeaturesEnabled }: TableHeadWrapperProps) {
             <StyledHeadCell
               headerStyle={{ ...styling.head, ...widthStyle }}
               key={column.id}
-              align={column.headCellTextAlign}
+              align={column.headTextAlign}
               className="sn-table-head-cell sn-table-cell"
               aria-sort={ariaSort}
               tabIndex={-1}

--- a/src/table/utils/__tests__/get-head-icons.spec.tsx
+++ b/src/table/utils/__tests__/get-head-icons.spec.tsx
@@ -8,7 +8,7 @@ import { Column } from '../../../types';
 import { DEFAULT_FONT_SIZE } from '../../styling-defaults';
 import { LockWrapper } from '../../components/head/styles';
 
-describe('getHeadIcons', () => {
+describe('get-head-icons', () => {
   const ascending = <Ascending height={DEFAULT_FONT_SIZE} />;
   const descending = <Descending height={DEFAULT_FONT_SIZE} />;
   const lock = (
@@ -22,7 +22,7 @@ describe('getHeadIcons', () => {
     column = {
       sortDirection: 'A',
       isLocked: false,
-      headCellTextAlign: 'left',
+      headTextAlign: 'left',
     } as Column;
   });
 
@@ -39,14 +39,14 @@ describe('getHeadIcons', () => {
   });
 
   it('should return ascending as endIcon and no lock icon when sortDirection i A and align is right', () => {
-    column.headCellTextAlign = 'right';
+    column.headTextAlign = 'right';
 
     const icons = getHeadIcons(column);
     expect(icons).toEqual({ startIcon: ascending, lockIcon: undefined });
   });
 
   it('should return descending as endIcon and no lock icon when sortDirection i D and align is right', () => {
-    column.headCellTextAlign = 'right';
+    column.headTextAlign = 'right';
     column.sortDirection = 'D';
 
     const icons = getHeadIcons(column);

--- a/src/table/utils/get-head-icons.tsx
+++ b/src/table/utils/get-head-icons.tsx
@@ -6,15 +6,15 @@ import { Column } from '../../types';
 import { DEFAULT_FONT_SIZE } from '../styling-defaults';
 import { LockWrapper } from '../components/head/styles';
 
-const getHeadIcons = ({ sortDirection, isLocked, headCellTextAlign }: Column) => {
+const getHeadIcons = ({ sortDirection, isLocked, headTextAlign }: Column) => {
   const sortIcon =
     sortDirection === 'A' ? <Ascending height={DEFAULT_FONT_SIZE} /> : <Descending height={DEFAULT_FONT_SIZE} />;
   const lockIcon = isLocked ? (
-    <LockWrapper className={`aligned-${headCellTextAlign}`}>
+    <LockWrapper className={`aligned-${headTextAlign}`}>
       <Lock height={DEFAULT_FONT_SIZE} data-testid="head-cell-lock-icon" />
     </LockWrapper>
   ) : undefined;
-  return headCellTextAlign === 'right' ? { startIcon: sortIcon, lockIcon } : { endIcon: sortIcon, lockIcon };
+  return headTextAlign === 'right' ? { startIcon: sortIcon, lockIcon } : { endIcon: sortIcon, lockIcon };
 };
 
 export default getHeadIcons;

--- a/src/table/utils/styling-utils.ts
+++ b/src/table/utils/styling-utils.ts
@@ -1,15 +1,7 @@
 import { stardust } from '@nebula.js/stardust';
 
 import { resolveToRGBAorRGB, isDarkColor, removeOpacity } from './color-utils';
-import {
-  TableLayout,
-  ExtendedTheme,
-  HeaderStyling,
-  ContentStyling,
-  PaletteColor,
-  BackgroundColors,
-  Align,
-} from '../../types';
+import { TableLayout, ExtendedTheme, HeaderStyling, ContentStyling, PaletteColor, BackgroundColors } from '../../types';
 import { GeneratedStyling, CellStyle, FooterStyle } from '../types';
 import { SelectionStates, PAGINATION_HEIGHT } from '../constants';
 import { SELECTION_STYLING, COLORING } from '../styling-defaults';
@@ -318,10 +310,3 @@ export function getSelectionStyle(styling: CellStyle, cellSelectionState: Select
     ...selectionStyling,
   };
 }
-
-export const getBodyCellAlign = (cell: EngineAPI.INxCell, textAlign: Align | 'auto') => {
-  if (textAlign === 'auto') {
-    return ((cell.qNum || cell.qNum === 0) && !Number.isNaN(+cell.qNum) ? 'right' : 'left') as Align;
-  }
-  return textAlign;
-};

--- a/src/table/virtualized-table/HeaderCell.tsx
+++ b/src/table/virtualized-table/HeaderCell.tsx
@@ -28,7 +28,7 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
   const column = columns[index];
   const isLastColumn = columns.length - 1 === index;
   const isActive = layout.qHyperCube.qEffectiveInterColumnSortOrder[0] === column.colIdx;
-  const flexDirection = column.headCellTextAlign === 'right' ? 'row-reverse' : 'row';
+  const flexDirection = column.headTextAlign === 'right' ? 'row-reverse' : 'row';
 
   return (
     <div
@@ -41,7 +41,7 @@ const HeaderCell = ({ index, style, data }: HeaderCellProps) => {
         borderStyle: 'solid',
         borderWidth: isLastColumn && !showRightBorder ? '0px 0px 1px 0px' : '0px 1px 1px 0px',
         padding: '4px',
-        justifyContent: column.headCellTextAlign,
+        justifyContent: column.headTextAlign,
         boxSizing: 'border-box',
         cursor: 'default',
         zIndex: columns.length - index,

--- a/src/table/virtualized-table/TotalsCell.tsx
+++ b/src/table/virtualized-table/TotalsCell.tsx
@@ -24,7 +24,7 @@ const TotalsCell = ({ index, style, data }: TotalsCellProps) => {
     totals,
   } = data;
   const label = columns[index].totalInfo;
-  const { totalsCellTextAlign } = columns[index];
+  const { totalsTextAlign } = columns[index];
   const isLastColumn = layout.qHyperCube.qSize.qcx - 1 === index;
 
   return (
@@ -41,7 +41,7 @@ const TotalsCell = ({ index, style, data }: TotalsCellProps) => {
         borderTopWidth: totals.atBottom ? '1px' : '0px',
         borderBottomWidth: totals.atTop ? '1px' : '0px',
         padding: '4px 12px',
-        justifyContent: totalsCellTextAlign,
+        justifyContent: totalsTextAlign,
         boxSizing: 'border-box',
         cursor: 'default',
         fontWeight: '600',

--- a/src/table/virtualized-table/hooks/use-data/utils/index.ts
+++ b/src/table/virtualized-table/hooks/use-data/utils/index.ts
@@ -1,4 +1,4 @@
-import { getBodyCellAlign } from '../../../../utils/styling-utils';
+import { getBodyCellAlign } from '../../../../../handle-data';
 import { Cell, Column, PageInfo, Row, TableLayout } from '../../../../../types';
 import { SetCellSize } from '../../../types';
 
@@ -18,11 +18,11 @@ const createRow = (
 
   cells.forEach((cell, cellColIdx: number) => {
     const pageColIdx = cellColIdx + qArea.qLeft;
-    const { colIdx, isDim, isLocked, id, textAlign } = columns[pageColIdx];
+    const { colIdx, isDim, isLocked, id, bodyTextAlign } = columns[pageColIdx];
 
     row[id] = {
       ...cell,
-      align: getBodyCellAlign(cell, textAlign),
+      align: getBodyCellAlign(cell, bodyTextAlign),
       rowIdx,
       colIdx,
       isSelectable: isDim && !isLocked,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { stardust } from '@nebula.js/stardust';
 
 export type Align = 'left' | 'center' | 'right';
 
-interface TextAlign {
+export interface TextAlign {
   auto: boolean;
   align: 'left' | 'center' | 'right';
 }
@@ -128,9 +128,9 @@ export interface Column {
   colIdx: number;
   pageColIdx: number;
   label: string;
-  headCellTextAlign: Align;
-  totalsCellTextAlign: Align;
-  textAlign: 'auto' | Align;
+  headTextAlign: Align;
+  totalsTextAlign: Align;
+  bodyTextAlign: 'auto' | Align;
   stylingIDs: string[];
   sortDirection: SortDirection;
   qReverseSort: boolean;


### PR DESCRIPTION
We have added things to getColumnInfo incrementally and it has become pretty unstructured and complex. There was some weird casting going on etc. This is mostly to prepare for a bug fix, I just broke this part out.
- renaming align props to more similar names
- moving all alignment logic to functions inside handle-data
- do all dimension specific props in on if in getColumnInfo