### PR TITLE
feat: show a snapshot with the exact scroll position

### DIFF
--- a/src/table/hooks/use-snapshot.ts
+++ b/src/table/hooks/use-snapshot.ts
@@ -34,12 +34,14 @@ export const getViewState = (layout: TableLayout, viewService: ViewService, root
 
   if (layout.usePagination) {
     const totalsPosition = getTotalPosition(layout);
-    const { visibleRowStartIndex = -1, visibleRowEndIndex = -1 } = findPaginationVisibleRows(
-      rootElement,
-      totalsPosition
-    );
+    const {
+      visibleRowStartIndex = -1,
+      visibleRowEndIndex = -1,
+      rowPartialHeight,
+    } = findPaginationVisibleRows(rootElement, totalsPosition);
 
     return {
+      rowPartialHeight,
       scrollLeft: viewService.scrollLeft,
       visibleTop: viewService.qTop + visibleRowStartIndex,
       visibleHeight: getVisibleHeight(visibleRowEndIndex, visibleRowStartIndex, layout, viewService),
@@ -47,7 +49,6 @@ export const getViewState = (layout: TableLayout, viewService: ViewService, root
       page: viewService.page,
     };
   }
-
   const { visibleRowStartIndex = -1, visibleRowEndIndex = -1 } = findVirtualizedVisibleRows(rootElement, viewService);
 
   return {
@@ -72,8 +73,17 @@ const useSnapshot = ({ layout, viewService, model, rootElement, contentRect }: U
       if (!snapshotLayout.qHyperCube) {
         snapshotLayout.qHyperCube = {} as HyperCube;
       }
-      const { scrollLeft, scrollTopRatio, visibleLeft, visibleWidth, visibleTop, visibleHeight, rowsPerPage, page } =
-        getViewState(layout, viewService, rootElement);
+      const {
+        rowPartialHeight,
+        scrollLeft,
+        scrollTopRatio,
+        visibleLeft,
+        visibleWidth,
+        visibleTop,
+        visibleHeight,
+        rowsPerPage,
+        page,
+      } = getViewState(layout, viewService, rootElement);
       snapshotLayout.qHyperCube.qDataPages = await (model as EngineAPI.IGenericObject).getHyperCubeData(
         '/qHyperCubeDef',
         [
@@ -86,6 +96,7 @@ const useSnapshot = ({ layout, viewService, model, rootElement, contentRect }: U
         ]
       );
       snapshotLayout.snapshotData.content = {
+        rowPartialHeight,
         scrollLeft,
         scrollTopRatio,
         visibleLeft,

--- a/src/table/hooks/use-view-service.ts
+++ b/src/table/hooks/use-view-service.ts
@@ -5,6 +5,7 @@ const createViewService = (viewState: ViewState, snapshotData?: SnapshotData): V
   return {
     qTop: 0,
     qHeight: 0,
+    rowPartialHeight: snapshotData?.content?.rowPartialHeight ?? 0,
     visibleTop: snapshotData?.content?.visibleTop ?? viewState?.visibleTop,
     visibleHeight: snapshotData?.content?.visibleHeight ?? viewState?.visibleHeight,
     scrollLeft: snapshotData?.content?.scrollLeft ?? viewState?.scrollLeft ?? 0,

--- a/src/table/pagination-table/components/TableWrapper.tsx
+++ b/src/table/pagination-table/components/TableWrapper.tsx
@@ -49,6 +49,7 @@ function TableWrapper(props: TableWrapperProps) {
 
   const isPrintingMode = isPrinting(layout, viewService);
   const scrollLeft = isPrintingMode ? viewService.scrollLeft ?? 0 : 0;
+  const scrollTopPartially = isPrintingMode ? viewService.rowPartialHeight ?? 0 : 0;
 
   const setShouldRefocus = useCallback(() => {
     shouldRefocus.current = rootElement.getElementsByTagName('table')[0].contains(document.activeElement);
@@ -83,8 +84,12 @@ function TableWrapper(props: TableWrapperProps) {
   useKeyboardActiveListener();
 
   useEffect(() => {
-    tableContainerRef.current?.scrollTo(scrollLeft, 0);
-  }, [pageInfo, totalRowCount, scrollLeft]);
+    const element = tableContainerRef.current;
+    if (element) {
+      element.scrollLeft = scrollLeft;
+      element.scrollTop = scrollTopPartially;
+    }
+  }, [pageInfo, totalRowCount, scrollLeft, scrollTopPartially]);
 
   // Except for first render, whenever the size of the data (number of rows per page, rows, columns) or page changes,
   // reset tabindex to first cell. If some cell had focus, focus the first cell as well.

--- a/src/table/pagination-table/components/head/TableHeadWrapper.tsx
+++ b/src/table/pagination-table/components/head/TableHeadWrapper.tsx
@@ -28,7 +28,7 @@ function TableHeadWrapper() {
 
   useEffect(() => {
     if (headRowRef.current) {
-      setHeadRowHeight(headRowRef.current.getBoundingClientRect().height);
+      setHeadRowHeight(headRowRef.current.clientHeight);
     }
   }, [styling.head.fontSize, columnWidths, setHeadRowHeight]);
 

--- a/src/table/utils/find-visible-rows.ts
+++ b/src/table/utils/find-visible-rows.ts
@@ -9,9 +9,7 @@ export const getPartialTopScrollHeight = (
 ): number => {
   if (!rows || rows.length === 0 || index < 0) return 0;
   const rowRect = rows[index].getBoundingClientRect();
-  if (rowRect.top === tableBodyRect.top) return 0;
-  const partialHeight = tableBodyRect.top - rowRect.top;
-  return partialHeight > 0 ? partialHeight : 0;
+  return Math.max(tableBodyRect.top - rowRect.top, 0);
 };
 
 const findStartIndex = (
@@ -91,7 +89,6 @@ export function findVirtualizedVisibleRows(rootElement: HTMLElement, viewService
   if (1 - scrollTopRatio < EPSILON) {
     // The last data row is visible, then the priority start from the bottom row
     const shouldIncludeTopRow = topLeftCellRect.y >= bodyYMin - 4;
-    console.log('value: ', visibleTopInPage + (shouldIncludeTopRow ? 0 : 1) + offset);
     return {
       visibleRowStartIndex: visibleTopInPage + (shouldIncludeTopRow ? 0 : 1) + offset,
       visibleRowEndIndex: visibleBottomInPage + offset,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import { stardust } from '@nebula.js/stardust';
 export type Align = 'left' | 'center' | 'right';
 
 export interface ViewService {
+  rowPartialHeight?: number;
   scrollLeft?: number;
   scrollTopRatio?: number;
   qTop: number;
@@ -23,6 +24,7 @@ export interface Size {
 }
 export interface SnapshotData {
   content?: {
+    rowPartialHeight?: number;
     scrollLeft?: number;
     scrollTopRatio?: number;
     visibleLeft?: number;
@@ -231,6 +233,7 @@ export interface ExtendedTheme extends stardust.Theme {
 }
 
 export interface ViewState {
+  rowPartialHeight: number;
   scrollLeft: number;
   scrollTopRatio?: number;
   visibleTop: number;


### PR DESCRIPTION
**The issue:**
The current sn-table snapshot calculations are not accurate. If the table row is half-visible, it will take it as a totally visible row and if the row is less than 50% visible, it will not consider it as part of the snapshot.

**Solution for pagination mode**
The improvement calculates the exact top row visible height (if there is any) and adjusts the final table scrollTop based on the new calculations to reach to the exact visible row height. The result is a snapshot that fulfills `what you get is what you see`

![image](https://github.com/qlik-oss/sn-table/assets/20701546/a259526b-6f08-4e85-8718-f8fde0cd004d)
![image](https://github.com/qlik-oss/sn-table/assets/20701546/45525c04-4587-4dc6-a63f-219c1b5bd822)
