### PR TITLE
fix: use capital Percentage while accessing enum value

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "sense": "nebula sense",
     "spec": "npx @scriptappy/cli from-jsdoc -c ./spec-configs/props.conf.js",
     "start": "nebula serve --build false --type sn-table",
+    "start:mfe": "nebula serve --mfe --build false --type sn-table",
     "test:integration": "playwright test --config=test/integration/integration.config.ts",
     "test:integration:local": "./test/integration/scripts/run-integration-tests.sh",
     "test:rendering": "playwright test",

--- a/src/ext/property-panel/data.js
+++ b/src/ext/property-panel/data.js
@@ -182,7 +182,7 @@ const getColumnResize = {
         translation: "Object.Table.Column.Pixels",
       },
       {
-        value: ColumnWidthType.percentage,
+        value: ColumnWidthType.Percentage,
         translation: "Object.Table.Column.Percentage",
       },
     ],


### PR DESCRIPTION
when clicking on percentage column size type, table breaks in sence-client, we noticed that the way we access the enum value is incorrect so this pr fixes it.

also while testing it through sence-client, noticed that the `start:mfe` script in pkg.json was not presented, so feel free to complain about it and tell me to remove it if you think it's not needed

Before fix:

https://github.com/qlik-oss/sn-table/assets/29652890/aaa7166f-bee3-4211-b2f6-75e1f3fbe279



After Fix: 

https://github.com/qlik-oss/sn-table/assets/29652890/f458adfe-6f06-441a-9500-f983d0e13634

