### PR TITLE
chore: remove redundent deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         }
       ],
       "@typescript-eslint/no-floating-promises": 0,
+      "@typescript-eslint/no-unsafe-enum-comparison": 0,
       "@typescript-eslint/no-unused-expressions": [
         1,
         {
@@ -125,8 +126,6 @@
     "@types/jest": "29.5.8",
     "@types/react": "18.2.37",
     "@types/react-window": "1.8.8",
-    "@typescript-eslint/eslint-plugin": "5.62.0",
-    "@typescript-eslint/parser": "5.62.0",
     "conventional-changelog-cli": "4.1.0",
     "eslint": "8.53.0",
     "eslint-plugin-jest": "27.6.0",

--- a/src/__test__/test-with-providers.tsx
+++ b/src/__test__/test-with-providers.tsx
@@ -2,7 +2,7 @@
 import { ThemeProvider } from "@mui/material/styles";
 import { stardust } from "@nebula.js/stardust";
 import type { ExtendedTheme } from "@qlik/nebula-table-utils/lib/hooks/use-extended-theme/types";
-import React from "react";
+import React, { ReactNode } from "react";
 import { EMPTY_TABLE_DATA, TableContextProvider } from "../table/context";
 import muiSetup from "../table/mui-setup";
 import {
@@ -17,7 +17,7 @@ import { generateLayout } from "./generate-test-data";
 
 interface ProviderProps {
   app?: EngineAPI.IApp;
-  children?: JSX.Element;
+  children?: ReactNode;
   selectionsAPI?: ExtendedSelectionAPI;
   tableData?: TableData;
   cellCoordMock?: [number, number];

--- a/src/ext/conversion/import-properties.ts
+++ b/src/ext/conversion/import-properties.ts
@@ -57,6 +57,7 @@ export const getMultiColumnInfo = (
 const importProperties = (
   exportFormat: ExportFormat,
   initialProperties: EngineAPI.IGenericHyperCubeProperties,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extension: any,
   hypercubePath?: string,
 ): PropTree => {

--- a/src/extend-context-menu.ts
+++ b/src/extend-context-menu.ts
@@ -3,9 +3,9 @@ import { onContextMenu } from "@nebula.js/stardust";
 import copyCellValue from "./table/utils/copy-utils";
 
 export default function extendContextMenu() {
-  onContextMenu?.((menu: any, event: any) => {
+  onContextMenu?.((menu: { addItem: (i: unknown) => void }, event: React.MouseEvent<Element>) => {
     event.target &&
-      event.target.closest(".sn-table-cell") &&
+      (event.target as HTMLElement).closest(".sn-table-cell") &&
       menu.addItem({
         translation: "contextMenu.copyCellValue",
         icon: "lui-icon lui-icon--copy",

--- a/src/table/components/head/MenuList/MenuGroup.tsx
+++ b/src/table/components/head/MenuList/MenuGroup.tsx
@@ -25,7 +25,7 @@ export const interceptClickOnMenuItems = (menuGroups: MenuItemGroup[], cache: Su
   return result;
 };
 
-type SubMenusOpenStatusCache = Record<string, React.Dispatch<React.SetStateAction<boolean>>>;
+export type SubMenusOpenStatusCache = Record<string, React.Dispatch<React.SetStateAction<boolean>>>;
 let subMenusOpenStatusCache: SubMenusOpenStatusCache = {};
 
 const MenuGroupItems = ({ autoFocus, id, onClick, itemTitle, icon, enabled, subMenus }: HeadCellMenuItem) => {

--- a/src/table/components/head/MenuList/__tests__/MenuGroup.spec.tsx
+++ b/src/table/components/head/MenuList/__tests__/MenuGroup.spec.tsx
@@ -1,12 +1,12 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { HeadCellMenuItem, MenuItemGroup } from "../../../../types";
-import MenuGroup, { interceptClickOnMenuItems } from "../MenuGroup";
+import MenuGroup, { SubMenusOpenStatusCache, interceptClickOnMenuItems } from "../MenuGroup";
 
 describe("MenuGroup", () => {
   describe("interceptClickOnMenuItems", () => {
     let menuGroups: MenuItemGroup[];
-    let cache: Record<string, any>;
+    let cache: SubMenusOpenStatusCache;
 
     it("should return proper values per menu", () => {
       menuGroups = [

--- a/src/table/components/head/MenuList/__tests__/RecursiveMenuList.spec.tsx
+++ b/src/table/components/head/MenuList/__tests__/RecursiveMenuList.spec.tsx
@@ -6,7 +6,7 @@ import RecursiveMenuList from "../RecursiveMenuList";
 
 describe("<RecursiveMenuList />", () => {
   let menuGroups: MenuItemGroup[];
-  let menuGroupWrapperMock: jest.Mock<any, any>;
+  let menuGroupWrapperMock: jest.Mock;
   let anchorEl: HTMLDivElement;
 
   beforeEach(() => {

--- a/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
+++ b/src/table/components/head/__tests__/HeadCellMenu.spec.tsx
@@ -18,11 +18,11 @@ describe("<HeadCellMenu />", () => {
   let embed: ExtendedEmbed;
   let layout: TableLayout;
   let column: Column;
-  let defaultListboxAnchorOpts: any;
+  let defaultListboxAnchorOpts: unknown;
   let fieldInstanceMock: EngineAPI.IField;
   let selectionActionsEnabledStatusMock: Record<string, boolean>;
-  let resetSelectionActionsEnabledStatusMock: jest.Mock<any, any>;
-  let updateSelectionActionsEnabledStatusMock: jest.Mock<any, any>;
+  let resetSelectionActionsEnabledStatusMock: jest.Mock<unknown, unknown[]>;
+  let updateSelectionActionsEnabledStatusMock: jest.Mock<unknown, unknown[]>;
   let model: EngineAPI.IGenericObject;
   let useFieldSelectionHookResult: useFieldSelectionHook.UseFieldSelectionOutput;
   let interactions: stardust.Interactions;

--- a/src/table/context/createSelectorProvider.tsx
+++ b/src/table/context/createSelectorProvider.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
 } from "react";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const contextMap: Map<Context<any>, Context<any>> = new Map();
 
 interface ProviderProps<T> {

--- a/src/table/context/useContextSelector.ts
+++ b/src/table/context/useContextSelector.ts
@@ -9,7 +9,7 @@ export function useContextSelector<T, TSelected>(context: Context<T>, selector: 
   const [, forceUpdate] = useReducer((dummy: number) => dummy + 1, 0);
 
   const latestSelector = useRef(selector);
-  const latestSelectedState = useRef<any>();
+  const latestSelectedState = useRef<unknown>();
 
   const currentValue = accessor();
 

--- a/src/table/hooks/__tests__/use-field-selection.spec.tsx
+++ b/src/table/hooks/__tests__/use-field-selection.spec.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import React from "react";
+import React, { ReactNode } from "react";
 import TestWithProviders from "../../../__test__/test-with-providers";
 import { Column, TableLayout } from "../../../types";
 import useFieldSelection from "../use-field-selection";
@@ -8,7 +8,9 @@ describe("useFieldSelection()", () => {
   let column: Column;
   let appMock: EngineAPI.IApp;
 
-  const wrapper = ({ children }: any) => <TestWithProviders app={appMock}>{children}</TestWithProviders>;
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <TestWithProviders app={appMock}>{children}</TestWithProviders>
+  );
   const getFieldSelectionResult = () => renderHook(() => useFieldSelection(column, true), { wrapper });
 
   beforeEach(() => {

--- a/src/table/hooks/__tests__/use-keyboard-active-listener.spec.tsx
+++ b/src/table/hooks/__tests__/use-keyboard-active-listener.spec.tsx
@@ -1,6 +1,6 @@
 import { stardust } from "@nebula.js/stardust";
 import { renderHook } from "@testing-library/react";
-import React from "react";
+import React, { ReactNode } from "react";
 import TestWithProviders from "../../../__test__/test-with-providers";
 import { FIRST_HEADER_CELL_COORD, FocusTypes } from "../../constants";
 import * as accessibilityUtils from "../../utils/accessibility-utils";
@@ -11,7 +11,7 @@ describe("use-keyboard-active-listener", () => {
   let keyboard: stardust.Keyboard;
   let focusedCellCoord: [number, number];
 
-  const wrapper = ({ children }: any) => (
+  const wrapper = ({ children }: { children: ReactNode }) => (
     <TestWithProviders cellCoordMock={focusedCellCoord} keyboard={keyboard}>
       {children}
     </TestWithProviders>

--- a/src/table/hooks/__tests__/use-selection-listener.spec.ts
+++ b/src/table/hooks/__tests__/use-selection-listener.spec.ts
@@ -7,8 +7,8 @@ import useSelectionListener from "../use-selection-listener";
 describe("useSelectionListener", () => {
   const listenerNames = ["deactivated", "canceled", "confirmed", "cleared"];
   let selectionsAPI: ExtendedSelectionAPI;
-  let selectionDispatch: jest.Mock<any, any>;
-  let setShouldRefocus: jest.Mock<any, any>;
+  let selectionDispatch: jest.Mock<unknown, unknown[]>;
+  let setShouldRefocus: jest.Mock<unknown, unknown[]>;
   let keyboard: stardust.Keyboard;
   let containsActiveElement: boolean;
   let tableWrapperRef: React.MutableRefObject<HTMLDivElement>;

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -18,7 +18,7 @@ import {
 } from "../types";
 import { FocusTypes, SelectionActions } from "./constants";
 
-interface Action<T = any> {
+interface Action<T = unknown> {
   type: T;
 }
 

--- a/src/table/utils/__tests__/copy-utils.spec.ts
+++ b/src/table/utils/__tests__/copy-utils.spec.ts
@@ -1,9 +1,7 @@
 import copyCellValue from "../copy-utils";
 
 describe("copyCellValue:", () => {
-  let evt: {
-    target: HTMLElement;
-  };
+  let evt: React.MouseEvent;
   let writeMock: (arg: string) => void;
   let elementClass: string;
 
@@ -27,7 +25,7 @@ describe("copyCellValue:", () => {
         }),
         classList,
       } as unknown as HTMLElement,
-    };
+    } as unknown as React.MouseEvent;
     jest.spyOn(console, "log");
     writeMock = jest.fn();
     Object.assign(navigator, {
@@ -59,7 +57,7 @@ describe("copyCellValue:", () => {
         querySelector: () => undefined,
         classList,
       } as unknown as HTMLElement,
-    };
+    } as unknown as React.MouseEvent;
     elementClass = "sn-table-cell";
     await copyCellValue(evt);
 
@@ -81,7 +79,7 @@ describe("copyCellValue:", () => {
         }),
         classList,
       } as unknown as HTMLElement,
-    };
+    } as unknown as React.MouseEvent;
     elementClass = "sn-table-cell";
 
     await copyCellValue(evt);

--- a/src/table/utils/__tests__/find-visible-rows.spec.ts
+++ b/src/table/utils/__tests__/find-visible-rows.spec.ts
@@ -206,7 +206,7 @@ describe("find-visible-rows", () => {
     let rootElement: HTMLElement;
     let tableBody: {
       getBoundingClientRect?: () => Rect;
-      querySelectorAll?: () => any;
+      querySelectorAll?: () => unknown;
     };
     let bodyRect: Rect;
     let cells: { getAttribute: () => string; getBoundingClientRect: () => Rect }[];

--- a/src/table/utils/__tests__/selections-utils.spec.ts
+++ b/src/table/utils/__tests__/selections-utils.spec.ts
@@ -45,7 +45,7 @@ describe("selections-utils", () => {
 
     describe("select", () => {
       let action: SelectAction;
-      let announce: jest.Mock<any, any>;
+      let announce: jest.Mock<unknown, unknown[]>;
 
       beforeEach(() => {
         announce = jest.fn();
@@ -101,7 +101,7 @@ describe("selections-utils", () => {
     describe("select multiple", () => {
       const mouseupOutsideCallback = () => {};
       let evt: React.KeyboardEvent | React.MouseEvent;
-      let announce: jest.Mock<any, any>;
+      let announce: jest.Mock<unknown, unknown[]>;
 
       beforeEach(() => {
         state.pageRows = createPageRows(4, 1);

--- a/src/table/utils/copy-utils.ts
+++ b/src/table/utils/copy-utils.ts
@@ -1,4 +1,4 @@
-const copyCellValue = async (evt: any) => {
+const copyCellValue = async (evt: React.MouseEvent | React.KeyboardEvent) => {
   let target = evt.target as HTMLElement;
 
   if (!target.classList.contains("sn-table-cell")) {

--- a/src/table/virtualized-table/hooks/__tests__/use-dynamic-row-height.spec.tsx
+++ b/src/table/virtualized-table/hooks/__tests__/use-dynamic-row-height.spec.tsx
@@ -19,8 +19,8 @@ describe("useDynamicRowHeight", () => {
   let layout: TableLayout;
   let pageInfo: PageInfo;
   let rowCount: number;
-  let gridRef: React.RefObject<VariableSizeGrid<any>> | undefined;
-  let lineRef: React.RefObject<VariableSizeList<any>> | undefined;
+  let gridRef: React.RefObject<VariableSizeGrid<unknown>> | undefined;
+  let lineRef: React.RefObject<VariableSizeList<unknown>> | undefined;
   let boldText: boolean | undefined;
   let gridState: React.MutableRefObject<GridState> | undefined;
   let props: UseDynamicRowHeightProps;

--- a/src/table/virtualized-table/hooks/__tests__/use-scroll-hander.test.ts
+++ b/src/table/virtualized-table/hooks/__tests__/use-scroll-hander.test.ts
@@ -5,9 +5,9 @@ import { BodyRef } from "../../types";
 import useScrollHandler from "../use-scroll-handler";
 
 describe("useScrollHandler", () => {
-  let headerRef: React.RefObject<VariableSizeList<any>>;
+  let headerRef: React.RefObject<VariableSizeList<unknown>>;
   let bodyRef: React.RefObject<BodyRef>;
-  let totalsRef: React.RefObject<VariableSizeList<any>>;
+  let totalsRef: React.RefObject<VariableSizeList<unknown>>;
   let listInstance: VariableSizeList;
   let listTotalsInstance: VariableSizeList;
   let refHandler: BodyRef;

--- a/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
+++ b/src/table/virtualized-table/hooks/use-dynamic-row-height.ts
@@ -21,8 +21,8 @@ export interface UseDynamicRowHeightProps {
   rowCount: number;
   columnWidths: number[];
   pageInfo: PageInfo;
-  gridRef?: React.RefObject<VariableSizeGrid<any>>;
-  lineRef?: React.RefObject<VariableSizeList<any>>;
+  gridRef?: React.RefObject<VariableSizeGrid<unknown>>;
+  lineRef?: React.RefObject<VariableSizeList<unknown>>;
   columns?: Column[];
   boldText?: boolean;
   gridState?: React.MutableRefObject<GridState>;

--- a/src/table/virtualized-table/hooks/use-heights.ts
+++ b/src/table/virtualized-table/hooks/use-heights.ts
@@ -13,8 +13,8 @@ interface UseHeightsProps {
   columnWidths: number[];
   pageInfo: PageInfo;
   totalsPosition: TotalsPosition;
-  headerRef: React.RefObject<VariableSizeList<any>>;
-  totalsRef: React.RefObject<VariableSizeList<any>>;
+  headerRef: React.RefObject<VariableSizeList<unknown>>;
+  totalsRef: React.RefObject<VariableSizeList<unknown>>;
   isSnapshot: boolean;
   viewService: ViewService;
 }

--- a/src/table/virtualized-table/hooks/use-reset-header.ts
+++ b/src/table/virtualized-table/hooks/use-reset-header.ts
@@ -3,7 +3,7 @@ import { VariableSizeList } from "react-window";
 import { PageInfo, TableLayout } from "../../../types";
 
 const useResetHeader = (
-  forwardRef: React.RefObject<VariableSizeList<any>>,
+  forwardRef: React.RefObject<VariableSizeList<unknown>>,
   layout: TableLayout,
   pageInfo: PageInfo,
   columnWidths: number[],

--- a/src/table/virtualized-table/hooks/use-scroll-handler.ts
+++ b/src/table/virtualized-table/hooks/use-scroll-handler.ts
@@ -4,8 +4,8 @@ import { ViewService } from "../../../types";
 import { BodyRef } from "../types";
 
 const useScrollHandler = (
-  headerRef: React.RefObject<VariableSizeList<any>>,
-  totalsRef: React.RefObject<VariableSizeList<any>>,
+  headerRef: React.RefObject<VariableSizeList<unknown>>,
+  totalsRef: React.RefObject<VariableSizeList<unknown>>,
   bodyRef: React.RefObject<BodyRef>,
   viewService: ViewService,
 ) =>

--- a/src/table/virtualized-table/types/index.ts
+++ b/src/table/virtualized-table/types/index.ts
@@ -56,6 +56,7 @@ export interface TableProps {
 export interface HeaderProps {
   rect: Rect;
   pageInfo: PageInfo;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   forwardRef: React.RefObject<VariableSizeList<any>>;
   columns: Column[];
   headerStyle: GeneratedStyling;
@@ -66,6 +67,7 @@ export interface HeaderProps {
 export interface TotalsProps {
   rect: Rect;
   pageInfo: PageInfo;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   forwardRef: React.RefObject<VariableSizeList<any>>;
   columns: Column[];
   totals: Totals;

--- a/test/integration/types/index.ts
+++ b/test/integration/types/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Collection = { [key: string]: any };
 export type Key =
   | "ArrowUp"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,7 +1374,7 @@
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.4.0", "@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
+"@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.7.0.tgz#96e7c05e738327602ae5942437f9c6b177ec279a"
   integrity sha512-+HencqxU7CFJnQb7IKtuNBqS6Yx3Tz4kOL8BJXo+JyeiBm5MEX6pO8onXDkjrkCRlfYXS1Axro15ZjVFe9YgsA==
@@ -2702,22 +2702,6 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
-  integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
-  dependencies:
-    "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.62.0"
-    "@typescript-eslint/type-utils" "5.62.0"
-    "@typescript-eslint/utils" "5.62.0"
-    debug "^4.3.4"
-    graphemer "^1.4.0"
-    ignore "^5.2.0"
-    natural-compare-lite "^1.4.0"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
 "@typescript-eslint/eslint-plugin@6.9.1":
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz#d8ce497dc0ed42066e195c8ecc40d45c7b1254f4"
@@ -2734,16 +2718,6 @@
     natural-compare "^1.4.0"
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
-
-"@typescript-eslint/parser@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
-  integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.62.0"
-    "@typescript-eslint/types" "5.62.0"
-    "@typescript-eslint/typescript-estree" "5.62.0"
-    debug "^4.3.4"
 
 "@typescript-eslint/parser@6.9.1":
   version "6.9.1"
@@ -2779,16 +2753,6 @@
   dependencies:
     "@typescript-eslint/types" "6.9.1"
     "@typescript-eslint/visitor-keys" "6.9.1"
-
-"@typescript-eslint/type-utils@5.62.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz#286f0389c41681376cdad96b309cedd17d70346a"
-  integrity sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "5.62.0"
-    "@typescript-eslint/utils" "5.62.0"
-    debug "^4.3.4"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/type-utils@6.9.1":
   version "6.9.1"
@@ -2854,20 +2818,6 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.58.0":
-  version "5.62.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
-  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.2.0"
-    "@types/json-schema" "^7.0.9"
-    "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.62.0"
-    "@typescript-eslint/types" "5.62.0"
-    "@typescript-eslint/typescript-estree" "5.62.0"
-    eslint-scope "^5.1.1"
-    semver "^7.3.7"
-
 "@typescript-eslint/utils@6.9.1":
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.9.1.tgz#763da41281ef0d16974517b5f0d02d85897a1c1e"
@@ -2880,6 +2830,20 @@
     "@typescript-eslint/types" "6.9.1"
     "@typescript-eslint/typescript-estree" "6.9.1"
     semver "^7.5.4"
+
+"@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.58.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
+  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
 
 "@typescript-eslint/utils@^6.9.1":
   version "6.10.0"
@@ -7821,11 +7785,6 @@ nanoid@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
-
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
-  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
The dependecies below where overriding the same deps coming from `@qlik/eslint-config` which are at v6. This PR removes those deps from sn-table and lets `@qlik/eslint-config` decide the version. The result is that `any` type is not allowed any more.

```json
"@typescript-eslint/eslint-plugin": "5.62.0",
"@typescript-eslint/parser": "5.62.0",
```