### PR TITLE
chore: fix tab stop when keyboard navigation is off

### DIFF
--- a/src/table/pagination-table/components/body/TableBodyWrapper.tsx
+++ b/src/table/pagination-table/components/body/TableBodyWrapper.tsx
@@ -64,7 +64,14 @@ const TableBodyWrapper = ({ setShouldRefocus, tableWrapperRef, announce }: Table
             const { id } = column;
             const cell = row[id] as Cell;
             const CellRenderer = columnRenderers[columnIndex];
-            const tabIndex = rowIndex === 0 && columnIndex === 0 && !totalsPosition.atTop && !keyboard.enabled ? 0 : -1;
+            const tabIndex =
+              !isNewHeadCellMenuEnabled &&
+              rowIndex === 0 &&
+              columnIndex === 0 &&
+              !totalsPosition.atTop &&
+              !keyboard.enabled
+                ? 0
+                : -1;
             const handleKeyDown = (evt: React.KeyboardEvent) => {
               handleBodyKeyDown({
                 evt,


### PR DESCRIPTION
when keyboard navigation is off, AND there is no totals row, the first body cell picks up tab a tab index of 0, which results in below scenario: 

![Kapture 2023-12-14 at 09 27 27](https://github.com/qlik-oss/sn-table/assets/29652890/6154b8a9-2b52-49a2-b5d1-94fbf1eb6569)

So this PR fixes that base on the rule for tab stops with new head cell (we might have only 1 tab stop in table), So if the flag is on -> we should directly return -1 for first body cell, where we decide to let it have tab stop or not.

the result becomes:

https://github.com/qlik-oss/sn-table/assets/29652890/5bcfccf0-8446-4c92-b7ca-26b0b82635a8

