### PR TITLE
fix: remove sanity check for rect.width === 0

### DIFF
--- a/src/table/hooks/__tests__/use-column-widths.spec.ts
+++ b/src/table/hooks/__tests__/use-column-widths.spec.ts
@@ -62,6 +62,13 @@ describe('use-column-widths', () => {
   const getTotalWidth = (widths: number[]) => widths.reduce((acc, w) => acc + w, 0);
 
   describe('getColumnWidths', () => {
+    it('should early return when there are no columns', () => {
+      columns = [];
+
+      const widths = getColumnWidthsState();
+      expect(widths).toEqual([]);
+    });
+
     describe('all have same type', () => {
       it('should return equal sizes when all cols have auto type', () => {
         const widths = getColumnWidthsState();

--- a/src/table/hooks/use-column-widths.ts
+++ b/src/table/hooks/use-column-widths.ts
@@ -27,7 +27,7 @@ type GetFitToContentWidth = (headLabel: string, totalsLabel: string, glyphCount:
  * The widths are sorted in the order they will be displayed
  */
 export const getColumnWidths = (columns: Column[], tableWidth: number, getFitToContentWidth: GetFitToContentWidth) => {
-  if (!columns?.length || tableWidth === 0) return [];
+  if (!columns?.length) return [];
 
   const columnWidths: number[] = [];
   const autoColumnIndexes: number[] = [];

--- a/src/table/pagination-table/components/head/TableHeadWrapper.tsx
+++ b/src/table/pagination-table/components/head/TableHeadWrapper.tsx
@@ -3,7 +3,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 
 import { useContextSelector, TableContext } from '../../../context';
-import { DEFAULT_COLUMN_PIXEL_WIDTH, FullSortDirection } from '../../../constants';
+import { FullSortDirection } from '../../../constants';
 import HeadCellContent from '../../../components/head/HeadCellContent';
 import ColumnAdjuster from '../../../components/head/ColumnAdjuster';
 import CellText from '../../../components/CellText';
@@ -60,9 +60,7 @@ function TableHeadWrapper() {
             });
 
           const widthStyle = {
-            width:
-              (columnWidths[columnIndex] || DEFAULT_COLUMN_PIXEL_WIDTH) -
-              (isLastColumn ? PADDING * 2 : PADDING * 2 + BORDER_WIDTH),
+            width: columnWidths[columnIndex] - (isLastColumn ? PADDING * 2 : PADDING * 2 + BORDER_WIDTH),
             zIndex: columns.length - columnIndex,
           };
 


### PR DESCRIPTION
When rect.width becomes 0, we early returned and set `columnWIdths` to `[]`. That means some calculations for the VT broke. There is no real reason to early return. The result will be that all columns get the min size.