### PR TITLE
fix: wait for fonts to load

### DIFF
--- a/src/nebula-hooks/use-pagination-table.ts
+++ b/src/nebula-hooks/use-pagination-table.ts
@@ -13,6 +13,7 @@ import {
   ApplyColumnWidths,
 } from '../types';
 import useAnnounceAndTranslations from './use-announce-and-translations';
+import useWaitForFonts from './virtualized-table/use-wait-for-fonts';
 
 interface UsePaginationTable {
   env: Galaxy;
@@ -68,6 +69,7 @@ const usePaginationTable = ({
 
     return null;
   }, [layout, pageInfo, model, constraints, shouldRender]);
+  const isFontLoaded = useWaitForFonts(theme, layout, shouldRender);
 
   useEffect(() => {
     const isReadyToRender =
@@ -80,6 +82,7 @@ const usePaginationTable = ({
       changeSortOrder &&
       theme &&
       selectionsAPI &&
+      isFontLoaded &&
       embed;
 
     if (!isReadyToRender) return;
@@ -132,6 +135,7 @@ const usePaginationTable = ({
     rect,
     footerContainer,
     areBasicFeaturesEnabled,
+    isFontLoaded,
   ]);
 };
 

--- a/src/nebula-hooks/use-virtualized-table.ts
+++ b/src/nebula-hooks/use-virtualized-table.ts
@@ -53,7 +53,7 @@ const useVirtualizedTable = ({
   const tableData = useMemo(() => getVirtualScrollTableData(layout, constraints), [layout, constraints]);
   const { pageInfo, setPage } = usePageInfo(layout, shouldRender);
   const { initialDataPages, isLoading } = useInitialDataPages({ model, layout, page: pageInfo.page, shouldRender });
-  const isFontLoaded = useWaitForFonts(theme, layout);
+  const isFontLoaded = useWaitForFonts(theme, layout, shouldRender);
 
   useEffect(() => {
     if (!shouldRender || !model || !changeSortOrder || !initialDataPages || isLoading || !isFontLoaded) return;

--- a/src/nebula-hooks/use-virtualized-table.ts
+++ b/src/nebula-hooks/use-virtualized-table.ts
@@ -12,6 +12,7 @@ import {
 } from '../types';
 import useInitialDataPages from './virtualized-table/use-initial-data-pages';
 import usePageInfo from './virtualized-table/use-page-info';
+import useWaitForFonts from './virtualized-table/use-wait-for-fonts';
 
 interface UseVirtualizedTable {
   app: EngineAPI.IApp | undefined;
@@ -52,9 +53,10 @@ const useVirtualizedTable = ({
   const tableData = useMemo(() => getVirtualScrollTableData(layout, constraints), [layout, constraints]);
   const { pageInfo, setPage } = usePageInfo(layout, shouldRender);
   const { initialDataPages, isLoading } = useInitialDataPages({ model, layout, page: pageInfo.page, shouldRender });
+  const isFontLoaded = useWaitForFonts(theme, layout);
 
   useEffect(() => {
-    if (!shouldRender || !model || !changeSortOrder || !initialDataPages || isLoading) return;
+    if (!shouldRender || !model || !changeSortOrder || !initialDataPages || isLoading || !isFontLoaded) return;
 
     renderVirtualizedTable(
       {
@@ -99,6 +101,7 @@ const useVirtualizedTable = ({
     pageInfo,
     isLoading,
     initialDataPages,
+    isFontLoaded,
   ]);
 };
 

--- a/src/nebula-hooks/virtualized-table/use-wait-for-fonts.ts
+++ b/src/nebula-hooks/virtualized-table/use-wait-for-fonts.ts
@@ -2,11 +2,13 @@ import { usePromise } from '@nebula.js/stardust';
 import { getBodyStyle, getHeaderStyle } from '../../table/utils/styling-utils';
 import { ExtendedTheme, TableLayout } from '../../types';
 
-const useWaitForFonts = (theme: ExtendedTheme, layout: TableLayout) => {
+const useWaitForFonts = (theme: ExtendedTheme, layout: TableLayout, shouldRender: boolean) => {
   const { fontSize: headerFontSize, fontFamily: headerFontFamily } = getHeaderStyle(layout, theme, false);
   const { fontSize, fontFamily } = getBodyStyle(layout, theme);
 
   const [isFontLoaded, error] = usePromise(async () => {
+    if (!shouldRender) return false;
+
     await document.fonts.load(`600 ${headerFontSize} ${headerFontFamily}`);
     await document.fonts.load(`${fontSize} ${fontFamily}`);
 
@@ -17,7 +19,7 @@ const useWaitForFonts = (theme: ExtendedTheme, layout: TableLayout) => {
   // log the error and continue rendering the table
   if (error) {
     // eslint-disable-next-line no-console
-    console.warn('Failed to load font styling from theme:', error);
+    console.warn('Failed to load font:', error);
     return true;
   }
 

--- a/src/nebula-hooks/virtualized-table/use-wait-for-fonts.ts
+++ b/src/nebula-hooks/virtualized-table/use-wait-for-fonts.ts
@@ -1,0 +1,27 @@
+import { usePromise } from '@nebula.js/stardust';
+import { getBodyStyle, getHeaderStyle } from '../../table/utils/styling-utils';
+import { ExtendedTheme, TableLayout } from '../../types';
+
+const useWaitForFonts = (theme: ExtendedTheme, layout: TableLayout) => {
+  const { fontSize: headerFontSize, fontFamily: headerFontFamily } = getHeaderStyle(layout, theme, false);
+  const { fontSize, fontFamily } = getBodyStyle(layout, theme);
+
+  const [isFontLoaded, error] = usePromise(async () => {
+    await document.fonts.load(`600 ${headerFontSize} ${headerFontFamily}`);
+    await document.fonts.load(`${fontSize} ${fontFamily}`);
+
+    return true;
+  }, [headerFontSize, headerFontFamily, fontSize, fontFamily]);
+
+  // An error while loading fonts should not block the table from rendering. So if an error occur,
+  // log the error and continue rendering the table
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to load font styling from theme:', error);
+    return true;
+  }
+
+  return !!isFontLoaded;
+};
+
+export default useWaitForFonts;


### PR DESCRIPTION
Fixes an issue where the width of some text, was measured before all fonts had been loaded.

This could result in that the length of the text in the browser, when it had been rendered, did not match the measured values. Producing artifacts where, for example, text would look like it required 2 lines but was only rendered on a single line.

~~I've only added this check for the virtual scroll table as I've yet to seen any issue with the pagination table.~~

Edit: it actually runs for pagination table too.

Edit2: Added the check for pagination table as it also depends on measuring text using a canvas context.