### PR TITLE
fix: totals row height when docked at bottom

### DIFF
--- a/src/table/virtualized-table/hooks/use-heights.ts
+++ b/src/table/virtualized-table/hooks/use-heights.ts
@@ -50,7 +50,7 @@ const useHeights = ({ columns, columnWidths, pageInfo, headerRef, totalsRef, tot
   const totalsRowHeight = totalsHeight.getRowHeight(0);
   const bodyRowHeight = getBodyRowHeight(styling.body);
   const headerAndTotalsHeight =
-    totalsPosition.atTop || totalsPosition.atBottom ? headerRowHeight + bodyRowHeight : headerRowHeight;
+    totalsPosition.atTop || totalsPosition.atBottom ? headerRowHeight + totalsRowHeight : headerRowHeight;
 
   return {
     headerRowHeight,


### PR DESCRIPTION
Fixes an issue where the totals row was not fully visible when docked at the bottom.

Before:
![Skärmavbild 2023-03-29 kl  08 38 00](https://user-images.githubusercontent.com/16608020/228447774-ddf2c6b5-0044-4ab2-8999-394c2b68b2e0.png)


After:
![Skärmavbild 2023-03-29 kl  08 38 30](https://user-images.githubusercontent.com/16608020/228447801-97fa4b1a-c710-4bdc-b673-d44c0f062fcf.png)
