### PR TITLE
fix: big table dont render properly

### DIFF
--- a/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
+++ b/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
@@ -32,7 +32,7 @@ export interface UseDynamicRowHeightProps {
   maxNbrLines?: number;
 }
 
-const MAX_ELEMENT_DOM_SIZE = 15_000_000; // Guestimated max height value in px of a DOM element
+const MAX_ELEMENT_DOM_SIZE = 8_000_000; // Guestimated max height value in px of a DOM element
 
 const useDynamicRowHeight = ({
   style,
@@ -46,7 +46,7 @@ const useDynamicRowHeight = ({
   boldText,
   gridState,
   isSnapshot,
-  viewService, 
+  viewService,
   maxNbrLines = MAX_NBR_LINES_OF_TEXT,
 }: UseDynamicRowHeightProps) => {
   const rowMeta = useRef<RowMeta>({


### PR DESCRIPTION
The failure to render a cells has to do with the max element dom size being exceeded. This PR just lowers the max allowed size. Where the consequence of that, is that instead of rendering some rows with 3 lines of text, it may now render them with only 1 or 2 lines.

There is a need to take an in-depth look at this and fix the issue in a far more dynamic way. But that is a much much larger and risky change. So this PR takes the easy path that may not work for every browser and machine combination.

![big-table-render-error](https://github.com/qlik-oss/sn-table/assets/16608020/175b5aa6-ddc2-440a-bdbf-763cef3c20f8)
