### PR TITLE
revert: columnWidths

### DIFF
--- a/src/qae/object-properties.js
+++ b/src/qae/object-properties.js
@@ -26,6 +26,8 @@ const properties = {
     qMeasures: [],
     /** @type {number[]} */
     qColumnOrder: [],
+    /** @type {number[]} */
+    columnWidths: [],
     qInitialDataFetch: [{ qWidth: 50, qHeight: 100 }],
   },
   /**


### PR DESCRIPTION
we need columnWidths for chart conversion. The implementation of chart conversion will be in another PR.