### PR TITLE
fix: consistent header cell width

### DIFF
--- a/src/table/components/head/styles.ts
+++ b/src/table/components/head/styles.ts
@@ -36,7 +36,7 @@ export const StyledSortButton = styled(Button, {
   },
   '& .MuiButton-endIcon, .MuiButton-startIcon': {
     marginBottom: '2px',
-    display: disabled ? 'none' : 'inherit',
+    visibility: disabled ? 'hidden' : 'visible',
   },
 }));
 


### PR DESCRIPTION
Fixes an issue where the header cell width would be calculated the same, but rendered different when interactions was disable or enabled.

Before:
Sort icon did not occupy any space. For example in Qlik Sense, going from Edit to View mode, could render different line breaks in a header label when a field had "column width" set to "Pixels".

After:
Sort icon occupies space. No difference between the line breaks any more. 