### PR TITLE
perf: throttle page fetch

### DIFF
--- a/src/table/virtualized-table/hooks/__tests__/use-data.test.ts
+++ b/src/table/virtualized-table/hooks/__tests__/use-data.test.ts
@@ -319,13 +319,9 @@ describe('useData', () => {
 
       // As the data cannot be derived, it needs to be fetched
       await waitFor(() =>
-        expect(model.getHyperCubeData).toHaveBeenNthCalledWith(
-          1,
-          '/qHyperCubeDef',
-          Array(VISIBLE_ROW_COUNT + ROW_DATA_BUFFER_SIZE)
-            .fill(undefined)
-            .map((_, rowIdx) => ({ qHeight: 1, qLeft: 0, qTop: rowIdx, qWidth: 6 }))
-        )
+        expect(model.getHyperCubeData).toHaveBeenNthCalledWith(1, '/qHyperCubeDef', [
+          { qHeight: 26, qLeft: 0, qTop: 0, qWidth: 6 },
+        ])
       );
       await waitFor(() => expect(renderHookResult.result.current.rowsInPage).toHaveLength(pageInfo.rowsPerPage));
     });

--- a/src/table/virtualized-table/hooks/use-get-hypercube-data-queue.ts
+++ b/src/table/virtualized-table/hooks/use-get-hypercube-data-queue.ts
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from 'react';
 import useMutableProp from './use-mutable-prop';
+import mergePages from '../utils/merge-pages';
 
 const pageToKey = ({ qLeft, qTop, qWidth, qHeight }: EngineAPI.INxPage) => `${qLeft}-${qTop}-${qWidth}-${qHeight}`;
 
@@ -29,7 +30,7 @@ const useGetHyperCubeDataQueue = (
         finished.current.add(key);
 
         if (queued.current.size === 1) {
-          queueMicrotask(async () => {
+          setTimeout(async () => {
             const qPages = Array.from(queued.current.values());
             if (qPages.length === 0) {
               return;
@@ -39,7 +40,8 @@ const useGetHyperCubeDataQueue = (
             ongoing.current.add(qPages);
 
             try {
-              const qDataPages = await mutableGetDataPages.current(qPages);
+              const mergedPages = mergePages(qPages);
+              const qDataPages = await mutableGetDataPages.current(mergedPages);
 
               if (ongoing.current.has(qPages)) {
                 mutableHandleDataPages.current(qDataPages);
@@ -52,7 +54,7 @@ const useGetHyperCubeDataQueue = (
             } finally {
               ongoing.current.delete(qPages);
             }
-          });
+          }, 75);
         }
       },
       clear: () => {

--- a/src/table/virtualized-table/utils/__tests__/merge-pages.spec.ts
+++ b/src/table/virtualized-table/utils/__tests__/merge-pages.spec.ts
@@ -1,0 +1,105 @@
+import mergePages from '../merge-pages';
+
+describe('mergePages', () => {
+  describe('merge rows', () => {
+    test('should merge pages', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 0, qTop: 1, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual([{ qLeft: 0, qTop: 0, qHeight: 2, qWidth: 1 }]);
+    });
+
+    test('should handle merging some pages but not others', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 0, qTop: 1, qHeight: 1, qWidth: 1 },
+        { qLeft: 0, qTop: 4, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual([
+        { qLeft: 0, qTop: 0, qHeight: 2, qWidth: 1 },
+        { qLeft: 0, qTop: 4, qHeight: 1, qWidth: 1 },
+      ]);
+    });
+
+    test('should not merge pages when the pages are not next to each other', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 0, qTop: 2, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual(qPages);
+    });
+
+    test('should not merge pages when the qLeft does not match', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 1, qTop: 1, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual(qPages);
+    });
+
+    test('should not merge pages when the qWidth does not match', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 0, qTop: 1, qHeight: 1, qWidth: 2 },
+      ];
+
+      expect(mergePages(qPages)).toEqual(qPages);
+    });
+  });
+
+  describe('merge columns', () => {
+    test('should merge pages', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 1, qTop: 0, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual([{ qLeft: 0, qTop: 0, qHeight: 1, qWidth: 2 }]);
+    });
+
+    test('should handle merging some pages but not others', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 1, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 4, qTop: 0, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual([
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 2 },
+        { qLeft: 4, qTop: 0, qHeight: 1, qWidth: 1 },
+      ]);
+    });
+
+    test('should not merge pages when the pages are not next to each other', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 2, qTop: 0, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual(qPages);
+    });
+
+    test('should not merge pages when the Qtop does not match', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 1, qTop: 1, qHeight: 1, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual(qPages);
+    });
+
+    test('should not merge pages when the qHeight does not match', () => {
+      const qPages: EngineAPI.INxPage[] = [
+        { qLeft: 0, qTop: 0, qHeight: 1, qWidth: 1 },
+        { qLeft: 1, qTop: 0, qHeight: 2, qWidth: 1 },
+      ];
+
+      expect(mergePages(qPages)).toEqual(qPages);
+    });
+  });
+});

--- a/src/table/virtualized-table/utils/merge-pages.ts
+++ b/src/table/virtualized-table/utils/merge-pages.ts
@@ -1,0 +1,31 @@
+const canMergeRows = (prevPage: EngineAPI.INxPage, page: EngineAPI.INxPage) =>
+  prevPage.qTop + prevPage.qHeight === page.qTop && prevPage.qLeft === page.qLeft && prevPage.qWidth === page.qWidth;
+
+const canMergeColumns = (prevPage: EngineAPI.INxPage, page: EngineAPI.INxPage) =>
+  prevPage.qLeft + prevPage.qWidth === page.qLeft && prevPage.qTop === page.qTop && prevPage.qHeight === page.qHeight;
+
+/**
+ * There is an assumption here that by merging multiple pages into fewer pages
+ * with a larger qHeight/qWidth value. The performance on the Engine side is improved.
+ */
+const mergePages = (qPages: EngineAPI.INxPage[]) => {
+  const pages: EngineAPI.INxPage[] = [];
+  qPages.forEach((page) => {
+    if (pages.length > 0) {
+      const prevPage = pages[pages.length - 1];
+      if (canMergeRows(prevPage, page)) {
+        prevPage.qHeight += page.qHeight;
+      } else if (canMergeColumns(prevPage, page)) {
+        prevPage.qWidth += page.qWidth;
+      } else {
+        pages.push({ ...page });
+      }
+    } else {
+      pages.push({ ...page });
+    }
+  });
+
+  return pages;
+};
+
+export default mergePages;


### PR DESCRIPTION
This PR changes two things:
1. qDataPage fetches are throttled by 75 ms, instead of "as fast as possible".
2. Pages in are merged so that the GetHyperDataCalls to Engine contains less "pages" with qWidth and qHeight === 1

The intention is to reduce the burden on Engine and in that way also improve the performance. Some smaller tables with a simple data structure are likely getting a small performances hit because of the throttles fetches.