### PR TITLE
fix: chart exploration should not be in the property panel when straight table is inside container

### DIFF
--- a/src/ext/property-panel/settings.js
+++ b/src/ext/property-panel/settings.js
@@ -248,6 +248,9 @@ const getChartExploration = (env) =>
           ],
         },
       },
+      // straight table that has chart exploration enabled and is placed inside a container
+      // should not show Chart exploration in the property panel
+      show: (itemData) => !itemData.insideContainer,
     },
   };
 


### PR DESCRIPTION
straight table that has chart exploration enabled and is placed inside a container should not show Chart exploration in the property panel