### PR TITLE
fix: adjuster keyboard issues

### DIFF
--- a/src/table/components/head/ColumnAdjuster.tsx
+++ b/src/table/components/head/ColumnAdjuster.tsx
@@ -17,7 +17,7 @@ const ColumnAdjuster = ({ column, isLastColumn, onColumnResize }: AdjusterProps)
   const { applyColumnWidths, constraints } = useContextSelector(TableContext, (value) => value.baseProps);
   const columnWidths = useContextSelector(TableContext, (value) => value.columnWidths);
   const setColumnWidths = useContextSelector(TableContext, (value) => value.setColumnWidths);
-  const tempWidths = useRef({ adjusterHitArea: {}, columnWidth: 0, initX: 0, initWidth: 0 });
+  const tempWidths = useRef({ columnWidth: 0, initX: 0, initWidth: 0 });
 
   if (constraints.active) return null;
 
@@ -48,14 +48,12 @@ const ColumnAdjuster = ({ column, isLastColumn, onColumnResize }: AdjusterProps)
     document.removeEventListener('mouseup', mouseUpHandler);
 
     confirmWidth();
-    ((tempWidths.current.adjusterHitArea as HTMLDivElement).closest('#adjuster-hit-area') as HTMLDivElement).blur();
   };
 
   const mouseDownHandler = (evt: React.MouseEvent) => {
     evt.stopPropagation();
 
     tempWidths.current = {
-      adjusterHitArea: evt.target,
       initX: evt.clientX,
       initWidth: columnWidths[pageColIdx],
       columnWidth: columnWidths[pageColIdx],
@@ -67,8 +65,7 @@ const ColumnAdjuster = ({ column, isLastColumn, onColumnResize }: AdjusterProps)
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === KeyCodes.LEFT || event.key === KeyCodes.RIGHT) {
-      event.preventDefault();
-
+      preventDefaultBehavior(event);
       const RESIZE_DISTANCE = 5;
       const prevWidth = columnWidths[pageColIdx];
       const columnWidth = event.key === KeyCodes.LEFT ? prevWidth - RESIZE_DISTANCE : prevWidth + RESIZE_DISTANCE;
@@ -77,12 +74,14 @@ const ColumnAdjuster = ({ column, isLastColumn, onColumnResize }: AdjusterProps)
       updateWidth(adjustedWidth);
     } else if (event.key === KeyCodes.SPACE || event.key === KeyCodes.ENTER) {
       preventDefaultBehavior(event);
+      focusHeadMenuButton(event);
+
       confirmWidth();
-      focusHeadMenuButton(event);
     } else if (event.key === KeyCodes.ESC) {
+      preventDefaultBehavior(event);
       focusHeadMenuButton(event);
-      // reset it to the init value
-      updateWidth(tempWidths.current.initWidth);
+
+      updateWidth(tempWidths.current.initWidth); // reset width to the initial value
     }
   };
 

--- a/src/table/components/head/styles.ts
+++ b/src/table/components/head/styles.ts
@@ -183,13 +183,11 @@ export const AdjusterHitArea = styled(Box, {
       background: '#D9D9D9',
     },
   },
-  '&&:focus, :active': {
+  '&&:focus-visible, :active': {
+    outline: 'none',
     '& .sn-table-adjuster-head-border': {
       background: '#177fe6',
     },
-  },
-  '&&:focus-visible': {
-    outline: 'none',
   },
 }));
 


### PR DESCRIPTION
Found two small issues with the column adjust when using the keyboard.
- lost focus after pressing arrow once, need to stop propagation
- focus was set to chart, not ... menu. Same there, needed to stop propagation

Also, learned a bit about focus-visible a while ago, so we can use that pseudo-class instead of manually blurring when using the mouse. 