### PR TITLE
fix: header and body out of sync

### DIFF
--- a/src/table/virtualized-table/Body.tsx
+++ b/src/table/virtualized-table/Body.tsx
@@ -100,7 +100,7 @@ const Body = forwardRef<BodyRef, BodyProps>((props, ref) => {
   // producing strange cases where some text may not properly fit inside the cell.
   useOnPropsChange(() => {
     gridRef.current?.resetAfterIndices({ columnIndex: 0, rowIndex: 0, shouldForceUpdate: false });
-  }, [layout, pageInfo, theme.name(), rect.width]);
+  }, [layout, pageInfo, theme.name(), rect.width, columnWidths]);
 
   useImperativeHandle(
     ref,


### PR DESCRIPTION
Fixes an issue where the header and body could become out of sync if the scrollbar occupied space in the container element.

Before:
![Skärmavbild 2023-04-12 kl  15 58 52](https://user-images.githubusercontent.com/16608020/231481337-2b9ac481-daa3-44ce-95c2-08da564edd80.png)


After:
![Skärmavbild 2023-04-12 kl  15 58 28](https://user-images.githubusercontent.com/16608020/231481385-c48fe0e2-696c-4d89-bd67-0d3f5663262e.png)
