### PR TITLE
refactor: remove unused code for sorting

### DIFF
--- a/src/nebula-hooks/__tests__/use-sorting.spec.ts
+++ b/src/nebula-hooks/__tests__/use-sorting.spec.ts
@@ -41,7 +41,7 @@ describe('use-sorting', () => {
       expectedPatches = [
         {
           qPath: '/qHyperCubeDef/qInterColumnSortOrder',
-          qOp: 'Replace' as EngineAPI.NxPatchOpType,
+          qOp: 'Replace',
           qValue: '[1,0,2,3]',
         },
       ];
@@ -55,7 +55,7 @@ describe('use-sorting', () => {
       expectedPatches = [
         {
           qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
-          qOp: 'Replace' as EngineAPI.NxPatchOpType,
+          qOp: 'Replace',
           qValue: 'true',
         },
       ];
@@ -71,7 +71,7 @@ describe('use-sorting', () => {
       expectedPatches = [
         {
           qPath: '/qHyperCubeDef/qMeasures/0/qDef/qReverseSort',
-          qOp: 'Replace' as EngineAPI.NxPatchOpType,
+          qOp: 'Replace',
           qValue: 'true',
         },
       ];

--- a/src/nebula-hooks/__tests__/use-sorting.spec.ts
+++ b/src/nebula-hooks/__tests__/use-sorting.spec.ts
@@ -1,6 +1,6 @@
 import { sortingFactory } from '../use-sorting';
 import { generateLayout } from '../../__test__/generate-test-data';
-import { Column, TableLayout, HyperCube, SortDirection } from '../../types';
+import { Column, TableLayout, HyperCube, SortDirection, ChangeSortOrder } from '../../types';
 
 describe('use-sorting', () => {
   describe('sortingFactory', () => {
@@ -16,7 +16,7 @@ describe('use-sorting', () => {
     let column: Column;
     let layout: TableLayout;
     let model: EngineAPI.IGenericObject;
-    let changeSortOrder: ((column: Column, sortDirection?: SortDirection) => Promise<void>) | undefined;
+    let changeSortOrder: (column: Column, sortDirection?: SortDirection) => Promise<void>;
     let expectedPatches: EngineAPI.INxPatch[];
 
     beforeEach(() => {
@@ -32,38 +32,35 @@ describe('use-sorting', () => {
             } as unknown as HyperCube,
           }),
       } as unknown as EngineAPI.IGenericObject;
-      changeSortOrder = sortingFactory(model, layout.qHyperCube.qDimensionInfo.length);
-      expectedPatches = [
-        {
-          qPath: '/qHyperCubeDef/qInterColumnSortOrder',
-          qOp: 'Replace' as EngineAPI.NxPatchOpType,
-          qValue: '[0,1,2,3]',
-        },
-      ];
+      changeSortOrder = sortingFactory(model, layout.qHyperCube.qDimensionInfo.length) as ChangeSortOrder;
     });
 
     afterEach(() => jest.clearAllMocks());
 
-    it('should call apply patches with second dimension first in sort order', async () => {
-      expectedPatches[0].qValue = '[1,0,2,3]';
+    it('should call apply patches with patch for second dimension first in sort order', async () => {
+      expectedPatches = [
+        {
+          qPath: '/qHyperCubeDef/qInterColumnSortOrder',
+          qOp: 'Replace' as EngineAPI.NxPatchOpType,
+          qValue: '[1,0,2,3]',
+        },
+      ];
 
-      if (changeSortOrder) {
-        await changeSortOrder(column);
-      }
+      await changeSortOrder(column);
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
 
-    it('should call apply patches with another patch for qReverseSort for dimension', async () => {
+    it('should call apply patches with patch for qReverseSort for dimension', async () => {
       column.colIdx = 0;
-      expectedPatches.push({
-        qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
-        qOp: 'Replace' as EngineAPI.NxPatchOpType,
-        qValue: 'true',
-      });
+      expectedPatches = [
+        {
+          qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
+          qOp: 'Replace' as EngineAPI.NxPatchOpType,
+          qValue: 'true',
+        },
+      ];
 
-      if (changeSortOrder) {
-        await changeSortOrder(column);
-      }
+      await changeSortOrder(column);
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
 
@@ -71,62 +68,15 @@ describe('use-sorting', () => {
       column = { isDim: false, colIdx: 2, qReverseSort: false } as Column;
       originalOrder = [2, 0, 1, 3];
       expectedPatches[0].qValue = '[2,0,1,3]';
-      expectedPatches.push({
-        qPath: '/qHyperCubeDef/qMeasures/0/qDef/qReverseSort',
-        qOp: 'Replace' as EngineAPI.NxPatchOpType,
-        qValue: 'true',
-      });
+      expectedPatches = [
+        {
+          qPath: '/qHyperCubeDef/qMeasures/0/qDef/qReverseSort',
+          qOp: 'Replace' as EngineAPI.NxPatchOpType,
+          qValue: 'true',
+        },
+      ];
 
-      if (changeSortOrder) {
-        await changeSortOrder(column);
-      }
-      expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
-    });
-
-    it('should not apply patches for qReverseSort for dimension when newSortDirection and qSortIndicator are both ascending', async () => {
-      column.colIdx = 0;
-      if (changeSortOrder) {
-        await changeSortOrder(column, 'A');
-      }
-      expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
-    });
-
-    it('should not apply patches for qReverseSort for dimension when newSortDirection and qSortIndicator are both descending', async () => {
-      column.colIdx = 0;
-      column.sortDirection = 'D';
-
-      if (changeSortOrder) {
-        await changeSortOrder(column, 'D');
-      }
-      expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
-    });
-
-    it('should apply patches for qReverseSort for dimension when newSortDirection is ascending and qSortIndicator is descending', async () => {
-      column.colIdx = 0;
-      column.sortDirection = 'D';
-      expectedPatches.push({
-        qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
-        qOp: 'Replace' as EngineAPI.NxPatchOpType,
-        qValue: 'true',
-      });
-
-      if (changeSortOrder) {
-        await changeSortOrder(column, 'A');
-      }
-      expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
-    });
-
-    it('should apply patches for qReverseSort for dimension when newSortDirection is descending and qSortIndicator is ascending', async () => {
-      column.colIdx = 0;
-      expectedPatches.push({
-        qPath: '/qHyperCubeDef/qDimensions/0/qDef/qReverseSort',
-        qOp: 'Replace' as EngineAPI.NxPatchOpType,
-        qValue: 'true',
-      });
-
-      if (changeSortOrder) {
-        await changeSortOrder(column, 'D');
-      }
+      await changeSortOrder(column);
       expect(model.applyPatches).toHaveBeenCalledWith(expectedPatches, true);
     });
   });


### PR DESCRIPTION
Since we remove the ability to pass a specific sort direction (ascending/descending) we can remove some logic and corresponding tests.