### PR TITLE
feat: restores all qCalcCondition for chart conversion

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,11 +27,11 @@
     "react/jsx-props-no-spreading": 0,
     "react-hooks/rules-of-hooks": 2,
     "react-hooks/exhaustive-deps": 1,
-    "import/no-extraneous-dependencies": [2, { "devDependencies": true }],
-    "prefer-destructuring": ["error", { "object": true, "array": false }],
+    "import/no-extraneous-dependencies": 0,
+    "prefer-destructuring": [2, { "object": true, "array": false }],
     "no-param-reassign": [2, { "props": false }],
     "import/extensions": [
-      "error",
+      2,
       "ignorePackages",
       {
         "js": "never",
@@ -41,10 +41,10 @@
       }
     ],
     "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
-    "@typescript-eslint/ban-ts-comment": ["error", { "ts-ignore": "allow-with-description" }],
-    "no-shadow": "off",
-    "@typescript-eslint/no-shadow": ["error"],
-    "@typescript-eslint/no-unused-expressions": ["warn", { "allowShortCircuit": true, "allowTernary": true }]
+    "@typescript-eslint/ban-ts-comment": [2, { "ts-ignore": "allow-with-description" }],
+    "no-shadow": 0,
+    "@typescript-eslint/no-shadow": 2,
+    "@typescript-eslint/no-unused-expressions": [1, { "allowShortCircuit": true, "allowTernary": true }]
   },
   "overrides": [
     {
@@ -61,11 +61,11 @@
       },
       "plugins": ["jest", "react"],
       "rules": {
-        "jest/no-disabled-tests": "warn",
-        "jest/no-focused-tests": "error",
-        "jest/no-identical-title": "error",
-        "jest/prefer-to-have-length": "warn",
-        "jest/valid-expect": "error"
+        "jest/no-disabled-tests": 1,
+        "jest/no-focused-tests": 2,
+        "jest/no-identical-title": 2,
+        "jest/prefer-to-have-length": 1,
+        "jest/valid-expect": 2
       }
     }
   ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
     "react/jsx-props-no-spreading": 0,
     "react-hooks/rules-of-hooks": 2,
     "react-hooks/exhaustive-deps": 1,
-    "import/no-extraneous-dependencies": 0,
+    "import/no-extraneous-dependencies": [2, { "devDependencies": true }],
     "prefer-destructuring": [2, { "object": true, "array": false }],
     "no-param-reassign": [2, { "props": false }],
     "import/extensions": [

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "stylis-plugin-rtl-sc": "npm:stylis-plugin-rtl@1.1.0",
     "ts-jest": "29.1.0",
     "typescript": "5.0.3",
-    "yargs": "17.7.1"
+    "yargs": "17.7.1",
+    "qlik-object-conversion": "0.16.0"
   },
   "peerDependencies": {
     "@nebula.js/stardust": ">=3.3.0"

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "prop-types": "15.8.1",
     "qlik-chart-modules": "0.52.0",
     "qlik-modifiers": "0.9.1",
+    "qlik-object-conversion": "0.16.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.71.5",
@@ -138,8 +139,7 @@
     "stylis-plugin-rtl-sc": "npm:stylis-plugin-rtl@1.1.0",
     "ts-jest": "29.1.0",
     "typescript": "5.0.3",
-    "yargs": "17.7.1",
-    "qlik-object-conversion": "0.16.0"
+    "yargs": "17.7.1"
   },
   "peerDependencies": {
     "@nebula.js/stardust": ">=3.3.0"

--- a/src/ext/conversion/exportProperties.ts
+++ b/src/ext/conversion/exportProperties.ts
@@ -1,0 +1,14 @@
+import conversion from 'qlik-object-conversion';
+
+import { ExportFormat, PropTree } from '../../types';
+
+const exportProperties = (propertyTree: PropTree, hyperCubePath: string): ExportFormat => {
+  const expFormat = conversion.hypercube.exportProperties({
+    propertyTree,
+    hyperCubePath,
+  });
+
+  return expFormat;
+};
+
+export default exportProperties;

--- a/src/ext/conversion/importProperties.ts
+++ b/src/ext/conversion/importProperties.ts
@@ -1,0 +1,28 @@
+import conversion from 'qlik-object-conversion';
+
+import data from '../../qae/data';
+import { ExportFormat, PropTree } from '../../types';
+
+const importProperties = (
+  exportFormat: ExportFormat,
+  initialProperties: EngineAPI.IGenericHyperCubeProperties,
+  extension: any,
+  hypercubePath: string
+): PropTree => {
+  const propertyTree = conversion.hypercube.importProperties({
+    exportFormat,
+    initialProperties,
+    dataDefinition: data().targets[0],
+    defaultPropertyValues: {
+      defaultDimension: extension.getDefaultDimensionProperties(),
+      defaultMeasure: extension.getDefaultMeasureProperties(),
+    },
+    hypercubePath,
+  });
+
+  conversion.conditionalShow.unquarantine(propertyTree.qProperty);
+
+  return propertyTree;
+};
+
+export default importProperties;

--- a/src/ext/conversion/index.ts
+++ b/src/ext/conversion/index.ts
@@ -1,0 +1,4 @@
+import importProperties from './importProperties';
+import exportProperties from './exportProperties';
+
+export { importProperties, exportProperties };

--- a/src/ext/index.js
+++ b/src/ext/index.js
@@ -1,5 +1,6 @@
 import getPropertyPanelDefinition from './property-panel';
 import getData from './data';
+import { importProperties, exportProperties } from './conversion';
 
 const getExploration = (env) =>
   env.flags.isEnabled('PS_18291_TABLE_EXPLORATION') && {
@@ -31,5 +32,7 @@ export default function ext(env) {
       viewData: false,
       exploration: true,
     },
+    importProperties,
+    exportProperties,
   };
 }

--- a/src/qlik-object-conversion.d.ts
+++ b/src/qlik-object-conversion.d.ts
@@ -1,0 +1,1 @@
+declare module 'qlik-object-conversion';

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,26 +11,24 @@ export interface TextAlign {
 // properties
 interface InlineDimensionDef extends EngineAPI.INxInlineDimensionDef {
   textAlign: TextAlign;
-  columnWidth?: ColumnWidth;
 }
 interface InlineMeasureDef extends EngineAPI.INxInlineMeasureDef {
   textAlign: TextAlign;
-  columnWidth?: ColumnWidth;
 }
 interface AttributeExpressionProperties extends EngineAPI.INxAttrExprDef {
   id: 'cellForegroundColor' | 'cellBackgroundColor';
 }
-export interface DimensionProperty extends Omit<EngineAPI.INxDimension, 'qDef' | 'qAttributeExpressions'> {
+interface DimensionProperties extends Omit<EngineAPI.INxDimension, 'qDef' | 'qAttributeExpressions'> {
   qDef: InlineDimensionDef;
   qAttributeExpressions: AttributeExpressionProperties[];
 }
-export interface MeasureProperty extends Omit<EngineAPI.INxMeasure, 'qDef' | 'qAttributeExpressions'> {
+interface MeasureProperties extends Omit<EngineAPI.INxMeasure, 'qDef' | 'qAttributeExpressions'> {
   qDef: InlineMeasureDef;
   qAttributeExpressions: AttributeExpressionProperties[];
 }
 export interface QHyperCubeDef extends Omit<EngineAPI.IHyperCubeDef, 'qDimensions' | 'qMeasures'> {
-  qDimensions: DimensionProperty[];
-  qMeasures: MeasureProperty[];
+  qDimensions: DimensionProperties[];
+  qMeasures: MeasureProperties[];
   qColumnOrder: number[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,24 +11,26 @@ export interface TextAlign {
 // properties
 interface InlineDimensionDef extends EngineAPI.INxInlineDimensionDef {
   textAlign: TextAlign;
+  columnWidth?: ColumnWidth;
 }
 interface InlineMeasureDef extends EngineAPI.INxInlineMeasureDef {
   textAlign: TextAlign;
+  columnWidth?: ColumnWidth;
 }
 interface AttributeExpressionProperties extends EngineAPI.INxAttrExprDef {
   id: 'cellForegroundColor' | 'cellBackgroundColor';
 }
-interface DimensionProperties extends Omit<EngineAPI.INxDimension, 'qDef' | 'qAttributeExpressions'> {
+export interface DimensionProperty extends Omit<EngineAPI.INxDimension, 'qDef' | 'qAttributeExpressions'> {
   qDef: InlineDimensionDef;
   qAttributeExpressions: AttributeExpressionProperties[];
 }
-interface MeasureProperties extends Omit<EngineAPI.INxMeasure, 'qDef' | 'qAttributeExpressions'> {
+export interface MeasureProperty extends Omit<EngineAPI.INxMeasure, 'qDef' | 'qAttributeExpressions'> {
   qDef: InlineMeasureDef;
   qAttributeExpressions: AttributeExpressionProperties[];
 }
 export interface QHyperCubeDef extends Omit<EngineAPI.IHyperCubeDef, 'qDimensions' | 'qMeasures'> {
-  qDimensions: DimensionProperties[];
-  qMeasures: MeasureProperties;
+  qDimensions: DimensionProperty[];
+  qMeasures: MeasureProperty[];
   qColumnOrder: number[];
 }
 
@@ -207,4 +209,14 @@ export interface Galaxy {
   translator: ExtendedTranslator;
   carbon: boolean;
   flags: stardust.Flags;
+}
+
+export interface ExportFormat {
+  data: unknown[];
+  properties: EngineAPI.IGenericHyperCubeProperties;
+}
+
+export interface PropTree {
+  qChildren: unknown[];
+  qProperty: EngineAPI.IGenericHyperCubeProperties;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11206,10 +11206,22 @@ qlik-chart-modules@0.52.0:
   resolved "https://registry.yarnpkg.com/qlik-chart-modules/-/qlik-chart-modules-0.52.0.tgz#2209cf2a2ba52b8d8294dd42f14afa3a1fa18ca3"
   integrity sha512-oSTh+kVXPKvAIZlbcE0jzuYiRp07B7g0IYa821bwvmCRHp5zEHXp0jS/CwxV6NTP+O6FnkuncbN92jVV2TvJ2Q==
 
+qlik-modifiers@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/qlik-modifiers/-/qlik-modifiers-0.5.1.tgz#df81fe57e24fc88f7271e91bc23ab960144667a4"
+  integrity sha512-jQXt3oH7UwO5mhwUf0fHiUMRNutb1Fsq2jjN4NQ5Q0ZvBzhjrJPGcIpMMIcU4tmrYabkXS/GaVMA3Oa38jzpsw==
+
 qlik-modifiers@0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/qlik-modifiers/-/qlik-modifiers-0.9.1.tgz#7ba46d707ca2243b42d64f2380fdb1dccb6235f9"
   integrity sha512-PXF3xyIh+1KBpQ+YUt/pfpPT1Z6BLaxQnoqVswrouw3XguceN6Iv1r2yVNbxsehhPoVwulv8HR5eKG6F0LmPpA==
+
+qlik-object-conversion@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/qlik-object-conversion/-/qlik-object-conversion-0.16.0.tgz#799767e511c02c5d937603499623e223ff5d9ee6"
+  integrity sha512-/jhGSs3ft7KfKlkx/YPrNxKP7Ctlqz+eF1Yk0bMactqgU2Dx6OgmAPPgNBr/2hSMxf0aw7v67lHcjwj5qoFb+g==
+  dependencies:
+    qlik-modifiers "0.5.1"
 
 qs@6.11.0:
   version "6.11.0"


### PR DESCRIPTION
chart conversion task 1:

- enable conditional show for chart conversion by `conversion.conditionalShow.unquarantine(propertyTree.qProperty);`	
	-	when a column is hidden in an old table, after converting that old table to the new one, that column remains hidden and vice versa.


chart conversion task 2: column width will be in the next PR