### PR TITLE
refactor: type events to remove need to cast

### DIFF
--- a/src/extend-context-menu.ts
+++ b/src/extend-context-menu.ts
@@ -5,13 +5,14 @@ import copyCellValue from "./table/utils/copy-utils";
 export default function extendContextMenu() {
   onContextMenu?.((menu: any, event: Event) => {
     const target = event.target as HTMLElement | null;
-    target?.closest(".sn-table-cell") &&
+    const cellElement = target?.closest<HTMLElement>(".sn-table-cell");
+    cellElement &&
       menu.addItem({
         translation: "contextMenu.copyCellValue",
         icon: "lui-icon lui-icon--copy",
         tid: "copy-cell-context-item",
         select: async () => {
-          copyCellValue(event);
+          copyCellValue(cellElement);
         },
       });
   });

--- a/src/table/pagination-table/components/body/TableBodyWrapper.tsx
+++ b/src/table/pagination-table/components/body/TableBodyWrapper.tsx
@@ -72,7 +72,7 @@ const TableBodyWrapper = ({ setShouldRefocus, tableWrapperRef, announce }: Table
               !keyboard.enabled
                 ? 0
                 : -1;
-            const handleKeyDown = (evt: React.KeyboardEvent) => {
+            const handleKeyDown = (evt: React.KeyboardEvent<HTMLElement>) => {
               handleBodyKeyDown({
                 evt,
                 rootElement,

--- a/src/table/pagination-table/components/body/TableTotals.tsx
+++ b/src/table/pagination-table/components/body/TableTotals.tsx
@@ -41,7 +41,7 @@ const TableTotals = () => {
             className="sn-table-cell"
             tabIndex={isNewHeadCellMenuEnabled ? -1 : tabIndex}
             title={interactions.passive ? column.totalInfo : undefined}
-            onKeyDown={(e: React.KeyboardEvent) => {
+            onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => {
               handleTotalKeyDown(
                 e,
                 rootElement,

--- a/src/table/pagination-table/components/head/HeadCell.tsx
+++ b/src/table/pagination-table/components/head/HeadCell.tsx
@@ -51,7 +51,7 @@ const HeadCell = ({ column, columnIndex, columnsLength }: HeadCellProps) => {
   const isLastColumn = columnIndex === columnsLength - 1;
   const cellCoord = [0, column.pageColIdx] as FocusedCellCoord;
 
-  const handleKeyDown = (evt: React.KeyboardEvent) =>
+  const handleKeyDown = (evt: React.KeyboardEvent<HTMLElement>) =>
     handleHeadKeyDown({
       evt,
       rootElement,

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -161,7 +161,7 @@ export interface HandleWrapperKeyDownProps {
 }
 
 export interface HandleHeadKeyDownProps {
-  evt: React.KeyboardEvent;
+  evt: React.KeyboardEvent<HTMLElement>;
   rootElement: HTMLElement;
   cellCoord: FocusedCellCoord;
   setFocusedCellCoord: SetFocusedCellCoord;
@@ -180,7 +180,7 @@ export interface HandleHeadMouseDownProps {
 }
 
 export interface BodyArrowHelperProps {
-  evt: React.KeyboardEvent;
+  evt: React.KeyboardEvent<HTMLElement>;
   rootElement: HTMLElement;
   cell: Cell;
   selectionDispatch: SelectionDispatch;
@@ -193,7 +193,7 @@ export interface BodyArrowHelperProps {
 }
 
 export interface HandleBodyKeyDownProps {
-  evt: React.KeyboardEvent;
+  evt: React.KeyboardEvent<HTMLElement>;
   rootElement: HTMLElement;
   cell: Cell;
   selectionDispatch: SelectionDispatch;
@@ -213,7 +213,7 @@ export interface CellFocusProps {
 }
 
 export interface MoveFocusWithArrowProps {
-  evt: React.KeyboardEvent;
+  evt: React.KeyboardEvent<HTMLElement>;
   rootElement: HTMLElement;
   cellCoord: FocusedCellCoord;
   setFocusedCellCoord: SetFocusedCellCoord;
@@ -356,3 +356,5 @@ export interface CellHOCProps extends TableCellProps {
 export type CellHOC = (props: CellHOCProps) => JSX.Element;
 
 export type EstimateWidth = (column: Column) => number;
+
+export type EventCurrentTarget = HTMLElement & EventTarget;

--- a/src/table/utils/__tests__/copy-utils.spec.ts
+++ b/src/table/utils/__tests__/copy-utils.spec.ts
@@ -1,31 +1,15 @@
 import copyCellValue from "../copy-utils";
 
 describe("copyCellValue:", () => {
-  let evt: Event;
+  let cellElement: HTMLElement;
   let writeMock: (arg: string) => void;
-  let elementClass: string;
-
-  const classList = {
-    contains: (className: string) => className === elementClass,
-  };
-
-  const closest = () => ({
-    querySelector: () => ({
-      textContent: "textFromClosest",
-    }),
-  });
 
   beforeEach(() => {
-    elementClass = "";
-    evt = {
-      target: {
-        closest,
-        querySelector: () => ({
-          textContent: "text",
-        }),
-        classList,
-      },
-    } as unknown as Event;
+    cellElement = {
+      querySelector: () => ({
+        textContent: "text",
+      }),
+    } as unknown as HTMLElement;
     jest.spyOn(console, "log");
     writeMock = jest.fn();
     Object.assign(navigator, {
@@ -36,30 +20,17 @@ describe("copyCellValue:", () => {
   afterEach(() => jest.clearAllMocks());
 
   it("should call clipboard.writeText but not console log for a table cell", async () => {
-    elementClass = "sn-table-cell";
-    await copyCellValue(evt);
+    await copyCellValue(cellElement);
     expect(global.console.log).toHaveBeenCalledTimes(0);
     expect(writeMock).toHaveBeenCalledTimes(1);
     expect(writeMock).toHaveBeenCalledWith("text");
   });
 
-  it("should call clipboard.writeText but not console log for a non-table cell", async () => {
-    elementClass = "";
-    await copyCellValue(evt);
-    expect(global.console.log).toHaveBeenCalledTimes(0);
-    expect(writeMock).toHaveBeenCalledTimes(1);
-    expect(writeMock).toHaveBeenCalledWith("textFromClosest");
-  });
-
   it("should not call clipboard.writeText nor console log when value is not defined", async () => {
-    evt = {
-      target: {
-        querySelector: () => undefined,
-        classList,
-      },
-    } as unknown as Event;
-    elementClass = "sn-table-cell";
-    await copyCellValue(evt);
+    cellElement = {
+      querySelector: () => undefined,
+    } as unknown as HTMLElement;
+    await copyCellValue(cellElement);
 
     expect(global.console.log).toHaveBeenCalledTimes(0);
     expect(writeMock).toHaveBeenCalledTimes(0);
@@ -72,17 +43,8 @@ describe("copyCellValue:", () => {
     Object.assign(navigator, {
       clipboard: { writeText: writeMock },
     });
-    evt = {
-      target: {
-        querySelector: () => ({
-          textContent: "text",
-        }),
-        classList,
-      },
-    } as unknown as Event;
-    elementClass = "sn-table-cell";
 
-    await copyCellValue(evt);
+    await copyCellValue(cellElement);
     expect(writeMock).toHaveBeenCalledTimes(1);
     expect(global.console.log).toHaveBeenCalledTimes(1);
   });

--- a/src/table/utils/__tests__/handle-keyboard.spec.ts
+++ b/src/table/utils/__tests__/handle-keyboard.spec.ts
@@ -25,7 +25,7 @@ describe("handle-keyboard", () => {
   afterEach(() => jest.clearAllMocks());
 
   describe("handleWrapperKeyDown", () => {
-    let evt: React.KeyboardEvent;
+    let evt: React.KeyboardEvent<HTMLElement>;
     let totalRowCount: number;
     let page: number;
     let rowsPerPage: number;
@@ -54,7 +54,7 @@ describe("handle-keyboard", () => {
         key: KeyCodes.RIGHT,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
-      } as unknown as React.KeyboardEvent;
+      } as unknown as React.KeyboardEvent<HTMLElement>;
       handleChangePage = jest.fn();
       setShouldRefocus = jest.fn();
       keyboard = { enabled: false, active: false, blur: jest.fn(), focus: jest.fn() };
@@ -121,7 +121,7 @@ describe("handle-keyboard", () => {
         key: KeyCodes.ESC,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
-      } as unknown as React.KeyboardEvent;
+      } as unknown as React.KeyboardEvent<HTMLElement>;
       keyboard.enabled = true;
       callHandleWrapperKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe("handle-keyboard", () => {
         key: KeyCodes.ESC,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
-      } as unknown as React.KeyboardEvent;
+      } as unknown as React.KeyboardEvent<HTMLElement>;
       keyboard.enabled = true;
       isSelectionMode = true;
       callHandleWrapperKeyDown();
@@ -156,7 +156,7 @@ describe("handle-keyboard", () => {
   describe("handleHeadKeyDown", () => {
     let rowIndex: number;
     let colIndex: number;
-    let evt: React.KeyboardEvent;
+    let evt: React.KeyboardEvent<HTMLElement>;
     let rootElement: HTMLElement;
     let changeSortOrder: (column: Column) => Promise<void>;
     let isInteractionEnabled: boolean;
@@ -184,14 +184,14 @@ describe("handle-keyboard", () => {
         key: KeyCodes.RIGHT,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
-        target: {
+        currentTarget: {
           blur: jest.fn(),
           setAttribute: jest.fn(),
           closest: () => ({
             nextSibling,
           }),
         } as unknown as HTMLElement,
-      } as unknown as React.KeyboardEvent;
+      } as unknown as React.KeyboardEvent<HTMLElement>;
       rootElement = {} as unknown as HTMLElement;
       changeSortOrder = jest.fn();
       isInteractionEnabled = true;
@@ -305,7 +305,7 @@ describe("handle-keyboard", () => {
         expect(accessibilityUtils.updateFocus).toHaveBeenCalledTimes(1);
         expect(accessibilityUtils.updateFocus).toHaveBeenCalledWith({
           focusType: FocusTypes.REMOVE_TAB,
-          cell: evt.target,
+          cell: evt.currentTarget,
         });
         expect(accessibilityUtils.moveFocusWithArrow).toHaveBeenCalledWith({
           evt,
@@ -319,7 +319,7 @@ describe("handle-keyboard", () => {
   });
 
   describe("handleTotalKeyDown", () => {
-    let evt: React.KeyboardEvent;
+    let evt: React.KeyboardEvent<HTMLElement>;
     let rootElement: HTMLElement;
     let setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
     let cellCoord: [number, number];
@@ -330,11 +330,11 @@ describe("handle-keyboard", () => {
         key: KeyCodes.DOWN,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
-        target: {
+        currentTarget: {
           blur: jest.fn(),
           setAttribute: jest.fn(),
         },
-      } as unknown as React.KeyboardEvent;
+      } as unknown as React.KeyboardEvent<HTMLElement>;
       cellCoord = [1, 1];
       rootElement = {
         getElementsByClassName: () => [
@@ -427,7 +427,7 @@ describe("handle-keyboard", () => {
   describe("handleBodyKeyDown", () => {
     let isModal: boolean;
     let isExcluded: boolean;
-    let evt: React.KeyboardEvent;
+    let evt: React.KeyboardEvent<HTMLElement>;
     let rootElement: HTMLElement;
     let selectionsAPI: ExtendedSelectionAPI;
     let cell: Cell;
@@ -463,14 +463,14 @@ describe("handle-keyboard", () => {
         key: KeyCodes.DOWN,
         stopPropagation: jest.fn(),
         preventDefault: jest.fn(),
-        target: {
+        currentTarget: {
           blur: jest.fn(),
           setAttribute: jest.fn(),
           classList: {
             contains: () => isExcluded,
           },
         },
-      } as unknown as React.KeyboardEvent;
+      } as unknown as React.KeyboardEvent<HTMLElement>;
       rootElement = {
         getElementsByClassName: () => [
           { getElementsByClassName: () => [{ focus: () => undefined, setAttribute: () => undefined }] },
@@ -593,8 +593,8 @@ describe("handle-keyboard", () => {
       runHandleBodyKeyDown();
       expect(evt.preventDefault).not.toHaveBeenCalled();
       expect(evt.stopPropagation).not.toHaveBeenCalled();
-      expect((evt.target as HTMLElement).blur).not.toHaveBeenCalled();
-      expect((evt.target as HTMLElement).setAttribute).not.toHaveBeenCalled();
+      expect(evt.currentTarget.blur).not.toHaveBeenCalled();
+      expect(evt.currentTarget.setAttribute).not.toHaveBeenCalled();
       expect(selectionsAPI.cancel).not.toHaveBeenCalled();
       expect(setFocusedCellCoord).not.toHaveBeenCalled();
     });
@@ -604,8 +604,8 @@ describe("handle-keyboard", () => {
       runHandleBodyKeyDown();
       expect(evt.preventDefault).toHaveBeenCalledTimes(1);
       expect(evt.stopPropagation).toHaveBeenCalledTimes(1);
-      expect((evt.target as HTMLElement).blur).not.toHaveBeenCalled();
-      expect((evt.target as HTMLElement).setAttribute).not.toHaveBeenCalled();
+      expect(evt.currentTarget.blur).not.toHaveBeenCalled();
+      expect(evt.currentTarget.setAttribute).not.toHaveBeenCalled();
       expect(selectionsAPI.cancel).not.toHaveBeenCalled();
       expect(setFocusedCellCoord).not.toHaveBeenCalled();
     });

--- a/src/table/utils/__tests__/keyboard-utils.spec.ts
+++ b/src/table/utils/__tests__/keyboard-utils.spec.ts
@@ -13,7 +13,7 @@ jest.mock("@qlik/nebula-table-utils/lib/utils", () => ({
 }));
 
 describe("keyboard-utils", () => {
-  let evt: React.KeyboardEvent;
+  let evt: React.KeyboardEvent<HTMLElement>;
   let rootElement: HTMLElement;
   let setFocusedCellCoord: React.Dispatch<React.SetStateAction<[number, number]>>;
 
@@ -23,10 +23,10 @@ describe("keyboard-utils", () => {
       shiftKey: false,
       ctrlKey: false,
       metaKey: false, // cases when meta key is pressed instead of ctrl is not tested here, the test are granular enough anyway
-      target: {} as HTMLElement,
+      currentTarget: {} as HTMLElement,
       stopPropagation: () => {},
       preventDefault: jest.fn(),
-    } as unknown as React.KeyboardEvent;
+    } as unknown as React.KeyboardEvent<HTMLElement>;
     rootElement = {
       querySelectorAll: () => [{}, {}],
       getElementsByClassName: () => [
@@ -319,10 +319,10 @@ describe("keyboard-utils", () => {
       containsLabelClass = true;
       evt = {
         ...evt,
-        target: {
+        currentTarget: {
           classList: { contains: () => containsLabelClass },
         },
-      } as unknown as React.KeyboardEvent;
+      } as unknown as React.KeyboardEvent<HTMLElement>;
       cellCoord = [0, 2];
       jest.spyOn(accessibilityUtils, "focusBodyFromHead").mockImplementation(() => {});
     });

--- a/src/table/utils/copy-utils.ts
+++ b/src/table/utils/copy-utils.ts
@@ -1,10 +1,5 @@
-const copyCellValue = async (evt: Event | React.KeyboardEvent) => {
-  let target = evt.target as HTMLElement | null | undefined;
-
-  if (!target?.classList.contains("sn-table-cell")) {
-    target = target?.closest<HTMLElement>(".sn-table-cell");
-  }
-  const value = target?.querySelector(".sn-table-cell-text")?.textContent;
+const copyCellValue = async (cellElement: HTMLElement) => {
+  const value = cellElement.querySelector(".sn-table-cell-text")?.textContent;
 
   try {
     value && (await navigator.clipboard.writeText(String(value)));

--- a/src/table/utils/handle-keyboard.ts
+++ b/src/table/utils/handle-keyboard.ts
@@ -121,8 +121,7 @@ export const handleHeadKeyDown = ({
 
   if (shouldBubbleEarly(evt)) return;
 
-  const target = evt.target as HTMLElement;
-  const isLastHeadCell = !target.closest(".sn-table-cell")?.nextSibling;
+  const isLastHeadCell = !evt.currentTarget.closest(".sn-table-cell")?.nextSibling;
 
   switch (evt.key) {
     case KeyCodes.LEFT:
@@ -132,7 +131,7 @@ export const handleHeadKeyDown = ({
         focusBodyFromHead(rootElement, setFocusedCellCoord);
       } else {
         if (isNewHeadCellMenuEnabled) {
-          updateFocus({ focusType: FocusTypes.REMOVE_TAB, cell: evt.target as HTMLElement });
+          updateFocus({ focusType: FocusTypes.REMOVE_TAB, cell: evt.currentTarget });
         }
         moveFocusWithArrow({
           evt,
@@ -159,7 +158,7 @@ export const handleHeadKeyDown = ({
       break;
     case KeyCodes.C:
       preventDefaultBehavior(evt);
-      isCtrlCmd(evt) && copyCellValue(evt);
+      isCtrlCmd(evt) && copyCellValue(evt.currentTarget);
       break;
     case isNewHeadCellMenuEnabled && KeyCodes.ENTER:
     case isNewHeadCellMenuEnabled && KeyCodes.SPACE:
@@ -174,7 +173,7 @@ export const handleHeadKeyDown = ({
  * handles keydown events for the totals cells (move focus, copy cell, value)
  */
 export const handleTotalKeyDown = (
-  evt: React.KeyboardEvent,
+  evt: React.KeyboardEvent<HTMLElement>,
   rootElement: HTMLElement,
   cellCoord: FocusedCellCoord,
   setFocusedCellCoord: SetFocusedCellCoord,
@@ -195,7 +194,7 @@ export const handleTotalKeyDown = (
       preventDefaultBehavior(evt);
       const focusType = getFocusType(cellCoord, evt, isNewHeadCellMenuEnabled);
       if (focusType === FocusTypes.FOCUS) {
-        updateFocus({ focusType: FocusTypes.REMOVE_TAB, cell: evt.target as HTMLElement });
+        updateFocus({ focusType: FocusTypes.REMOVE_TAB, cell: evt.currentTarget });
       }
 
       moveFocusWithArrow({ evt, rootElement, cellCoord, setFocusedCellCoord, focusType });
@@ -206,7 +205,7 @@ export const handleTotalKeyDown = (
       break;
     case KeyCodes.C: {
       preventDefaultBehavior(evt);
-      isCtrlCmd(evt) && copyCellValue(evt);
+      isCtrlCmd(evt) && copyCellValue(evt.currentTarget);
       break;
     }
     case KeyCodes.SPACE:
@@ -234,7 +233,7 @@ export const handleBodyKeyDown = ({
   selectionsAPI,
   isNewHeadCellMenuEnabled,
 }: HandleBodyKeyDownProps) => {
-  if ((evt.target as HTMLElement).classList.contains("excluded")) {
+  if (evt.currentTarget.classList.contains("excluded")) {
     preventDefaultBehavior(evt);
     return;
   }
@@ -297,7 +296,7 @@ export const handleBodyKeyDown = ({
     // Ctrl + c: copy cell value
     case KeyCodes.C:
       preventDefaultBehavior(evt);
-      isCtrlCmd(evt) && copyCellValue(evt);
+      isCtrlCmd(evt) && copyCellValue(evt.currentTarget);
       break;
     default:
       break;

--- a/src/table/utils/keyboard-utils.ts
+++ b/src/table/utils/keyboard-utils.ts
@@ -79,7 +79,7 @@ export const bodyArrowHelper = ({
   const focusType = getFocusType(cellCoord, evt, isNewHeadCellMenuEnabled);
 
   if (focusType === FocusTypes.FOCUS) {
-    updateFocus({ focusType: FocusTypes.REMOVE_TAB, cell: evt.target as HTMLElement });
+    updateFocus({ focusType: FocusTypes.REMOVE_TAB, cell: evt.currentTarget });
   }
 
   const nextCell = moveFocusWithArrow({
@@ -113,14 +113,13 @@ export const bodyArrowHelper = ({
  * If you tab on the menu in the last cell, go to the tabstop in the body
  */
 export const headTabHelper = (
-  evt: React.KeyboardEvent,
+  evt: React.KeyboardEvent<HTMLElement>,
   rootElement: HTMLElement,
   cellCoord: FocusedCellCoord,
   setFocusedCellCoord: SetFocusedCellCoord,
   isLastHeadCell: boolean,
 ) => {
-  const target = evt.target as HTMLElement;
-  const isLabel = target.classList.contains("sn-table-head-label");
+  const isLabel = evt.currentTarget.classList.contains("sn-table-head-label");
   if (isLabel && evt.shiftKey && cellCoord[1] > 0) {
     setFocusedCellCoord([cellCoord[0], cellCoord[1] - 1]);
   } else if (!isLabel && !evt.shiftKey) {
@@ -134,7 +133,7 @@ export const headTabHelper = (
 };
 
 interface BodyTabHelperProps {
-  evt: React.KeyboardEvent;
+  evt: React.KeyboardEvent<HTMLElement>;
   rootElement: HTMLElement;
   setFocusedCellCoord: SetFocusedCellCoord;
   keyboard?: stardust.Keyboard;
@@ -160,7 +159,7 @@ export const bodyTabHelper = ({
 
   if (tabToToolbar) {
     preventDefaultBehavior(evt);
-    focusSelectionToolbar(evt.target as HTMLElement, keyboard, evt.shiftKey);
+    focusSelectionToolbar(evt.currentTarget, keyboard, evt.shiftKey);
   } else if (evt.shiftKey && !isNewHeadCellMenuEnabled) {
     const headCells = rootElement.querySelectorAll(".sn-table-head-cell");
     const lastIndex = headCells.length - 1;


### PR DESCRIPTION
- Realized we could (and should) use `currentTarget` which can actually be typed. This removes most castings to `HTMLElement` There are a couple exceptions:
  - `onContextMenu,` since we don't control where the event comes from
  - `getElementsByClassName,` since the return type is not generic
  - `isEventFromColumnAdjuster`, since we might move this to common repo
  - native `FocusEvent`, the target types are hard coded
- Rewrite of copyCellValue. It becomes much cleaner if you just pass the cell element, which is `currentElement` in the keyboard functions, and we already get from `closest` in `onContextMenu`. plus the arg type becomes simpler