### PR TITLE
fix(pagination-table): miss direction in table wrapper

### DIFF
--- a/src/table/Root.tsx
+++ b/src/table/Root.tsx
@@ -53,7 +53,7 @@ export function renderPaginationTable(props: RenderProps, reactRoot?: ReactDom.R
           applyColumnWidths={applyColumnWidths as ApplyColumnWidths}
           rect={rect}
         >
-          <TableWrapper {...(wrapperProps as TableWrapperProps)} />
+          <TableWrapper {...(wrapperProps as TableWrapperProps)} direction={direction} />
         </TableContextProvider>
       </ThemeProvider>
     </StyleSheetManager>

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -261,7 +261,7 @@ export interface RenderProps {
 }
 
 export interface TableWrapperProps {
-  direction?: Direction;
+  direction: Direction | undefined;
   pageInfo: PageInfo;
   setPageInfo: SetPageInfo;
   footerContainer?: HTMLElement;


### PR DESCRIPTION
a good example of when to use undefined instead of optional in types