### PR TITLE
fix: wait for fonts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import useVirtualizedTable from './nebula-hooks/use-virtualized-table';
 import usePaginationTable from './nebula-hooks/use-pagination-table';
 import useCarbonTable from './nebula-hooks/use-carbon-table';
 import useApplyColumnWidths from './nebula-hooks/use-apply-column-widths';
+import useWaitForFonts from './nebula-hooks/use-wait-for-fonts';
 
 export default function supernova(env: Galaxy) {
   return {
@@ -49,6 +50,7 @@ export default function supernova(env: Galaxy) {
       const embed = useEmbed();
       const changeSortOrder = useSorting(model, layout.qHyperCube);
       const applyColumnWidths = useApplyColumnWidths(model, layout.qHyperCube);
+      const isFontLoaded = useWaitForFonts(theme, layout);
 
       useContextMenu();
 
@@ -67,6 +69,7 @@ export default function supernova(env: Galaxy) {
         embed,
         reactRoot,
         applyColumnWidths,
+        isFontLoaded,
       });
 
       usePaginationTable({
@@ -85,6 +88,7 @@ export default function supernova(env: Galaxy) {
         embed,
         reactRoot,
         applyColumnWidths,
+        isFontLoaded,
       });
 
       useCarbonTable({

--- a/src/nebula-hooks/use-pagination-table.ts
+++ b/src/nebula-hooks/use-pagination-table.ts
@@ -13,7 +13,6 @@ import {
   ApplyColumnWidths,
 } from '../types';
 import useAnnounceAndTranslations from './use-announce-and-translations';
-import useWaitForFonts from './virtualized-table/use-wait-for-fonts';
 
 interface UsePaginationTable {
   env: Galaxy;
@@ -31,6 +30,7 @@ interface UsePaginationTable {
   embed?: stardust.Embed;
   reactRoot: Root;
   applyColumnWidths: ApplyColumnWidths;
+  isFontLoaded: boolean;
 }
 
 const initialPageInfo = {
@@ -55,6 +55,7 @@ const usePaginationTable = ({
   embed,
   reactRoot,
   applyColumnWidths,
+  isFontLoaded,
 }: UsePaginationTable) => {
   const shouldRender = !env.carbon && layout.usePagination !== false;
   const { direction, footerContainer } = useOptions() as UseOptions;
@@ -67,7 +68,6 @@ const usePaginationTable = ({
 
     return null;
   }, [layout, pageInfo, model, constraints, shouldRender]);
-  const isFontLoaded = useWaitForFonts(theme, layout, shouldRender);
 
   useEffect(() => {
     const isReadyToRender =

--- a/src/nebula-hooks/use-virtualized-table.ts
+++ b/src/nebula-hooks/use-virtualized-table.ts
@@ -12,7 +12,6 @@ import {
 } from '../types';
 import useInitialDataPages from './virtualized-table/use-initial-data-pages';
 import usePageInfo from './virtualized-table/use-page-info';
-import useWaitForFonts from './virtualized-table/use-wait-for-fonts';
 
 interface UseVirtualizedTable {
   app: EngineAPI.IApp | undefined;
@@ -29,6 +28,7 @@ interface UseVirtualizedTable {
   changeSortOrder: ChangeSortOrder | undefined;
   reactRoot: Root;
   applyColumnWidths: ApplyColumnWidths;
+  isFontLoaded: boolean;
 }
 
 const useVirtualizedTable = ({
@@ -46,12 +46,12 @@ const useVirtualizedTable = ({
   embed,
   reactRoot,
   applyColumnWidths,
+  isFontLoaded,
 }: UseVirtualizedTable) => {
   const shouldRender = layout.usePagination === false;
   const tableData = useMemo(() => getVirtualScrollTableData(layout, constraints), [layout, constraints]);
   const { pageInfo, setPage } = usePageInfo(layout, shouldRender);
   const { initialDataPages, isLoading } = useInitialDataPages({ model, layout, page: pageInfo.page, shouldRender });
-  const isFontLoaded = useWaitForFonts(theme, layout, shouldRender);
 
   useEffect(() => {
     if (!shouldRender || !model || !changeSortOrder || !initialDataPages || isLoading || !isFontLoaded) return;

--- a/src/nebula-hooks/use-wait-for-fonts.ts
+++ b/src/nebula-hooks/use-wait-for-fonts.ts
@@ -1,14 +1,12 @@
 import { usePromise } from '@nebula.js/stardust';
-import { getBodyStyle, getHeaderStyle } from '../../table/utils/styling-utils';
-import { ExtendedTheme, TableLayout } from '../../types';
+import { getBodyStyle, getHeaderStyle } from '../table/utils/styling-utils';
+import { ExtendedTheme, TableLayout } from '../types';
 
-const useWaitForFonts = (theme: ExtendedTheme, layout: TableLayout, shouldRender: boolean) => {
+const useWaitForFonts = (theme: ExtendedTheme, layout: TableLayout) => {
   const { fontSize: headerFontSize, fontFamily: headerFontFamily } = getHeaderStyle(layout, theme, false);
   const { fontSize, fontFamily } = getBodyStyle(layout, theme);
 
   const [isFontLoaded, error] = usePromise(async () => {
-    if (!shouldRender) return false;
-
     await document.fonts.load(`600 ${headerFontSize} ${headerFontFamily}`);
     await document.fonts.load(`${fontSize} ${fontFamily}`);
 


### PR DESCRIPTION
The `useWaitForFonts` hook was not working as intended when both tables had it's own usage of it. You could end up in  scenario where toggling the `usePagination` "switch" did not re-render with a different table.

Now both use the same output from the hook, which I think makes more sense anyway as we don't neeed to make duplicate async `load` calls.