### PR TITLE
fix: quaratine and unquarantine column order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ test/integration/state.json
 #pack files
 *.tgz
 build
+
+# editor directories and files
+.vscode

--- a/src/ext/conversion/__test__/export-properties.spec.ts
+++ b/src/ext/conversion/__test__/export-properties.spec.ts
@@ -84,7 +84,7 @@ describe('exportProperties', () => {
           qDimensions,
           qMeasures,
           qColumnOrder: [0, 2, 1],
-          columnOrder: [0, 1],
+          columnOrder: [0, 2, 1],
         },
       },
     } as unknown as PropTree;
@@ -102,6 +102,6 @@ describe('exportProperties', () => {
     ).toEqual([0, 2, 1]);
     expect(
       expFormat.properties.qLayoutExclude.quarantine.straightTableColumnOrder['qHyperCubeDef.columnOrder']
-    ).toEqual([0, 1]);
+    ).toEqual([0, 2, 1]);
   });
 });

--- a/src/ext/conversion/__test__/export-properties.spec.ts
+++ b/src/ext/conversion/__test__/export-properties.spec.ts
@@ -83,6 +83,8 @@ describe('exportProperties', () => {
         qHyperCubeDef: {
           qDimensions,
           qMeasures,
+          qColumnOrder: [0, 2, 1],
+          columnOrder: [0, 1],
         },
       },
     } as unknown as PropTree;
@@ -92,5 +94,14 @@ describe('exportProperties', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     expect(expFormat.properties.qHyperCubeDef.columnWidths).toEqual([-1, 200, 200, -1]);
+    expect(
+      expFormat.properties.qLayoutExclude.quarantine.straightTableColumnWidths['qHyperCubeDef.columnWidths']
+    ).toEqual([-1, 200, 200, -1]);
+    expect(
+      expFormat.properties.qLayoutExclude.quarantine.straightTableColumnOrder['qHyperCubeDef.qColumnOrder']
+    ).toEqual([0, 2, 1]);
+    expect(
+      expFormat.properties.qLayoutExclude.quarantine.straightTableColumnOrder['qHyperCubeDef.columnOrder']
+    ).toEqual([0, 1]);
   });
 });

--- a/src/ext/conversion/__test__/import-properties.spec.ts
+++ b/src/ext/conversion/__test__/import-properties.spec.ts
@@ -171,5 +171,17 @@ describe('importProperties', () => {
         type: 'pixels',
       });
     });
+
+    it('should unquaratine column order correctly', () => {
+      exportFormat.properties.qLayoutExclude = {
+        quarantine: {
+          straightTableColumnOrder: {
+            'qHyperCubeDef.qColumnOrder': [0, 2, 1],
+          },
+        },
+      };
+      const propertyTree = importProperties(exportFormat, initialProperties, extension, hypercubePath);
+      expect(propertyTree.qProperty.qHyperCubeDef.qColumnOrder).toEqual([0, 2, 1]);
+    });
   });
 });

--- a/src/ext/conversion/export-properties.ts
+++ b/src/ext/conversion/export-properties.ts
@@ -44,6 +44,8 @@ const exportProperties = (propertyTree: PropTree, hyperCubePath?: string): Expor
   setValue(expFormat, 'properties.qHyperCubeDef', qHyperCubeDef);
 
   conversion.quarantineProperty(expFormat.properties, 'qHyperCubeDef.columnWidths', 'straightTableColumnWidths');
+  conversion.quarantineProperty(expFormat.properties, 'qHyperCubeDef.qColumnOrder', 'straightTableColumnOrder');
+  conversion.quarantineProperty(expFormat.properties, 'qHyperCubeDef.columnOrder', 'straightTableColumnOrder');
 
   return expFormat;
 };

--- a/src/ext/conversion/import-properties.ts
+++ b/src/ext/conversion/import-properties.ts
@@ -82,6 +82,7 @@ const importProperties = (
   }
 
   conversion.conditionalShow.unquarantine(propertyTree.qProperty);
+  conversion.unquarantineProperty(propertyTree.qProperty, 'straightTableColumnOrder');
 
   return propertyTree;
 };

--- a/src/ext/conversion/import-properties.ts
+++ b/src/ext/conversion/import-properties.ts
@@ -71,6 +71,7 @@ const importProperties = (
     hypercubePath,
     extension,
   });
+  conversion.unquarantineProperty(propertyTree.qProperty, 'straightTableColumnOrder');
   const {
     qHyperCubeDef: { qDimensions, qMeasures, qColumnOrder, columnWidths },
   } = propertyTree.qProperty;
@@ -82,7 +83,6 @@ const importProperties = (
   }
 
   conversion.conditionalShow.unquarantine(propertyTree.qProperty);
-  conversion.unquarantineProperty(propertyTree.qProperty, 'straightTableColumnOrder');
 
   return propertyTree;
 };


### PR DESCRIPTION
## Description

Quarantine and unquarantine column order of sn-table so that the property can be stored and recovered correctly.
