### PR TITLE
fix: add aria-label for head menu button

### DIFF
--- a/src/locale/locales/en.json
+++ b/src/locale/locales/en.json
@@ -17,7 +17,7 @@
   },
   "SNTable.Accessibility.ColumnOptions": {
     "value": "Column options",
-    "comment": "aria label for the button in the header that opens the column menu"
+    "comment": "aria label for the button in the header that opens the column menu (buy 230705)"
   },
   "SNTable.Pagination.RowsPerPage": {
     "value": "Rows per page",

--- a/src/locale/locales/en.json
+++ b/src/locale/locales/en.json
@@ -17,7 +17,7 @@
   },
   "SNTable.Accessibility.ColumnOptions": {
     "value": "Column options",
-    "comment": "label for the button in the header to open the column menu"
+    "comment": "aria label for the button in the header that opens the column menu"
   },
   "SNTable.Pagination.RowsPerPage": {
     "value": "Rows per page",

--- a/src/locale/locales/en.json
+++ b/src/locale/locales/en.json
@@ -15,6 +15,10 @@
     "value": "Descending",
     "comment": "Tooltip showing that column is in descending order. (tew 230411)"
   },
+  "SNTable.Accessibility.ColumnOptions": {
+    "value": "Column options",
+    "comment": "Ara label for the button in the header to open the column menu"
+  },
   "SNTable.Pagination.RowsPerPage": {
     "value": "Rows per page",
     "comment": "label for the rows per page dropdown. (tew 210929)"

--- a/src/locale/locales/en.json
+++ b/src/locale/locales/en.json
@@ -17,7 +17,7 @@
   },
   "SNTable.Accessibility.ColumnOptions": {
     "value": "Column options",
-    "comment": "Ara label for the button in the header to open the column menu"
+    "comment": "label for the button in the header to open the column menu"
   },
   "SNTable.Pagination.RowsPerPage": {
     "value": "Rows per page",

--- a/src/table/components/head/HeadCellMenu.tsx
+++ b/src/table/components/head/HeadCellMenu.tsx
@@ -173,6 +173,7 @@ export default function HeadCellMenu({ column, tabIndex }: HeadCellMenuProps) {
         aria-expanded={openMenuDropdown ? 'true' : undefined}
         aria-haspopup="true"
         onClick={handleOpenDropdown}
+        aria-label={translator.get('SNTable.Accessibility.ColumnOptions')}
       >
         <More height={DEFAULT_FONT_SIZE} />
       </StyledMenuIconButton>


### PR DESCRIPTION
The button in the header (see image) needs to be label to be accessible. Simply done with a aria-label, since there is no label on the button
![Screenshot 2023-07-05 at 15 28 10](https://github.com/qlik-oss/sn-table/assets/9249820/02ac2502-ba1f-4db8-a28d-dcd11682f6c1)
