### PR TITLE
fix: pressing space scrolls down on totals row

### DIFF
--- a/src/table/utils/__tests__/handle-keyboard.spec.ts
+++ b/src/table/utils/__tests__/handle-keyboard.spec.ts
@@ -370,6 +370,12 @@ describe('handle-keyboard', () => {
       handleTotalKeyDown(evt, rootElement, cellCoord, setFocusedCellCoord, isSelectionMode);
       expect(keyboardUtils.bodyTabHelper).toHaveBeenCalledTimes(1);
     });
+
+    it('should call preventDefault when the pressed key is Space', () => {
+      evt.key = KeyCodes.SPACE;
+      handleTotalKeyDown(evt, rootElement, cellCoord, setFocusedCellCoord, isSelectionMode);
+      expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('handleBodyKeyDown', () => {

--- a/src/table/utils/handle-keyboard.ts
+++ b/src/table/utils/handle-keyboard.ts
@@ -195,6 +195,9 @@ export const handleTotalKeyDown = (
       isCtrlCmd(evt) && copyCellValue(evt);
       break;
     }
+    case KeyCodes.SPACE:
+      evt.preventDefault();
+      break;
     default:
       break;
   }


### PR DESCRIPTION
pressing space on totals row || any cell of it causes and unnecessary scroll down. This small pr fixes it!