### PR TITLE
fix: Unexpected focused test

### DIFF
--- a/src/table/hooks/__tests__/get-view-state.spec.ts
+++ b/src/table/hooks/__tests__/get-view-state.spec.ts
@@ -8,7 +8,7 @@ jest.mock('@nebula.js/stardust', () => ({
 }));
 
 describe('use-snapshot', () => {
-  describe.only('useSnapshot', () => {
+  describe('useSnapshot', () => {
     let layout: TableLayout;
     let viewService: ViewService;
     let rootElement: HTMLElement;


### PR DESCRIPTION
Due to the unexpected focused test (mistakenly left perhaps) `sn-table` code change are not committable. Throws a linting issue. Hence this was removed. 

![image](https://github.com/qlik-oss/sn-table/assets/91126632/ec1fc718-1d14-43ad-a47e-fc7f21f47212)

![image](https://github.com/qlik-oss/sn-table/assets/91126632/cd8a8c6a-48e0-4ab2-97f7-3b9bfbc69511)
