### PR TITLE
fix: show pagination table when flag is off

### DIFF
--- a/src/nebula-hooks/use-pagination-table.ts
+++ b/src/nebula-hooks/use-pagination-table.ts
@@ -57,7 +57,7 @@ const usePaginationTable = ({
   reactRoot,
   applyColumnWidths,
 }: UsePaginationTable) => {
-  const shouldRender = !env.carbon && layout.usePagination !== false;
+  const shouldRender = !env.carbon && (layout.usePagination !== false || !areBasicFeaturesEnabled);
   const { direction, footerContainer } = useOptions() as UseOptions;
   const announce = useAnnounceAndTranslations(rootElement, translator);
   const [pageInfo, setPageInfo] = useState(initialPageInfo);


### PR DESCRIPTION
when `areBasicFeaturesEnabled === false && usePagination === true` nothing was rendered. We should default to the pagination table in that case