### PR TITLE
fix: empty cell height

### DIFF
--- a/src/table/components/CellText.tsx
+++ b/src/table/components/CellText.tsx
@@ -22,6 +22,8 @@ export default function CellText({ children, fontSize = '', wordBreak = false, l
   return wordBreak ? (
     <>{Text}</>
   ) : (
-    <StyledCellTextWrapper maxHeight={size * LINE_HEIGHT * lines}>{Text}</StyledCellTextWrapper>
+    <StyledCellTextWrapper minHeight={size * LINE_HEIGHT} maxHeight={size * LINE_HEIGHT * lines}>
+      {Text}
+    </StyledCellTextWrapper>
   );
 }


### PR DESCRIPTION
In the pagination table. Empty cells or cells with only white-space does not render with correct height.

Before:
![Skärmavbild 2023-03-31 kl  13 36 03](https://user-images.githubusercontent.com/16608020/229110158-b79d1165-6e93-4a0f-a061-f6c8732cdf06.png)


After:
![Skärmavbild 2023-03-31 kl  13 35 32](https://user-images.githubusercontent.com/16608020/229110193-d7e22806-554b-4b4c-841f-ac1673fd1582.png)
