### PR TITLE
chore: nebula build without systemjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build": "yarn run locale:generate && node ./tools/build.js --core --ext",
     "build:dev": "yarn run locale:generate && node ./tools/build.js --core --ext --mode development",
     "build:watch": "yarn run locale:generate && node ./tools/build.js --mode development -w",
+    "build:debug": "yarn run locale:generate && node ./tools/build.js --ext --systemjs false",
     "build:rn": "yarn run locale:generate && node ./tools/build.js --reactNative",
     "build:rn:dev": "yarn run locale:generate && ditto src ./react-native/dist && rm -rf ./react-native/dist/__test__ && mv ./react-native/dist/index.js ./react-native/dist/sn-table.js",
     "lint": "eslint --cache .",


### PR DESCRIPTION
motivation:

it takes too much time to build an extension using `yarn build`

solution:

to disable systemjs build using `yarn build:debug`