### PR TITLE
fix: infinite loop after column resize

### DIFF
--- a/src/table/virtualized-table/utils/cell-width-utils.ts
+++ b/src/table/virtualized-table/utils/cell-width-utils.ts
@@ -2,11 +2,11 @@ import { Column } from "../../../types";
 import { ADJUSTED_HEADER_WIDTH, LOOK_BUTTON_AND_AUTO_MARGIN } from "../../styling-defaults";
 import { BORDER_WIDTH, PADDING_LEFT_RIGHT } from "../constants";
 
-export const getAdjustedCellWidth = (width: number) => width - PADDING_LEFT_RIGHT * 2 - BORDER_WIDTH;
+export const getAdjustedCellWidth = (width: number) => Math.max(0, width - PADDING_LEFT_RIGHT * 2 - BORDER_WIDTH);
 
 export const getAdjustedHeadCellWidth = (width: number, column: Column) => {
   let newWidth = width - ADJUSTED_HEADER_WIDTH;
   newWidth -= column.isLocked ? LOOK_BUTTON_AND_AUTO_MARGIN : 0;
 
-  return newWidth;
+  return Math.max(0, newWidth);
 };


### PR DESCRIPTION
When using the new headers and the virtualized table. Re-sizing a column to mininum size would trigger a inifinite loop.