### PR TITLE
fix: head cell width

### DIFF
--- a/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
+++ b/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
@@ -11,7 +11,7 @@ import {
 } from '../../utils/styling-utils';
 import { MAX_NBR_LINES_OF_TEXT, MIN_BODY_ROW_HEIGHT } from '../constants';
 import { BodyStyle, GridState, RowMeta } from '../types';
-import { subtractCellPaddingAndBorder, subtractCellPaddingIconsAndBorder } from '../utils/cell-width-utils';
+import { getAdjustedCellWidth, getAdjustedHeadCellWidth } from '../utils/cell-width-utils';
 import useMeasureText from './use-measure-text';
 import useOnPropsChange from './use-on-props-change';
 
@@ -66,8 +66,8 @@ const useDynamicRowHeight = ({
     (text: string, colIdx: number) => {
       const width = measureText(text.trim());
       const cellWidth = columns
-        ? subtractCellPaddingIconsAndBorder(columnWidths[colIdx], columns[colIdx])
-        : subtractCellPaddingAndBorder(columnWidths[colIdx]);
+        ? getAdjustedHeadCellWidth(columnWidths[colIdx], columns[colIdx])
+        : getAdjustedCellWidth(columnWidths[colIdx]);
       const estimatedLineCount = Math.min(maxLineCount, Math.ceil(width / cellWidth));
       const textHeight = Math.max(1, estimatedLineCount) * lineHeight;
 

--- a/src/table/virtualized-table/utils/cell-width-utils.ts
+++ b/src/table/virtualized-table/utils/cell-width-utils.ts
@@ -1,20 +1,24 @@
 import { Column } from '../../../types';
 import { BORDER_WIDTH, PADDING_LEFT_RIGHT } from '../constants';
 
-// Actual padding is 12px * 2, but as this is used when measuring text an extra pixels are added as the measurement is not perfect
-const AMPLIFIED_PADDING = PADDING_LEFT_RIGHT + 2;
+const HEAD_CELL_PADDING = 4 * 2;
+const HEAD_BUTTON_PADDING = 8 * 2;
 const SORT_ICON_WIDTH = 18;
 const LOCK_ICON_WIDTH = 24;
-const MENU_BUTTON_WIDTH = 28;
+const MENU_BUTTON_WIDTH = 24;
+const GRID_GAP = 4;
 
-export const subtractCellPaddingAndBorder = (width: number) => width - AMPLIFIED_PADDING * 2 - BORDER_WIDTH;
+export const getAdjustedCellWidth = (width: number) => width - PADDING_LEFT_RIGHT * 2 - BORDER_WIDTH;
 
-export const subtractCellPaddingIconsAndBorder = (width: number, column: Column) => {
-  let newWidth = width - AMPLIFIED_PADDING * 2 - BORDER_WIDTH - SORT_ICON_WIDTH;
+export const getAdjustedHeadCellWidth = (width: number, column: Column) => {
+  let newWidth = width;
+  newWidth -= HEAD_CELL_PADDING;
+  newWidth -= HEAD_BUTTON_PADDING;
+  newWidth -= BORDER_WIDTH;
+  newWidth -= SORT_ICON_WIDTH;
+  newWidth -= MENU_BUTTON_WIDTH;
+  newWidth -= GRID_GAP;
   newWidth -= column.isLocked ? LOCK_ICON_WIDTH : 0;
-  newWidth -= column.isDim ? MENU_BUTTON_WIDTH : 0;
 
   return newWidth;
 };
-
-export const appendCellPaddingAndBorder = (width: number) => width + AMPLIFIED_PADDING * 2 + BORDER_WIDTH;


### PR DESCRIPTION
Fixes an issue in virtual scroll table where the cell height for a measure header, would not be properly calculated. Primerly it did not include the width of the "menu button", as that is now also available on the measure label.