### PR TITLE
feat: VIZ-2624-set-size-to-table-snapshot

### DIFF
--- a/src/nebula-hooks/use-pagination-table.ts
+++ b/src/nebula-hooks/use-pagination-table.ts
@@ -36,7 +36,7 @@ interface UsePaginationTable {
   viewService: ViewService;
 }
 
-const initialPageInfo = {
+export const initialPageInfo = {
   page: 0,
   rowsPerPage: 100,
   rowsPerPageOptions: [10, 25, 100],

--- a/src/table/hooks/use-snapshot.ts
+++ b/src/table/hooks/use-snapshot.ts
@@ -3,6 +3,7 @@ import { onTakeSnapshot, useImperativeHandle, stardust } from '@nebula.js/stardu
 import type { TableLayout, ViewService, SnapshotLayout, HyperCube } from '../../types';
 import { findPaginationVisibleRows, findVirtualizedVisibleRows } from '../utils/find-visible-rows';
 import { getTotalPosition } from '../../handle-data';
+import { initialPageInfo } from '../../nebula-hooks/use-pagination-table';
 
 interface UseSnapshotProps {
   layout: TableLayout;
@@ -21,10 +22,21 @@ const useSnapshot = ({ layout, viewService, model, rootElement, contentRect }: U
         rootElement,
         totalsPosition
       );
+
+      const totalRowCount = layout.qHyperCube.qSize.qcy;
+      const paginationNeeded = totalRowCount > 10;
+      const rowsPerPage = viewService.rowsPerPage || initialPageInfo.rowsPerPage;
+      const rowsRendered = visibleRowEndIndex - visibleRowStartIndex + 1;
+      const getVisibleHeight = () => {
+        return paginationNeeded && rowsRendered < rowsPerPage
+          ? visibleRowEndIndex - visibleRowStartIndex + 4 // Temp:is considered to avoid ratio change to remove empty space at the bottom
+          : rowsRendered;
+      };
+
       return {
         scrollLeft: viewService.scrollLeft,
         visibleTop: viewService.qTop + visibleRowStartIndex,
-        visibleHeight: visibleRowEndIndex < 0 ? 0 : visibleRowEndIndex - visibleRowStartIndex + 1,
+        visibleHeight: visibleRowEndIndex < 0 ? 0 : getVisibleHeight(),
         rowsPerPage: viewService.rowsPerPage,
         page: viewService.page,
       };


### PR DESCRIPTION
A table can be seen as 5 components:
1) the tilte
2) the footer
3) the data area
4) the vertical scroll
5) the horizontal scroll
The main area is the table but not include the title

Currently we use the main area to render data area in snapshot or download mode.
Expected: We should deduct the footer and scrolls from the main area when render data area in snapshot mode. Both the Pagination and Virtual Table should show content like below. 

**Decision**: Develop the feature by filling up with more rows and remove the footer when total number of rows displayed on the screen is more than 100. In the case of rows 10, 25 and 100 show the exact rows if available. 

![image](https://github.com/qlik-oss/sn-table/assets/91126632/72cc1f70-44e1-4e9e-bd21-b00e9ac0c58b)


